### PR TITLE
Remove implicit 'mem' feature for '-none' targets.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,7 +27,6 @@ fn main() {
     // provide them.
     if (target.contains("wasm32") && !target.contains("wasi"))
         || (target.contains("sgx") && target.contains("fortanix"))
-        || target.contains("-none")
         || target.contains("nvptx")
     {
         println!("cargo:rustc-cfg=feature=\"mem\"");


### PR DESCRIPTION
Now that https://github.com/rust-lang/rust/pull/77284 is merged, anyone who needs the `mem` feature can opt-in with `-Zbuild-std-features=compiler-builtins-mem`. This change stops targets with '-none' in there triple from implicitly having the `mem` feature enabled.

Fixes #369 