### PR TITLE
Fix warnings on latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 // We use `u128` in a whole bunch of places which we currently agree with the
 // compiler on ABIs and such, so we should be "good enough" for now and changes
 // to the `u128` ABI will be reflected here.
-#![allow(improper_ctypes)]
+#![allow(improper_ctypes, improper_ctypes_definitions)]
 
 // We disable #[no_mangle] for tests so that we can verify the test results
 // against the native compiler-rt implementations of the builtins.


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/72700 caused the existing
`allow(improper_ctypes)` guard to stop working, we now need
`allow(improper_ctypes_definitions)` instead.

We keep the old one to avoid any issues with older nightlies.

Signed-off-by: Joe Richey <joerichey@google.com>