### PR TITLE
add mips/mips64 compiler-rt fallbacks so that libgcc is not required

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,8 +111,8 @@ jobs:
     - run: rustup target add ${{ matrix.target }}
     - name: Download compiler-rt reference sources
       run: |
-        curl -L -o code.tar.gz https://github.com/rust-lang/llvm-project/archive/rustc/8.0-2019-03-18.tar.gz
-        tar xzf code.tar.gz --strip-components 1 llvm-project-rustc-8.0-2019-03-18/compiler-rt
+        curl -L -o code.tar.gz https://github.com/rust-lang/llvm-project/archive/rustc/10.0-2020-02-05.tar.gz
+        tar xzf code.tar.gz --strip-components 1 llvm-project-rustc-10.0-2020-02-05/compiler-rt
         echo "##[set-env name=RUST_COMPILER_RT_ROOT]./compiler-rt"
       shell: bash
 

--- a/build.rs
+++ b/build.rs
@@ -396,6 +396,25 @@ mod c {
             }
         }
 
+        if target_arch == "mips" {
+            sources.extend(&[("__bswapsi2", "bswapsi2.c")]);
+        }
+
+        if target_arch == "mips64" {
+            sources.extend(&[
+                ("__extenddftf2", "extenddftf2.c"),
+                ("__netf2", "comparetf2.c"),
+                ("__addtf3", "addtf3.c"),
+                ("__multf3", "multf3.c"),
+                ("__subtf3", "subtf3.c"),
+                ("__fixtfsi", "fixtfsi.c"),
+                ("__floatsitf", "floatsitf.c"),
+                ("__fixunstfsi", "fixunstfsi.c"),
+                ("__floatunsitf", "floatunsitf.c"),
+                ("__fe_getround", "fp_mode.c"),
+            ]);
+        }
+
         // Remove the assembly implementations that won't compile for the target
         if llvm_target[0] == "thumbv6m" || llvm_target[0] == "thumbv8m.base" {
             let mut to_remove = Vec::new();


### PR DESCRIPTION
This adds compiler-rt fallbacks for mips and mips64 arches.

Solves linking issues like https://github.com/rust-lang/rust/issues/57820.

Signed-off-by: Yuxiang Zhu <vfreex@gmail.com>