### PR TITLE
Use weak linkage for aeabi memory functions

### DIFF
--- a/src/arm.rs
+++ b/src/arm.rs
@@ -138,18 +138,20 @@ pub unsafe fn __aeabi_ldivmod() {
     intrinsics::unreachable();
 }
 
+// The following functions use weak linkage to allow users to override
+// with custom implementation.
 // FIXME: The `*4` and `*8` variants should be defined as aliases.
 
 #[cfg(not(target_os = "ios"))]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[cfg_attr(thumb, linkage = "weak")]
+#[linkage = "weak"]
 pub unsafe extern "aapcs" fn __aeabi_memcpy(dest: *mut u8, src: *const u8, n: usize) {
     ::mem::memcpy(dest, src, n);
 }
 
 #[cfg(not(target_os = "ios"))]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[cfg_attr(thumb, linkage = "weak")]
+#[linkage = "weak"]
 pub unsafe extern "aapcs" fn __aeabi_memcpy4(dest: *mut u8, src: *const u8, mut n: usize) {
     // We are guaranteed 4-alignment, so accessing at u32 is okay.
     let mut dest = dest as *mut u32;
@@ -167,35 +169,35 @@ pub unsafe extern "aapcs" fn __aeabi_memcpy4(dest: *mut u8, src: *const u8, mut 
 
 #[cfg(not(target_os = "ios"))]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[cfg_attr(thumb, linkage = "weak")]
+#[linkage = "weak"]
 pub unsafe extern "aapcs" fn __aeabi_memcpy8(dest: *mut u8, src: *const u8, n: usize) {
     __aeabi_memcpy4(dest, src, n);
 }
 
 #[cfg(not(target_os = "ios"))]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[cfg_attr(thumb, linkage = "weak")]
+#[linkage = "weak"]
 pub unsafe extern "aapcs" fn __aeabi_memmove(dest: *mut u8, src: *const u8, n: usize) {
     ::mem::memmove(dest, src, n);
 }
 
 #[cfg(not(any(target_os = "ios", target_env = "msvc")))]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[cfg_attr(thumb, linkage = "weak")]
+#[linkage = "weak"]
 pub unsafe extern "aapcs" fn __aeabi_memmove4(dest: *mut u8, src: *const u8, n: usize) {
     __aeabi_memmove(dest, src, n);
 }
 
 #[cfg(not(any(target_os = "ios", target_env = "msvc")))]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[cfg_attr(thumb, linkage = "weak")]
+#[linkage = "weak"]
 pub unsafe extern "aapcs" fn __aeabi_memmove8(dest: *mut u8, src: *const u8, n: usize) {
     __aeabi_memmove(dest, src, n);
 }
 
 #[cfg(not(target_os = "ios"))]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[cfg_attr(thumb, linkage = "weak")]
+#[linkage = "weak"]
 pub unsafe extern "aapcs" fn __aeabi_memset(dest: *mut u8, n: usize, c: i32) {
     // Note the different argument order
     ::mem::memset(dest, c, n);
@@ -203,7 +205,7 @@ pub unsafe extern "aapcs" fn __aeabi_memset(dest: *mut u8, n: usize, c: i32) {
 
 #[cfg(not(target_os = "ios"))]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[cfg_attr(thumb, linkage = "weak")]
+#[linkage = "weak"]
 pub unsafe extern "aapcs" fn __aeabi_memset4(dest: *mut u8, mut n: usize, c: i32) {
     let mut dest = dest as *mut u32;
 
@@ -221,28 +223,28 @@ pub unsafe extern "aapcs" fn __aeabi_memset4(dest: *mut u8, mut n: usize, c: i32
 
 #[cfg(not(target_os = "ios"))]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[cfg_attr(thumb, linkage = "weak")]
+#[linkage = "weak"]
 pub unsafe extern "aapcs" fn __aeabi_memset8(dest: *mut u8, n: usize, c: i32) {
     __aeabi_memset4(dest, n, c);
 }
 
 #[cfg(not(target_os = "ios"))]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[cfg_attr(thumb, linkage = "weak")]
+#[linkage = "weak"]
 pub unsafe extern "aapcs" fn __aeabi_memclr(dest: *mut u8, n: usize) {
     __aeabi_memset(dest, n, 0);
 }
 
 #[cfg(not(any(target_os = "ios", target_env = "msvc")))]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[cfg_attr(thumb, linkage = "weak")]
+#[linkage = "weak"]
 pub unsafe extern "aapcs" fn __aeabi_memclr4(dest: *mut u8, n: usize) {
     __aeabi_memset4(dest, n, 0);
 }
 
 #[cfg(not(any(target_os = "ios", target_env = "msvc")))]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[cfg_attr(thumb, linkage = "weak")]
+#[linkage = "weak"]
 pub unsafe extern "aapcs" fn __aeabi_memclr8(dest: *mut u8, n: usize) {
     __aeabi_memset4(dest, n, 0);
 }


### PR DESCRIPTION
This is the PR for issue #378. Copy pasting from the issue:

> I am developing for armv7-none-eabihf targets, and I hope that the aeabi memory functions can be declared as weak symbols so I can replace them with other implementations that are more efficient.
> 
> Currently the functions `__aeabi_memcpy*`, `__aeabi_memmove*`, `__aeabi_memset*`, `__aeabi_memclr*` defined in [arm.rs](https://github.com/rust-lang/compiler-builtins/blob/master/src/arm.rs) are exported as weak symbols only on thumb mode. There is no way to override the implementation for other arm targets even if we turn off the mem feature, as the implementation would refer to the functions defined in `mem.rs`. The only workaround I currently know of is to maintain a fork of the compiler_builtins (and patch cargo-xbuild so it would use the forked version).
> 
> The implementation here is indeed slower than the optimized version found in other libraries. For example, the newlib implementation of [memcpy for armv7a](https://github.com/bminor/newlib/blob/master/newlib/libc/machine/arm/aeabi_memcpy-armv7a.S) which uses SIMD and other techniques. In our bare-metal project ([artiq zynq port](https://git.m-labs.hk/M-Labs/artiq-zynq)) which does quite a lot of copying, we got significant performance improvement for some workload by replacing the memcpy routine with the newlib one (at least doubled the ethernet throughput). I think this proves that there are use cases where we want to replace the implementation.
>
> It seems that in PR #164, the author originally marked all aeabi memory functions as weak symbols, but later changed to thumb targets only (https://github.com/rust-lang/compiler-builtins/pull/164/commits/b8a662040ee919d958a0fe13ac9ce001666fcdd7), I am not sure about the reason for that.

This PR changes those memory functions to weak symbols, so users can override them if they want for specific purpose or better performance.

For example, in our project https://git.m-labs.hk/pca006132/artiq-zynq/src/branch/test, we overrided the `aeabi_memcpy*` functions with an implementation from newlib which uses NEON instructions for faster memcpy.