### PR TITLE
Add more targets to automatically select `mem` feature.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,6 +27,8 @@ fn main() {
     // provide them.
     if (target.contains("wasm32") && !target.contains("wasi"))
         || (target.contains("sgx") && target.contains("fortanix"))
+        || target.contains("-none")
+        || target.contains("nvptx")
     {
         println!("cargo:rustc-cfg=feature=\"mem\"");
     }


### PR DESCRIPTION
This is an attempt to address some issues with Cargo's `build-std` feature. Currently, Cargo does not know whether or not the `mem` feature needs to be enabled. This will hopefully automatically cover the majority of platforms where this is needed.

I suspect it is likely this may not be sufficient for custom platforms (such as those using custom JSON specs). If there are any ideas on how to automatically cover that, I'd like to discuss options.

cc https://github.com/rust-lang/wg-cargo-std-aware/issues/15 https://github.com/rust-lang/wg-cargo-std-aware/issues/53