### PR TITLE
Remove `count_ones`

### DIFF
--- a/src/int/mod.rs
+++ b/src/int/mod.rs
@@ -90,7 +90,6 @@ pub trait Int:
     fn aborting_div(self, other: Self) -> Self;
     fn aborting_rem(self, other: Self) -> Self;
     fn leading_zeros(self) -> u32;
-    fn count_ones(self) -> u32;
 }
 
 fn unwrap<T>(t: Option<T>) -> T {
@@ -228,10 +227,6 @@ macro_rules! int_impl_common {
 
         fn leading_zeros(self) -> u32 {
             <Self>::leading_zeros(self)
-        }
-
-        fn count_ones(self) -> u32 {
-            <Self>::count_ones(self)
         }
     };
 }


### PR DESCRIPTION
I can't remember why I added this in the first place since it isn't actually used. This fixes https://github.com/rust-lang/compiler-builtins/issues/398.

I just realized that no unused warnings are produced for unused functions in traits, even if I make the traits `pub(crate)`. Is there a way I can automatically check for unused functions in traits, so that I can remove them in my other PR?