### PR TITLE
Emit `_fltused` on `uefi` targets as a short-term workaround

### DIFF
--- a/ci/docker/x86_64-unknown-uefi/Dockerfile
+++ b/ci/docker/x86_64-unknown-uefi/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:18.04
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc libc6-dev ca-certificates

--- a/ci/docker/x86_64-unknown-uefi/Dockerfile
+++ b/ci/docker/x86_64-unknown-uefi/Dockerfile
@@ -1,4 +1,0 @@
-FROM ubuntu:18.04
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    gcc libc6-dev ca-certificates

--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -73,3 +73,10 @@ pub unsafe fn ___chkstk() {
     );
     intrinsics::unreachable();
 }
+
+// HACK(https://github.com/rust-lang/rust/issues/62785): x86_64-unknown-uefi needs special LLVM
+// support unless we emit the _fltused
+#[no_mangle]
+#[used]
+#[cfg(target_os = "uefi")]
+static _fltused: i32 = 0;


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/62785