### PR TITLE
Set probestack visibility to hidden on ELF targets

### DIFF
--- a/src/probestack.rs
+++ b/src/probestack.rs
@@ -64,6 +64,7 @@ macro_rules! define_rust_probestack {
             .pushsection .text.__rust_probestack
             .globl __rust_probestack
             .type  __rust_probestack, @function
+            .hidden __rust_probestack
         __rust_probestack:
             ",
             $body,


### PR DESCRIPTION
Fix for https://github.com/rust-lang/rust/issues/68794. Tested across a few different platforms in https://github.com/rust-lang/rust/pull/69045, and it looks like it hasn't broken anything.

cc @Mark-Simulacrum @Amanieu 