### PR TITLE
Division tweaks

### DIFF
--- a/src/int/leading_zeros.rs
+++ b/src/int/leading_zeros.rs
@@ -4,6 +4,7 @@
 // Compilers will insert the check for zero in cases where it is needed.
 
 /// Returns the number of leading binary zeros in `x`.
+#[doc(hidden)]
 pub fn usize_leading_zeros_default(x: usize) -> usize {
     // The basic idea is to test if the higher bits of `x` are zero and bisect the number
     // of leading zeros. It is possible for all branches of the bisection to use the same
@@ -75,6 +76,7 @@ pub fn usize_leading_zeros_default(x: usize) -> usize {
 // RISC-V that allows `(x >= power-of-two) as usize` to be branchless.
 
 /// Returns the number of leading binary zeros in `x`.
+#[doc(hidden)]
 pub fn usize_leading_zeros_riscv(x: usize) -> usize {
     let mut x = x;
     // the number of potential leading zeros

--- a/src/int/sdiv.rs
+++ b/src/int/sdiv.rs
@@ -1,65 +1,166 @@
-use int::specialized_div_rem::*;
+use int::udiv::*;
 
+macro_rules! sdivmod {
+    (
+        $unsigned_fn:ident, // name of the unsigned division function
+        $signed_fn:ident, // name of the signed division function
+        $uX:ident, // unsigned integer type for the inputs and outputs of `$unsigned_name`
+        $iX:ident, // signed integer type for the inputs and outputs of `$signed_name`
+        $($attr:tt),* // attributes
+    ) => {
+        intrinsics! {
+            $(
+                #[$attr]
+            )*
+            /// Returns `n / d` and sets `*rem = n % d`
+            pub extern "C" fn $signed_fn(a: $iX, b: $iX, rem: &mut $iX) -> $iX {
+                let a_neg = a < 0;
+                let b_neg = b < 0;
+                let mut a = a;
+                let mut b = b;
+                if a_neg {
+                    a = a.wrapping_neg();
+                }
+                if b_neg {
+                    b = b.wrapping_neg();
+                }
+                let mut r = *rem as $uX;
+                let t = $unsigned_fn(a as $uX, b as $uX, Some(&mut r)) as $iX;
+                let mut r = r as $iX;
+                if a_neg {
+                    r = r.wrapping_neg();
+                }
+                *rem = r;
+                if a_neg != b_neg {
+                    t.wrapping_neg()
+                } else {
+                    t
+                }
+            }
+        }
+    }
+}
+
+macro_rules! sdiv {
+    (
+        $unsigned_fn:ident, // name of the unsigned division function
+        $signed_fn:ident, // name of the signed division function
+        $uX:ident, // unsigned integer type for the inputs and outputs of `$unsigned_name`
+        $iX:ident, // signed integer type for the inputs and outputs of `$signed_name`
+        $($attr:tt),* // attributes
+    ) => {
+        intrinsics! {
+            $(
+                #[$attr]
+            )*
+            /// Returns `n / d`
+            pub extern "C" fn $signed_fn(a: $iX, b: $iX) -> $iX {
+                let a_neg = a < 0;
+                let b_neg = b < 0;
+                let mut a = a;
+                let mut b = b;
+                if a_neg {
+                    a = a.wrapping_neg();
+                }
+                if b_neg {
+                    b = b.wrapping_neg();
+                }
+                let t = $unsigned_fn(a as $uX, b as $uX) as $iX;
+                if a_neg != b_neg {
+                    t.wrapping_neg()
+                } else {
+                    t
+                }
+            }
+        }
+    }
+}
+
+macro_rules! smod {
+    (
+        $unsigned_fn:ident, // name of the unsigned division function
+        $signed_fn:ident, // name of the signed division function
+        $uX:ident, // unsigned integer type for the inputs and outputs of `$unsigned_name`
+        $iX:ident, // signed integer type for the inputs and outputs of `$signed_name`
+        $($attr:tt),* // attributes
+    ) => {
+        intrinsics! {
+            $(
+                #[$attr]
+            )*
+            /// Returns `n % d`
+            pub extern "C" fn $signed_fn(a: $iX, b: $iX) -> $iX {
+                let a_neg = a < 0;
+                let b_neg = b < 0;
+                let mut a = a;
+                let mut b = b;
+                if a_neg {
+                    a = a.wrapping_neg();
+                }
+                if b_neg {
+                    b = b.wrapping_neg();
+                }
+                let r = $unsigned_fn(a as $uX, b as $uX) as $iX;
+                if a_neg {
+                    r.wrapping_neg()
+                } else {
+                    r
+                }
+            }
+        }
+    }
+}
+
+sdivmod!(
+    __udivmodsi4,
+    __divmodsi4,
+    u32,
+    i32,
+    maybe_use_optimized_c_shim
+);
+// The `#[arm_aeabi_alias = __aeabi_idiv]` attribute cannot be made to work with `intrinsics!` in macros
 intrinsics! {
     #[maybe_use_optimized_c_shim]
     #[arm_aeabi_alias = __aeabi_idiv]
     /// Returns `n / d`
     pub extern "C" fn __divsi3(a: i32, b: i32) -> i32 {
-        i32_div_rem(a, b).0
-    }
-
-    #[maybe_use_optimized_c_shim]
-    /// Returns `n % d`
-    pub extern "C" fn __modsi3(a: i32, b: i32) -> i32 {
-        i32_div_rem(a, b).1
-    }
-
-    #[maybe_use_optimized_c_shim]
-    /// Returns `n / d` and sets `*rem = n % d`
-    pub extern "C" fn __divmodsi4(a: i32, b: i32, rem: &mut i32) -> i32 {
-        let quo_rem = i32_div_rem(a, b);
-        *rem = quo_rem.1;
-        quo_rem.0
-    }
-
-    #[maybe_use_optimized_c_shim]
-    /// Returns `n / d`
-    pub extern "C" fn __divdi3(a: i64, b: i64) -> i64 {
-        i64_div_rem(a, b).0
-    }
-
-    #[maybe_use_optimized_c_shim]
-    /// Returns `n % d`
-    pub extern "C" fn __moddi3(a: i64, b: i64) -> i64 {
-        i64_div_rem(a, b).1
-    }
-
-    #[maybe_use_optimized_c_shim]
-    /// Returns `n / d` and sets `*rem = n % d`
-    pub extern "C" fn __divmoddi4(a: i64, b: i64, rem: &mut i64) -> i64 {
-        let quo_rem = i64_div_rem(a, b);
-        *rem = quo_rem.1;
-        quo_rem.0
-    }
-
-    #[win64_128bit_abi_hack]
-    /// Returns `n / d`
-    pub extern "C" fn __divti3(a: i128, b: i128) -> i128 {
-        i128_div_rem(a, b).0
-    }
-
-    #[win64_128bit_abi_hack]
-    /// Returns `n % d`
-    pub extern "C" fn __modti3(a: i128, b: i128) -> i128 {
-        i128_div_rem(a, b).1
-    }
-
-    // LLVM does not currently have a `__divmodti4` function, but GCC does
-    #[maybe_use_optimized_c_shim]
-    /// Returns `n / d` and sets `*rem = n % d`
-    pub extern "C" fn __divmodti4(a: i128, b: i128, rem: &mut i128) -> i128 {
-        let quo_rem = i128_div_rem(a, b);
-        *rem = quo_rem.1;
-        quo_rem.0
+        let a_neg = a < 0;
+        let b_neg = b < 0;
+        let mut a = a;
+        let mut b = b;
+        if a_neg {
+            a = a.wrapping_neg();
+        }
+        if b_neg {
+            b = b.wrapping_neg();
+        }
+        let t = __udivsi3(a as u32, b as u32) as i32;
+        if a_neg != b_neg {
+            t.wrapping_neg()
+        } else {
+            t
+        }
     }
 }
+smod!(__umodsi3, __modsi3, u32, i32, maybe_use_optimized_c_shim);
+
+sdivmod!(
+    __udivmoddi4,
+    __divmoddi4,
+    u64,
+    i64,
+    maybe_use_optimized_c_shim
+);
+sdiv!(__udivdi3, __divdi3, u64, i64, maybe_use_optimized_c_shim);
+smod!(__umoddi3, __moddi3, u64, i64, maybe_use_optimized_c_shim);
+
+// LLVM does not currently have a `__divmodti4` function, but GCC does
+sdivmod!(
+    __udivmodti4,
+    __divmodti4,
+    u128,
+    i128,
+    maybe_use_optimized_c_shim
+);
+sdiv!(__udivti3, __divti3, u128, i128, win64_128bit_abi_hack);
+smod!(__umodti3, __modti3, u128, i128, win64_128bit_abi_hack);

--- a/src/int/specialized_div_rem/asymmetric.rs
+++ b/src/int/specialized_div_rem/asymmetric.rs
@@ -3,6 +3,7 @@
 /// assembly instruction that can divide a 128 bit integer by a 64 bit integer if the quotient fits
 /// in 64 bits. The 128 bit version of this algorithm would use that fast hardware division to
 /// construct a full 128 bit by 128 bit division.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! impl_asymmetric {
     (

--- a/src/int/specialized_div_rem/binary_long.rs
+++ b/src/int/specialized_div_rem/binary_long.rs
@@ -4,6 +4,7 @@
 /// predicate instructions. For architectures with predicated instructions, one of the algorithms
 /// described in the documentation of these functions probably has higher performance, and a custom
 /// assembly routine should be used instead.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! impl_binary_long {
     (

--- a/src/int/specialized_div_rem/delegate.rs
+++ b/src/int/specialized_div_rem/delegate.rs
@@ -2,6 +2,7 @@
 /// binary long division to divide integers larger than what hardware division by itself can do. This
 /// function is intended for microarchitectures that have division hardware, but not fast enough
 /// multiplication hardware for `impl_trifecta` to be faster.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! impl_delegate {
     (

--- a/src/int/specialized_div_rem/mod.rs
+++ b/src/int/specialized_div_rem/mod.rs
@@ -111,13 +111,6 @@ fn u64_by_u64_div_rem(duo: u64, div: u64) -> (u64, u64) {
     zero_div_fn()
 }
 
-// `inline(never)` is placed on unsigned division functions so that there are just three division
-// functions (`u32_div_rem`, `u64_div_rem`, and `u128_div_rem`) backing all `compiler-builtins`
-// division functions. The signed functions like `i32_div_rem` will get inlined into the
-// `compiler-builtins` signed division functions, so that they directly call the three division
-// functions. Otherwise, LLVM may try to inline the unsigned division functions 4 times into the
-// signed division functions, which results in an explosion in code size.
-
 // Whether `trifecta` or `delegate` is faster for 128 bit division depends on the speed at which a
 // microarchitecture can multiply and divide. We decide to be optimistic and assume `trifecta` is
 // faster if the target pointer width is at least 64.
@@ -127,16 +120,12 @@ fn u64_by_u64_div_rem(duo: u64, div: u64) -> (u64, u64) {
 ))]
 impl_trifecta!(
     u128_div_rem,
-    i128_div_rem,
     zero_div_fn,
     u64_by_u64_div_rem,
     32,
     u32,
     u64,
-    u128,
-    i128,
-    inline(never);
-    inline
+    u128
 );
 
 // If the pointer width less than 64, then the target architecture almost certainly does not have
@@ -147,7 +136,6 @@ impl_trifecta!(
 ))]
 impl_delegate!(
     u128_div_rem,
-    i128_div_rem,
     zero_div_fn,
     u64_normalization_shift,
     u64_by_u64_div_rem,
@@ -155,9 +143,7 @@ impl_delegate!(
     u32,
     u64,
     u128,
-    i128,
-    inline(never);
-    inline
+    i128
 );
 
 /// Divides `duo` by `div` and returns a tuple of the quotient and the remainder.
@@ -191,17 +177,13 @@ unsafe fn u128_by_u64_div_rem(duo: u128, div: u64) -> (u64, u64) {
 #[cfg(all(feature = "asm", target_arch = "x86_64"))]
 impl_asymmetric!(
     u128_div_rem,
-    i128_div_rem,
     zero_div_fn,
     u64_by_u64_div_rem,
     u128_by_u64_div_rem,
     32,
     u32,
     u64,
-    u128,
-    i128,
-    inline(never);
-    inline
+    u128
 );
 
 /// Divides `duo` by `div` and returns a tuple of the quotient and the remainder.
@@ -226,7 +208,6 @@ fn u32_by_u32_div_rem(duo: u32, div: u32) -> (u32, u32) {
 ))]
 impl_delegate!(
     u64_div_rem,
-    i64_div_rem,
     zero_div_fn,
     u32_normalization_shift,
     u32_by_u32_div_rem,
@@ -234,9 +215,7 @@ impl_delegate!(
     u16,
     u32,
     u64,
-    i64,
-    inline(never);
-    inline
+    i64
 );
 
 // When not on x86 and the pointer width is 64, use `binary_long`.
@@ -246,14 +225,11 @@ impl_delegate!(
 ))]
 impl_binary_long!(
     u64_div_rem,
-    i64_div_rem,
     zero_div_fn,
     u64_normalization_shift,
     64,
     u64,
-    i64,
-    inline(never);
-    inline
+    i64
 );
 
 /// Divides `duo` by `div` and returns a tuple of the quotient and the remainder.
@@ -287,28 +263,21 @@ unsafe fn u64_by_u32_div_rem(duo: u64, div: u32) -> (u32, u32) {
 #[cfg(all(feature = "asm", target_arch = "x86"))]
 impl_asymmetric!(
     u64_div_rem,
-    i64_div_rem,
     zero_div_fn,
     u32_by_u32_div_rem,
     u64_by_u32_div_rem,
     16,
     u16,
     u32,
-    u64,
-    i64,
-    inline(never);
-    inline
+    u64
 );
 
 // 32 bits is the smallest division used by `compiler-builtins`, so we end with binary long division
 impl_binary_long!(
     u32_div_rem,
-    i32_div_rem,
     zero_div_fn,
     u32_normalization_shift,
     32,
     u32,
-    i32,
-    inline(never);
-    inline
+    i32
 );

--- a/src/int/specialized_div_rem/norm_shift.rs
+++ b/src/int/specialized_div_rem/norm_shift.rs
@@ -1,4 +1,5 @@
 /// Creates a function used by some division algorithms to compute the "normalization shift".
+#[doc(hidden)]
 #[macro_export]
 macro_rules! impl_normalization_shift {
     (

--- a/src/int/specialized_div_rem/trifecta.rs
+++ b/src/int/specialized_div_rem/trifecta.rs
@@ -2,6 +2,7 @@
 /// larger than the largest hardware integer division supported. These functions use large radix
 /// division algorithms that require both fast division and very fast widening multiplication on the
 /// target microarchitecture. Otherwise, `impl_delegate` should be used instead.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! impl_trifecta {
     (


### PR DESCRIPTION
This slims down `asymmetric.rs`, removes the old style signed division macro code, and constructs signed divisions independent of the `specialized_div_rem` module. I figured out that when this is done, LLVM autoinlines just how I want it (except that the code gen for RISCV is still horrendous, I guess my `leading_zeros` changes still have not made it into nightly). The fact that I don't have to manage the signed divisions in the `specialized_div_rem` module will make it much easier to convert some macros to generics later. In another PR, I will fix problems I have with the division testing code and improve the edge cases that it covers.