### PR TITLE
Place __muloti4 in a separate object file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,8 @@ jobs:
           rust: nightly
         - target: i686-pc-windows-gnu
           os: windows-latest
-          rust: nightly-i686-gnu
+          # FIXME: Use nigthly when https://github.com/rust-lang/rust/issues/70316 is resolved.
+          rust: nightly-2020-03-14-i686-gnu
         - target: x86_64-pc-windows-gnu
           os: windows-latest
           rust: nightly-x86_64-gnu
@@ -106,7 +107,7 @@ jobs:
       with:
         submodules: true
     - name: Install Rust (rustup)
-      run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
+      run: rustup update ${{ matrix.rust }} --no-self-update --force && rustup default ${{ matrix.rust }}
       shell: bash
     - run: rustup target add ${{ matrix.target }}
     - name: Download compiler-rt reference sources

--- a/build.rs
+++ b/build.rs
@@ -126,6 +126,7 @@ mod c {
         let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
         let target_vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap();
+        let target_pointer_width = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
         let mut consider_float_intrinsics = true;
         let cfg = &mut cc::Build::new();
 
@@ -222,9 +223,8 @@ mod c {
             sources.extend(&[("__ffsdi2", "ffsdi2.c")]);
         }
 
-        // On iOS and 32-bit OSX these are all just empty intrinsics, no need to
-        // include them.
-        if target_os != "ios" && (target_vendor != "apple" || target_arch != "x86") {
+        // On targets without __int128 these are all just empty.
+        if target_pointer_width == "64" && target_env != "msvc" {
             sources.extend(&[
                 ("__absvti2", "absvti2.c"),
                 ("__addvti3", "addvti3.c"),
@@ -232,6 +232,7 @@ mod c {
                 ("__cmpti2", "cmpti2.c"),
                 ("__ctzti2", "ctzti2.c"),
                 ("__ffsti2", "ffsti2.c"),
+                ("__muloti4", "muloti4.c"),
                 ("__mulvti3", "mulvti3.c"),
                 ("__negti2", "negti2.c"),
                 ("__parityti2", "parityti2.c"),

--- a/src/int/mul.rs
+++ b/src/int/mul.rs
@@ -103,6 +103,7 @@ intrinsics! {
         a.mulo(b, oflow)
     }
 
+    #[maybe_use_optimized_c_shim]
     #[unadjusted_on_win64]
     pub extern "C" fn __muloti4(a: i128, b: i128, oflow: &mut i32) -> i128 {
         a.mulo(b, oflow)


### PR DESCRIPTION
libc++ defines __muloti4 builtin llvm.org/PR30643. When referenced and
linked before compiler builtins, it will likely lead to a link failure,
since all Rust implemented builtins are currently placed in a single
object file.

Workaround the issue by using a C implementation when enabled.