### PR TITLE
Allow FFI-unsafe warnings for u128/i128

### DIFF
--- a/examples/intrinsics.rs
+++ b/examples/intrinsics.rs
@@ -7,7 +7,6 @@
 #![cfg_attr(thumb, no_main)]
 #![deny(dead_code)]
 #![feature(asm)]
-#![feature(compiler_builtins_lib)]
 #![feature(lang_items)]
 #![feature(start)]
 #![feature(allocator_api)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,11 @@
     )
 )]
 
+// We use `u128` in a whole bunch of places which we currently agree with the
+// compiler on ABIs and such, so we should be "good enough" for now and changes
+// to the `u128` ABI will be reflected here.
+#![allow(improper_ctypes)]
+
 // We disable #[no_mangle] for tests so that we can verify the test results
 // against the native compiler-rt implementations of the builtins.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,7 @@
 #![feature(repr_simd)]
 #![no_builtins]
 #![no_std]
-
 #![allow(unused_features)]
-
 // We use `u128` in a whole bunch of places which we currently agree with the
 // compiler on ABIs and such, so we should be "good enough" for now and changes
 // to the `u128` ABI will be reflected here.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,34 +1,16 @@
-#![cfg_attr(not(stage0), deny(warnings))]
-#![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "compiler-builtins", compiler_builtins)]
-#![crate_name = "compiler_builtins"]
-#![crate_type = "rlib"]
-#![doc(
-    html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
-    html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-    html_root_url = "https://doc.rust-lang.org/nightly/",
-    html_playground_url = "https://play.rust-lang.org/",
-    test(attr(deny(warnings)))
-)]
+#![feature(abi_unadjusted)]
 #![feature(asm)]
 #![feature(compiler_builtins)]
 #![feature(core_intrinsics)]
+#![feature(lang_items)]
+#![feature(linkage)]
 #![feature(naked_functions)]
 #![feature(repr_simd)]
-#![feature(abi_unadjusted)]
-#![feature(linkage)]
-#![feature(lang_items)]
-#![allow(unused_features)]
 #![no_builtins]
-#![cfg_attr(feature = "compiler-builtins", feature(staged_api))]
-#![cfg_attr(
-    feature = "compiler-builtins",
-    unstable(
-        feature = "compiler_builtins_lib",
-        reason = "Compiler builtins. Will never become stable.",
-        issue = "0"
-    )
-)]
+#![no_std]
+
+#![allow(unused_features)]
 
 // We use `u128` in a whole bunch of places which we currently agree with the
 // compiler on ABIs and such, so we should be "good enough" for now and changes

--- a/testcrate/tests/aeabi_memclr.rs
+++ b/testcrate/tests/aeabi_memclr.rs
@@ -46,7 +46,7 @@ impl Aligned {
 
 #[test]
 fn memclr4() {
-    let mut aligned = Aligned::new();;
+    let mut aligned = Aligned::new();
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
 

--- a/testcrate/tests/aeabi_memset.rs
+++ b/testcrate/tests/aeabi_memset.rs
@@ -45,7 +45,7 @@ impl Aligned {
 
 #[test]
 fn zero() {
-    let mut aligned = Aligned::new([0u8; 8]);;
+    let mut aligned = Aligned::new([0u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let c = 0xdeadbeef;
@@ -54,7 +54,7 @@ fn zero() {
 
     assert_eq!(*xs, [0; 8]);
 
-    let mut aligned = Aligned::new([1u8; 8]);;
+    let mut aligned = Aligned::new([1u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let c = 0xdeadbeef;
@@ -66,7 +66,7 @@ fn zero() {
 
 #[test]
 fn one() {
-    let mut aligned = Aligned::new([0u8; 8]);;
+    let mut aligned = Aligned::new([0u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let n = 1;
@@ -76,7 +76,7 @@ fn one() {
 
     assert_eq!(*xs, [0xef, 0, 0, 0, 0, 0, 0, 0]);
 
-    let mut aligned = Aligned::new([1u8; 8]);;
+    let mut aligned = Aligned::new([1u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let c = 0xdeadbeef;
@@ -88,7 +88,7 @@ fn one() {
 
 #[test]
 fn two() {
-    let mut aligned = Aligned::new([0u8; 8]);;
+    let mut aligned = Aligned::new([0u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let n = 2;
@@ -98,7 +98,7 @@ fn two() {
 
     assert_eq!(*xs, [0xef, 0xef, 0, 0, 0, 0, 0, 0]);
 
-    let mut aligned = Aligned::new([1u8; 8]);;
+    let mut aligned = Aligned::new([1u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let c = 0xdeadbeef;
@@ -110,7 +110,7 @@ fn two() {
 
 #[test]
 fn three() {
-    let mut aligned = Aligned::new([0u8; 8]);;
+    let mut aligned = Aligned::new([0u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let n = 3;
@@ -120,7 +120,7 @@ fn three() {
 
     assert_eq!(*xs, [0xef, 0xef, 0xef, 0, 0, 0, 0, 0]);
 
-    let mut aligned = Aligned::new([1u8; 8]);;
+    let mut aligned = Aligned::new([1u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let c = 0xdeadbeef;
@@ -132,7 +132,7 @@ fn three() {
 
 #[test]
 fn four() {
-    let mut aligned = Aligned::new([0u8; 8]);;
+    let mut aligned = Aligned::new([0u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let n = 4;
@@ -142,7 +142,7 @@ fn four() {
 
     assert_eq!(*xs, [0xef, 0xef, 0xef, 0xef, 0, 0, 0, 0]);
 
-    let mut aligned = Aligned::new([1u8; 8]);;
+    let mut aligned = Aligned::new([1u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let c = 0xdeadbeef;
@@ -154,7 +154,7 @@ fn four() {
 
 #[test]
 fn five() {
-    let mut aligned = Aligned::new([0u8; 8]);;
+    let mut aligned = Aligned::new([0u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let n = 5;
@@ -164,7 +164,7 @@ fn five() {
 
     assert_eq!(*xs, [0xef, 0xef, 0xef, 0xef, 0xef, 0, 0, 0]);
 
-    let mut aligned = Aligned::new([1u8; 8]);;
+    let mut aligned = Aligned::new([1u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let c = 0xdeadbeef;
@@ -176,7 +176,7 @@ fn five() {
 
 #[test]
 fn six() {
-    let mut aligned = Aligned::new([0u8; 8]);;
+    let mut aligned = Aligned::new([0u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let n = 6;
@@ -186,7 +186,7 @@ fn six() {
 
     assert_eq!(*xs, [0xef, 0xef, 0xef, 0xef, 0xef, 0xef, 0, 0]);
 
-    let mut aligned = Aligned::new([1u8; 8]);;
+    let mut aligned = Aligned::new([1u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let c = 0xdeadbeef;
@@ -198,7 +198,7 @@ fn six() {
 
 #[test]
 fn seven() {
-    let mut aligned = Aligned::new([0u8; 8]);;
+    let mut aligned = Aligned::new([0u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let n = 7;
@@ -208,7 +208,7 @@ fn seven() {
 
     assert_eq!(*xs, [0xef, 0xef, 0xef, 0xef, 0xef, 0xef, 0xef, 0]);
 
-    let mut aligned = Aligned::new([1u8; 8]);;
+    let mut aligned = Aligned::new([1u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let c = 0xdeadbeef;
@@ -220,7 +220,7 @@ fn seven() {
 
 #[test]
 fn eight() {
-    let mut aligned = Aligned::new([0u8; 8]);;
+    let mut aligned = Aligned::new([0u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let n = 8;
@@ -230,7 +230,7 @@ fn eight() {
 
     assert_eq!(*xs, [0xef, 0xef, 0xef, 0xef, 0xef, 0xef, 0xef, 0xef]);
 
-    let mut aligned = Aligned::new([1u8; 8]);;
+    let mut aligned = Aligned::new([1u8; 8]);
     assert_eq!(mem::align_of_val(&aligned), 4);
     let xs = &mut aligned.array;
     let c = 0xdeadbeef;


### PR DESCRIPTION


Handle new warnings on nightly, and we shouldn't need to worry about
these with compiler-builtins since this is tied to a particular compiler.

