### PR TITLE
math: add {fmin,fmax}{f,} for thumb*-none-eabi*

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -92,6 +92,10 @@ no_mangle! {
 // only for the thumb*-none-eabi* targets
 #[cfg(all(target_arch = "arm", target_os = "none"))]
 no_mangle! {
+    fn fmin(x: f64, y: f64) -> f64;
+    fn fminf(x: f32, y: f32) -> f32;
+    fn fmax(x: f64, y: f64) -> f64;
+    fn fmaxf(x: f32, y: f32) -> f32;
     // `f64 % f64`
     fn fmod(x: f64, y: f64) -> f64;
     // `f32 % f32`


### PR DESCRIPTION
These are exposed in core::f32

close #354 
c.f. rust-lang/rust#62729
Patch from @whitequark (https://paste.debian.net/1168430/)