### PR TITLE
Don't modify the intrinsic abi for aarch64 windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Jorge Aparicio <japaricious@gmail.com>"]
 name = "compiler_builtins"
-version = "0.1.23"
+version = "0.1.24"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-lang/compiler-builtins"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -165,13 +165,13 @@ macro_rules! intrinsics {
 
         $($rest:tt)*
     ) => (
-        #[cfg(all(windows, target_pointer_width = "64"))]
+        #[cfg(all(windows, target_arch = "x86_64"))]
         $(#[$($attr)*])*
         pub extern $abi fn $name( $($argname: $ty),* ) -> $ret {
             $($body)*
         }
 
-        #[cfg(all(windows, target_pointer_width = "64"))]
+        #[cfg(all(windows, target_arch = "x86_64"))]
         pub mod $name {
 
             intrinsics! {
@@ -184,7 +184,7 @@ macro_rules! intrinsics {
             }
         }
 
-        #[cfg(not(all(windows, target_pointer_width = "64")))]
+        #[cfg(not(all(windows, target_arch = "x86_64")))]
         intrinsics! {
             $(#[$($attr)*])*
             pub extern $abi fn $name( $($argname: $ty),* ) -> $ret {


### PR DESCRIPTION
I was running rustc on aarch64-pc-windows-msvc and ran into compilation errors when evaluating constants.

After some hunting, it appeared that 128 bit integer remainder operations were getting the incorrect value (the result of the division, not the remainder).

This behavior can be observed with a simple program that performs remainder operations on the aarch64-pc-windows-msvc target.

This change disables a macro from adjusting some intrinsic operations and resolves the issue I was seeing with remainder, but there may be a better way to resolve the problem.