### PR TITLE
Use the AT&T syntax to support old LLVM on rust-lang/rust

### DIFF
--- a/src/int/specialized_div_rem/mod.rs
+++ b/src/int/specialized_div_rem/mod.rs
@@ -169,12 +169,13 @@ unsafe fn u128_by_u64_div_rem(duo: u128, div: u64) -> (u64, u64) {
     unsafe {
         // divides the combined registers rdx:rax (`duo` is split into two 64 bit parts to do this)
         // by `div`. The quotient is stored in rax and the remainder in rdx.
+        // FIXME: Use the Intel syntax once we drop LLVM 9 support on rust-lang/rust.
         asm!(
             "div {0}",
             in(reg) div,
             inlateout("rax") duo_lo => quo,
             inlateout("rdx") duo_hi => rem,
-            options(pure, nomem, nostack)
+            options(att_syntax, pure, nomem, nostack)
         );
     }
     (quo, rem)
@@ -255,12 +256,13 @@ unsafe fn u64_by_u32_div_rem(duo: u64, div: u32) -> (u32, u32) {
     unsafe {
         // divides the combined registers rdx:rax (`duo` is split into two 32 bit parts to do this)
         // by `div`. The quotient is stored in rax and the remainder in rdx.
+        // FIXME: Use the Intel syntax once we drop LLVM 9 support on rust-lang/rust.
         asm!(
             "div {0}",
             in(reg) div,
             inlateout("rax") duo_lo => quo,
             inlateout("rdx") duo_hi => rem,
-            options(pure, nomem, nostack)
+            options(att_syntax, pure, nomem, nostack)
         );
     }
     (quo, rem)


### PR DESCRIPTION
This needs to support LLVM 9 on rust-lang/rust: https://github.com/rust-lang/rust/pull/79863#issuecomment-742055315
I'm unfamiliar with the assembly so something may be wrong.

r? @Amanieu 