### PR TITLE
Implement bcmp

### DIFF
--- a/src/mem.rs
+++ b/src/mem.rs
@@ -63,6 +63,11 @@ pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
     0
 }
 
+#[cfg_attr(all(feature = "mem", not(feature = "mangled-names")), no_mangle)]
+pub unsafe extern "C" fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
+    memcmp(s1, s2, n)
+}
+
 // `bytes` must be a multiple of `mem::size_of::<T>()`
 fn memcpy_element_unordered_atomic<T: Copy>(dest: *mut T, src: *const T, bytes: usize) {
     unsafe {


### PR DESCRIPTION
As of LLVM 9.0, [certain calls to memcmp may be converted to bcmp](https://releases.llvm.org/9.0.0/docs/ReleaseNotes.html#noteworthy-optimizations), which I guess
could save a single subtraction on some architectures. 

bcmp is just like memcmp except instead of returning the difference between the
two differing bytes, it returns non-zero instead. As such, memcmp is a valid
implementation of bcmp.

If we care about size, bcmp should just call memcmp.
If we care about "speed", we can change bcmp to save a single sub like this instead:
```rust
pub unsafe extern "C" fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
    let mut i = 0;
    while i < n {
        let a = *s1.offset(i as isize);
        let b = *s2.offset(i as isize);
        if a != b {
            return 1;
        }
        i += 1;
    }
    0
}
```
I'm unsure if the difference in icache size outweighs the single sub in programs which otherwise use memcmp, but I'll trust the LLVM devs to know what they're doing.

In this PR I do not address any changes which may or may not be needed for arm
aebi as I lack proper test hardware.