### PR TITLE
Expand wasm32 testing on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,30 +7,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        target:
-        - aarch64-unknown-linux-gnu
-        - arm-unknown-linux-gnueabi
-        - arm-unknown-linux-gnueabihf
-        - i586-unknown-linux-gnu
-        - i686-unknown-linux-gnu
-        - mips-unknown-linux-gnu
-        - mips64-unknown-linux-gnuabi64
-        - mips64el-unknown-linux-gnuabi64
-        - mipsel-unknown-linux-gnu
-        - powerpc-unknown-linux-gnu
-        - powerpc64-unknown-linux-gnu
-        - powerpc64le-unknown-linux-gnu
-        - thumbv6m-none-eabi
-        - thumbv7em-none-eabi
-        - thumbv7em-none-eabihf
-        - thumbv7m-none-eabi
-        - wasm32-unknown-unknown
-        - x86_64-unknown-linux-gnu
-        - x86_64-apple-darwin
-        - i686-pc-windows-msvc
-        - x86_64-pc-windows-msvc
-        - i686-pc-windows-gnu
-        - x86_64-pc-windows-gnu
         include:
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-latest
@@ -109,6 +85,7 @@ jobs:
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
     - run: rustup target add ${{ matrix.target }}
+    - run: rustup component add llvm-tools-preview
     - name: Download compiler-rt reference sources
       run: |
         curl -L -o code.tar.gz https://github.com/rust-lang/llvm-project/archive/rustc/8.0-2019-03-18.tar.gz
@@ -121,13 +98,9 @@ jobs:
       if: matrix.os != 'ubuntu-latest'
       shell: bash
 
-    # Wasm is special and is just build as a smoke test
-    - run: cargo build --target ${{ matrix.target }}
-      if: matrix.target == 'wasm32-unknown-unknown'
-
     # Otherwise we use our docker containers to run builds
     - run: cargo generate-lockfile && ./ci/run-docker.sh ${{ matrix.target }}
-      if: matrix.target != 'wasm32-unknown-unknown' && matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest'
 
   rustfmt:
     name: Rustfmt

--- a/ci/docker/wasm32-unknown-unknown/Dockerfile
+++ b/ci/docker/wasm32-unknown-unknown/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:20.04
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc libc6-dev ca-certificates
+
+ENV CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=true

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -32,7 +32,10 @@ case $1 in
         ;;
 esac
 
-NM=nm
+NM=$(find $(rustc --print sysroot) -name llvm-nm)
+if [ "$NM" = "" ]; then
+  NM=${PREFIX}nm
+fi
 
 if [ -d /target ]; then
     path=/target/${1}/debug/deps/libcompiler_builtins-*.rlib
@@ -47,8 +50,7 @@ for rlib in $(echo $path); do
     echo checking $rlib for duplicate symbols
     echo "================================================================"
 
-    stdout=$($PREFIX$NM -g --defined-only $rlib 2>&1)
-
+    stdout=$($NM -g --defined-only $rlib 2>&1)
     # NOTE On i586, It's normal that the get_pc_thunk symbol appears several
     # times so ignore it
     #
@@ -94,7 +96,7 @@ CARGO_PROFILE_RELEASE_LTO=true \
 # Ensure no references to a panicking function
 for rlib in $(echo $path); do
     set +ex
-    $PREFIX$NM -u $rlib 2>&1 | grep panicking
+    $NM -u $rlib 2>&1 | grep panicking
 
     if test $? = 0; then
         exit 1

--- a/examples/intrinsics.rs
+++ b/examples/intrinsics.rs
@@ -14,7 +14,7 @@
 
 extern crate panic_handler;
 
-#[cfg(all(not(thumb), not(windows)))]
+#[cfg(all(not(thumb), not(windows), not(target_arch = "wasm32")))]
 #[link(name = "c")]
 extern "C" {}
 
@@ -340,11 +340,11 @@ fn run() {
     something_with_a_dtor(&|| assert_eq!(bb(1), 1));
 
     extern "C" {
-        fn rust_begin_unwind();
+        fn rust_begin_unwind(x: usize);
     }
     // if bb(false) {
     unsafe {
-        rust_begin_unwind();
+        rust_begin_unwind(0);
     }
     // }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 extern crate core;
 
 fn abort() -> ! {
-    unsafe { core::intrinsics::abort() }
+    core::intrinsics::abort()
 }
 
 #[macro_use]


### PR DESCRIPTION
Run the full `run.sh` test script to get full assertions, including that
nothing in the wasm compiler-builtins is panicking. Unfortunately it's
currently panicking, so this is good to weed out!