### PR TITLE
Optimize memcpy, memmove and memset

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -33,6 +33,11 @@ fn main() {
         println!("cargo:rustc-cfg=feature=\"mem\"");
     }
 
+    // These targets have hardware unaligned access support.
+    if target.contains("x86_64") || target.contains("i686") || target.contains("aarch64") {
+        println!("cargo:rustc-cfg=feature=\"mem-unaligned\"");
+    }
+
     // NOTE we are going to assume that llvm-target, what determines our codegen option, matches the
     // target triple. This is usually correct for our built-in targets but can break in presence of
     // custom targets, which can have arbitrary names.

--- a/src/mem/impls.rs
+++ b/src/mem/impls.rs
@@ -1,27 +1,219 @@
+use core::intrinsics::likely;
+
+const WORD_SIZE: usize = core::mem::size_of::<usize>();
+const WORD_MASK: usize = WORD_SIZE - 1;
+
+// If the number of bytes involved exceed this threshold we will opt in word-wise copy.
+// The value here selected is max(2 * WORD_SIZE, 16):
+// * We need at least 2 * WORD_SIZE bytes to guarantee that at least 1 word will be copied through
+//   word-wise copy.
+// * The word-wise copy logic needs to perform some checks so it has some small overhead.
+//   ensures that even on 32-bit platforms we have copied at least 8 bytes through
+//   word-wise copy so the saving of word-wise copy outweights the fixed overhead.
+const WORD_COPY_THRESHOLD: usize = if 2 * WORD_SIZE > 16 {
+    2 * WORD_SIZE
+} else {
+    16
+};
+
 #[inline(always)]
-pub unsafe fn copy_forward(dest: *mut u8, src: *const u8, n: usize) {
-    let mut i = 0;
-    while i < n {
-        *dest.add(i) = *src.add(i);
-        i += 1;
+pub unsafe fn copy_forward(mut dest: *mut u8, mut src: *const u8, mut n: usize) {
+    #[inline(always)]
+    unsafe fn copy_forward_bytes(mut dest: *mut u8, mut src: *const u8, n: usize) {
+        let dest_end = dest.add(n);
+        while dest < dest_end {
+            *dest = *src;
+            dest = dest.add(1);
+            src = src.add(1);
+        }
     }
+
+    #[inline(always)]
+    unsafe fn copy_forward_aligned_words(dest: *mut u8, src: *const u8, n: usize) {
+        let mut dest_usize = dest as *mut usize;
+        let mut src_usize = src as *mut usize;
+        let dest_end = dest.add(n) as *mut usize;
+
+        while dest_usize < dest_end {
+            *dest_usize = *src_usize;
+            dest_usize = dest_usize.add(1);
+            src_usize = src_usize.add(1);
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn copy_forward_misaligned_words(dest: *mut u8, src: *const u8, n: usize) {
+        let mut dest_usize = dest as *mut usize;
+        let dest_end = dest.add(n) as *mut usize;
+
+        // Calculate the misalignment offset and shift needed to reassemble value.
+        let offset = src as usize & WORD_MASK;
+        let shift = offset * 8;
+
+        // Realign src
+        let mut src_aligned = (src as usize & !WORD_MASK) as *mut usize;
+        // XXX: Could this possibly be UB?
+        let mut prev_word = *src_aligned;
+
+        while dest_usize < dest_end {
+            src_aligned = src_aligned.add(1);
+            let cur_word = *src_aligned;
+            #[cfg(target_endian = "little")]
+            let resembled = prev_word >> shift | cur_word << (WORD_SIZE * 8 - shift);
+            #[cfg(target_endian = "big")]
+            let resembled = prev_word << shift | cur_word >> (WORD_SIZE * 8 - shift);
+            prev_word = cur_word;
+
+            *dest_usize = resembled;
+            dest_usize = dest_usize.add(1);
+        }
+    }
+
+    if n >= WORD_COPY_THRESHOLD {
+        // Align dest
+        // Because of n >= 2 * WORD_SIZE, dst_misalignment < n
+        let dest_misalignment = (dest as usize).wrapping_neg() & WORD_MASK;
+        copy_forward_bytes(dest, src, dest_misalignment);
+        dest = dest.add(dest_misalignment);
+        src = src.add(dest_misalignment);
+        n -= dest_misalignment;
+
+        let n_words = n & !WORD_MASK;
+        let src_misalignment = src as usize & WORD_MASK;
+        if likely(src_misalignment == 0) {
+            copy_forward_aligned_words(dest, src, n_words);
+        } else {
+            copy_forward_misaligned_words(dest, src, n_words);
+        }
+        dest = dest.add(n_words);
+        src = src.add(n_words);
+        n -= n_words;
+    }
+    copy_forward_bytes(dest, src, n);
 }
 
 #[inline(always)]
-pub unsafe fn copy_backward(dest: *mut u8, src: *const u8, n: usize) {
-    // copy from end
-    let mut i = n;
-    while i != 0 {
-        i -= 1;
-        *dest.add(i) = *src.add(i);
+pub unsafe fn copy_backward(dest: *mut u8, src: *const u8, mut n: usize) {
+    // The following backward copy helper functions uses the pointers past the end
+    // as their inputs instead of pointers to the start!
+    #[inline(always)]
+    unsafe fn copy_backward_bytes(mut dest: *mut u8, mut src: *const u8, n: usize) {
+        let dest_start = dest.sub(n);
+        while dest_start < dest {
+            dest = dest.sub(1);
+            src = src.sub(1);
+            *dest = *src;
+        }
     }
+
+    #[inline(always)]
+    unsafe fn copy_backward_aligned_words(dest: *mut u8, src: *const u8, n: usize) {
+        let mut dest_usize = dest as *mut usize;
+        let mut src_usize = src as *mut usize;
+        let dest_start = dest.sub(n) as *mut usize;
+
+        while dest_start < dest_usize {
+            dest_usize = dest_usize.sub(1);
+            src_usize = src_usize.sub(1);
+            *dest_usize = *src_usize;
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn copy_backward_misaligned_words(dest: *mut u8, src: *const u8, n: usize) {
+        let mut dest_usize = dest as *mut usize;
+        let dest_start = dest.sub(n) as *mut usize;
+
+        // Calculate the misalignment offset and shift needed to reassemble value.
+        let offset = src as usize & WORD_MASK;
+        let shift = offset * 8;
+
+        // Realign src_aligned
+        let mut src_aligned = (src as usize & !WORD_MASK) as *mut usize;
+        // XXX: Could this possibly be UB?
+        let mut prev_word = *src_aligned;
+
+        while dest_start < dest_usize {
+            src_aligned = src_aligned.sub(1);
+            let cur_word = *src_aligned;
+            #[cfg(target_endian = "little")]
+            let resembled = prev_word << (WORD_SIZE * 8 - shift) | cur_word >> shift;
+            #[cfg(target_endian = "big")]
+            let resembled = prev_word >> (WORD_SIZE * 8 - shift) | cur_word << shift;
+            prev_word = cur_word;
+
+            dest_usize = dest_usize.sub(1);
+            *dest_usize = resembled;
+        }
+    }
+
+    let mut dest = dest.add(n);
+    let mut src = src.add(n);
+
+    if n >= WORD_COPY_THRESHOLD {
+        // Align dest
+        // Because of n >= 2 * WORD_SIZE, dst_misalignment < n
+        let dest_misalignment = dest as usize & WORD_MASK;
+        copy_backward_bytes(dest, src, dest_misalignment);
+        dest = dest.sub(dest_misalignment);
+        src = src.sub(dest_misalignment);
+        n -= dest_misalignment;
+
+        let n_words = n & !WORD_MASK;
+        let src_misalignment = src as usize & WORD_MASK;
+        if likely(src_misalignment == 0) {
+            copy_backward_aligned_words(dest, src, n_words);
+        } else {
+            copy_backward_misaligned_words(dest, src, n_words);
+        }
+        dest = dest.sub(n_words);
+        src = src.sub(n_words);
+        n -= n_words;
+    }
+    copy_backward_bytes(dest, src, n);
 }
 
 #[inline(always)]
-pub unsafe fn set_bytes(s: *mut u8, c: u8, n: usize) {
-    let mut i = 0;
-    while i < n {
-        *s.add(i) = c;
-        i += 1;
+pub unsafe fn set_bytes(mut s: *mut u8, c: u8, mut n: usize) {
+    #[inline(always)]
+    pub unsafe fn set_bytes_bytes(mut s: *mut u8, c: u8, n: usize) {
+        let end = s.add(n);
+        while s < end {
+            *s = c;
+            s = s.add(1);
+        }
     }
+
+    #[inline(always)]
+    pub unsafe fn set_bytes_words(s: *mut u8, c: u8, n: usize) {
+        let mut broadcast = c as usize;
+        let mut bits = 8;
+        while bits < WORD_SIZE * 8 {
+            broadcast |= broadcast << bits;
+            bits *= 2;
+        }
+
+        let mut s_usize = s as *mut usize;
+        let end = s.add(n) as *mut usize;
+
+        while s_usize < end {
+            *s_usize = broadcast;
+            s_usize = s_usize.add(1);
+        }
+    }
+
+    if likely(n >= WORD_COPY_THRESHOLD) {
+        // Align s
+        // Because of n >= 2 * WORD_SIZE, dst_misalignment < n
+        let misalignment = (s as usize).wrapping_neg() & WORD_MASK;
+        set_bytes_bytes(s, c, misalignment);
+        s = s.add(misalignment);
+        n -= misalignment;
+
+        let n_words = n & !WORD_MASK;
+        set_bytes_words(s, c, n_words);
+        s = s.add(n_words);
+        n -= n_words;
+    }
+    set_bytes_bytes(s, c, n);
 }

--- a/src/mem/impls.rs
+++ b/src/mem/impls.rs
@@ -61,8 +61,8 @@ pub unsafe fn copy_forward(mut dest: *mut u8, mut src: *const u8, mut n: usize) 
 
         // Realign src
         let mut src_aligned = (src as usize & !WORD_MASK) as *mut usize;
-        // XXX: Could this possibly be UB?
-        let mut prev_word = *src_aligned;
+        // This will read (but won't use) bytes out of bound.
+        let mut prev_word = core::intrinsics::atomic_load_unordered(src_aligned);
 
         while dest_usize < dest_end {
             src_aligned = src_aligned.add(1);
@@ -154,8 +154,8 @@ pub unsafe fn copy_backward(dest: *mut u8, src: *const u8, mut n: usize) {
 
         // Realign src_aligned
         let mut src_aligned = (src as usize & !WORD_MASK) as *mut usize;
-        // XXX: Could this possibly be UB?
-        let mut prev_word = *src_aligned;
+        // This will read (but won't use) bytes out of bound.
+        let mut prev_word = core::intrinsics::atomic_load_unordered(src_aligned);
 
         while dest_start < dest_usize {
             src_aligned = src_aligned.sub(1);

--- a/testcrate/benches/mem.rs
+++ b/testcrate/benches/mem.rs
@@ -6,30 +6,64 @@ use test::{black_box, Bencher};
 extern crate compiler_builtins;
 use compiler_builtins::mem::{memcmp, memcpy, memmove, memset};
 
-fn memcpy_builtin(b: &mut Bencher, n: usize, offset: usize) {
-    let v1 = vec![1u8; n + offset];
-    let mut v2 = vec![0u8; n + offset];
+const WORD_SIZE: usize = core::mem::size_of::<usize>();
+
+struct AlignedVec {
+    vec: Vec<usize>,
+    size: usize,
+}
+
+impl AlignedVec {
+    fn new(fill: u8, size: usize) -> Self {
+        let mut broadcast = fill as usize;
+        let mut bits = 8;
+        while bits < WORD_SIZE * 8 {
+            broadcast |= broadcast << bits;
+            bits *= 2;
+        }
+
+        let vec = vec![broadcast; (size + WORD_SIZE - 1) & !WORD_SIZE];
+        AlignedVec { vec, size }
+    }
+}
+
+impl core::ops::Deref for AlignedVec {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self.vec.as_ptr() as *const u8, self.size) }
+    }
+}
+
+impl core::ops::DerefMut for AlignedVec {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        unsafe { core::slice::from_raw_parts_mut(self.vec.as_mut_ptr() as *mut u8, self.size) }
+    }
+}
+
+fn memcpy_builtin(b: &mut Bencher, n: usize, offset1: usize, offset2: usize) {
+    let v1 = AlignedVec::new(1, n + offset1);
+    let mut v2 = AlignedVec::new(0, n + offset2);
     b.bytes = n as u64;
     b.iter(|| {
-        let src: &[u8] = black_box(&v1[offset..]);
-        let dst: &mut [u8] = black_box(&mut v2[offset..]);
+        let src: &[u8] = black_box(&v1[offset1..]);
+        let dst: &mut [u8] = black_box(&mut v2[offset2..]);
         dst.copy_from_slice(src);
     })
 }
 
-fn memcpy_rust(b: &mut Bencher, n: usize, offset: usize) {
-    let v1 = vec![1u8; n + offset];
-    let mut v2 = vec![0u8; n + offset];
+fn memcpy_rust(b: &mut Bencher, n: usize, offset1: usize, offset2: usize) {
+    let v1 = AlignedVec::new(1, n + offset1);
+    let mut v2 = AlignedVec::new(0, n + offset2);
     b.bytes = n as u64;
     b.iter(|| {
-        let src: &[u8] = black_box(&v1[offset..]);
-        let dst: &mut [u8] = black_box(&mut v2[offset..]);
+        let src: &[u8] = black_box(&v1[offset1..]);
+        let dst: &mut [u8] = black_box(&mut v2[offset2..]);
         unsafe { memcpy(dst.as_mut_ptr(), src.as_ptr(), n) }
     })
 }
 
 fn memset_builtin(b: &mut Bencher, n: usize, offset: usize) {
-    let mut v1 = vec![0u8; n + offset];
+    let mut v1 = AlignedVec::new(0, n + offset);
     b.bytes = n as u64;
     b.iter(|| {
         let dst: &mut [u8] = black_box(&mut v1[offset..]);
@@ -41,7 +75,7 @@ fn memset_builtin(b: &mut Bencher, n: usize, offset: usize) {
 }
 
 fn memset_rust(b: &mut Bencher, n: usize, offset: usize) {
-    let mut v1 = vec![0u8; n + offset];
+    let mut v1 = AlignedVec::new(0, n + offset);
     b.bytes = n as u64;
     b.iter(|| {
         let dst: &mut [u8] = black_box(&mut v1[offset..]);
@@ -51,8 +85,8 @@ fn memset_rust(b: &mut Bencher, n: usize, offset: usize) {
 }
 
 fn memcmp_builtin(b: &mut Bencher, n: usize) {
-    let v1 = vec![0u8; n];
-    let mut v2 = vec![0u8; n];
+    let v1 = AlignedVec::new(0, n);
+    let mut v2 = AlignedVec::new(0, n);
     v2[n - 1] = 1;
     b.bytes = n as u64;
     b.iter(|| {
@@ -63,8 +97,8 @@ fn memcmp_builtin(b: &mut Bencher, n: usize) {
 }
 
 fn memcmp_rust(b: &mut Bencher, n: usize) {
-    let v1 = vec![0u8; n];
-    let mut v2 = vec![0u8; n];
+    let v1 = AlignedVec::new(0, n);
+    let mut v2 = AlignedVec::new(0, n);
     v2[n - 1] = 1;
     b.bytes = n as u64;
     b.iter(|| {
@@ -74,20 +108,20 @@ fn memcmp_rust(b: &mut Bencher, n: usize) {
     })
 }
 
-fn memmove_builtin(b: &mut Bencher, n: usize) {
-    let mut v = vec![0u8; n + n / 2];
+fn memmove_builtin(b: &mut Bencher, n: usize, offset: usize) {
+    let mut v = AlignedVec::new(0, n + n / 2 + offset);
     b.bytes = n as u64;
     b.iter(|| {
         let s: &mut [u8] = black_box(&mut v);
-        s.copy_within(0..n, n / 2);
+        s.copy_within(0..n, n / 2 + offset);
     })
 }
 
-fn memmove_rust(b: &mut Bencher, n: usize) {
-    let mut v = vec![0u8; n + n / 2];
+fn memmove_rust(b: &mut Bencher, n: usize, offset: usize) {
+    let mut v = AlignedVec::new(0, n + n / 2 + offset);
     b.bytes = n as u64;
     b.iter(|| {
-        let dst: *mut u8 = black_box(&mut v[n / 2..]).as_mut_ptr();
+        let dst: *mut u8 = black_box(&mut v[n / 2 + offset..]).as_mut_ptr();
         let src: *const u8 = black_box(&v).as_ptr();
         unsafe { memmove(dst, src, n) };
     })
@@ -95,35 +129,51 @@ fn memmove_rust(b: &mut Bencher, n: usize) {
 
 #[bench]
 fn memcpy_builtin_4096(b: &mut Bencher) {
-    memcpy_builtin(b, 4096, 0)
+    memcpy_builtin(b, 4096, 0, 0)
 }
 #[bench]
 fn memcpy_rust_4096(b: &mut Bencher) {
-    memcpy_rust(b, 4096, 0)
+    memcpy_rust(b, 4096, 0, 0)
 }
 #[bench]
 fn memcpy_builtin_1048576(b: &mut Bencher) {
-    memcpy_builtin(b, 1048576, 0)
+    memcpy_builtin(b, 1048576, 0, 0)
 }
 #[bench]
 fn memcpy_rust_1048576(b: &mut Bencher) {
-    memcpy_rust(b, 1048576, 0)
+    memcpy_rust(b, 1048576, 0, 0)
 }
 #[bench]
 fn memcpy_builtin_4096_offset(b: &mut Bencher) {
-    memcpy_builtin(b, 4096, 65)
+    memcpy_builtin(b, 4096, 65, 65)
 }
 #[bench]
 fn memcpy_rust_4096_offset(b: &mut Bencher) {
-    memcpy_rust(b, 4096, 65)
+    memcpy_rust(b, 4096, 65, 65)
 }
 #[bench]
 fn memcpy_builtin_1048576_offset(b: &mut Bencher) {
-    memcpy_builtin(b, 1048576, 65)
+    memcpy_builtin(b, 1048576, 65, 65)
 }
 #[bench]
 fn memcpy_rust_1048576_offset(b: &mut Bencher) {
-    memcpy_rust(b, 1048576, 65)
+    memcpy_rust(b, 1048576, 65, 65)
+}
+#[bench]
+fn memcpy_builtin_4096_misalign(b: &mut Bencher) {
+    memcpy_builtin(b, 4096, 65, 66)
+}
+#[bench]
+fn memcpy_rust_4096_misalign(b: &mut Bencher) {
+    memcpy_rust(b, 4096, 65, 66)
+}
+#[bench]
+fn memcpy_builtin_1048576_misalign(b: &mut Bencher) {
+    memcpy_builtin(b, 1048576, 65, 66)
+}
+#[bench]
+fn memcpy_rust_1048576_misalign(b: &mut Bencher) {
+    memcpy_rust(b, 1048576, 65, 66)
 }
 
 #[bench]
@@ -178,17 +228,33 @@ fn memcmp_rust_1048576(b: &mut Bencher) {
 
 #[bench]
 fn memmove_builtin_4096(b: &mut Bencher) {
-    memmove_builtin(b, 4096)
+    memmove_builtin(b, 4096, 0)
 }
 #[bench]
 fn memmove_rust_4096(b: &mut Bencher) {
-    memmove_rust(b, 4096)
+    memmove_rust(b, 4096, 0)
 }
 #[bench]
 fn memmove_builtin_1048576(b: &mut Bencher) {
-    memmove_builtin(b, 1048576)
+    memmove_builtin(b, 1048576, 0)
 }
 #[bench]
 fn memmove_rust_1048576(b: &mut Bencher) {
-    memmove_rust(b, 1048576)
+    memmove_rust(b, 1048576, 0)
+}
+#[bench]
+fn memmove_builtin_4096_misalign(b: &mut Bencher) {
+    memmove_builtin(b, 4096, 1)
+}
+#[bench]
+fn memmove_rust_4096_misalign(b: &mut Bencher) {
+    memmove_rust(b, 4096, 1)
+}
+#[bench]
+fn memmove_builtin_1048576_misalign(b: &mut Bencher) {
+    memmove_builtin(b, 1048576, 1)
+}
+#[bench]
+fn memmove_rust_1048576_misalign(b: &mut Bencher) {
+    memmove_rust(b, 1048576, 1)
 }


### PR DESCRIPTION
Partially addresses #339. (memcmp is not implemented in this PR)

This PR modifies the current simple implementation of memcpy, memmove and memset with a more sophisticated one.
It will first align dest to machine-word boundary using bytewise copy.
If dest and src are co-aligned (i.e. dest and src address are congruent modular machine-word size), it will proceed to use machine-word-wide copy to copy as many bytes as possible. Remaining bytes are copied using bytewise copy.
If dest and src are not co-aligned, misaligned copying is performed by reading two adjacent machine words and assemble them together with logical shifts before writing to dest.

The existing implementation can be pretty fast on platforms with SIMD and vectorization, but falls short for those without. The code in this PR is carefully written so it is fast on those platforms while is still vectorizable.

Here are some performance numbers:

<details>
<summary>Rust Builtin</summary>

```
test memcpy_builtin_1048576        ... bench:      33,388 ns/iter (+/- 2,619) = 31405 MB/s
test memcpy_builtin_1048576_offset ... bench:      33,988 ns/iter (+/- 2,371) = 30851 MB/s
test memcpy_builtin_4096           ... bench:          37 ns/iter (+/- 2) = 110702 MB/s
test memcpy_builtin_4096_offset    ... bench:          37 ns/iter (+/- 1) = 110702 MB/s
test memmove_builtin_1048576       ... bench:      28,862 ns/iter (+/- 1,013) = 36330 MB/s
test memmove_builtin_4096          ... bench:          38 ns/iter (+/- 1) = 107789 MB/s
test memset_builtin_1048576        ... bench:      21,171 ns/iter (+/- 1,369) = 49528 MB/s
test memset_builtin_1048576_offset ... bench:      21,516 ns/iter (+/- 906) = 48734 MB/s
test memset_builtin_4096           ... bench:          62 ns/iter (+/- 0) = 66064 MB/s
test memset_builtin_4096_offset    ... bench:          68 ns/iter (+/- 2) = 60235 MB/s
```

</details>

<details>
<summary>New Implementation</summary>

```
test memcpy_rust_1048576           ... bench:      40,900 ns/iter (+/- 2,602) = 25637 MB/s
test memcpy_rust_1048576_offset    ... bench:      46,575 ns/iter (+/- 2,994) = 22513 MB/s
test memcpy_rust_4096              ... bench:          76 ns/iter (+/- 4) = 53894 MB/s
test memcpy_rust_4096_offset       ... bench:          95 ns/iter (+/- 3) = 43115 MB/s
test memmove_rust_1048576          ... bench:      50,363 ns/iter (+/- 2,829) = 20820 MB/s
test memmove_rust_4096             ... bench:         176 ns/iter (+/- 6) = 23272 MB/s
test memset_rust_1048576           ... bench:      27,171 ns/iter (+/- 1,168) = 38591 MB/s
test memset_rust_1048576_offset    ... bench:      36,623 ns/iter (+/- 1,418) = 28631 MB/s
test memset_rust_4096              ... bench:          74 ns/iter (+/- 5) = 55351 MB/s
test memset_rust_4096_offset       ... bench:          95 ns/iter (+/- 2) = 43115 MB/s
```

</details>

<details>
<summary>Old Implementation</summary>

```
test memcpy_rust_1048576           ... bench:      43,626 ns/iter (+/- 5,963) = 24035 MB/s
test memcpy_rust_1048576_offset    ... bench:      47,138 ns/iter (+/- 4,029) = 22244 MB/s
test memcpy_rust_4096              ... bench:          73 ns/iter (+/- 3) = 56109 MB/s
test memcpy_rust_4096_offset       ... bench:          90 ns/iter (+/- 3) = 45511 MB/s
test memmove_rust_1048576          ... bench:     305,743 ns/iter (+/- 12,242) = 3429 MB/s
test memmove_rust_4096             ... bench:       1,071 ns/iter (+/- 60) = 3824 MB/s
test memset_rust_1048576           ... bench:      28,485 ns/iter (+/- 2,085) = 36811 MB/s
test memset_rust_1048576_offset    ... bench:      36,999 ns/iter (+/- 316) = 28340 MB/s
test memset_rust_4096              ... bench:          69 ns/iter (+/- 0) = 59362 MB/s
test memset_rust_4096_offset       ... bench:          90 ns/iter (+/- 9) = 45511 MB/s
```

</details>

<details>
<summary>New, with no-vectorize-loops</summary>

```
test memcpy_rust_1048576           ... bench:      70,713 ns/iter (+/- 24,368) = 14828 MB/s
test memcpy_rust_1048576_offset    ... bench:      68,340 ns/iter (+/- 5,622) = 15343 MB/s
test memcpy_rust_4096              ... bench:         272 ns/iter (+/- 15) = 15058 MB/s
test memcpy_rust_4096_offset       ... bench:         279 ns/iter (+/- 7) = 14681 MB/s
test memmove_rust_1048576          ... bench:      68,726 ns/iter (+/- 3,034) = 15257 MB/s
test memmove_rust_4096             ... bench:         275 ns/iter (+/- 10) = 14894 MB/s
test memset_rust_1048576           ... bench:      42,382 ns/iter (+/- 1,542) = 24741 MB/s
test memset_rust_1048576_offset    ... bench:      42,585 ns/iter (+/- 1,722) = 24623 MB/s
test memset_rust_4096              ... bench:         145 ns/iter (+/- 5) = 28248 MB/s
test memset_rust_4096_offset       ... bench:         146 ns/iter (+/- 7) = 28054 MB/s
```

</details>

<details>
<summary>Old, with no-vectorize-loops</summary>

```
test memcpy_rust_1048576           ... bench:     306,552 ns/iter (+/- 19,395) = 3420 MB/s
test memcpy_rust_1048576_offset    ... bench:     311,564 ns/iter (+/- 14,247) = 3365 MB/s
test memcpy_rust_4096              ... bench:       1,076 ns/iter (+/- 63) = 3806 MB/s
test memcpy_rust_4096_offset       ... bench:       1,074 ns/iter (+/- 30) = 3813 MB/s
test memmove_rust_1048576          ... bench:     315,208 ns/iter (+/- 158,448) = 3326 MB/s
test memmove_rust_4096             ... bench:       1,077 ns/iter (+/- 33) = 3803 MB/s
test memset_rust_1048576           ... bench:     303,456 ns/iter (+/- 7,937) = 3455 MB/s
test memset_rust_1048576_offset    ... bench:     304,886 ns/iter (+/- 21,495) = 3439 MB/s
test memset_rust_4096              ... bench:       1,070 ns/iter (+/- 30) = 3828 MB/s
test memset_rust_4096_offset       ... bench:       1,064 ns/iter (+/- 99) = 3849 MB/s
```

</details>

All above numbers are tested on my Coffee Lake laptop, with no-asm feature on.

The number shows that if vectorization is enabled or supported on the platform, then memcpy and memset performance of the old and the new implementation are similar (while much faster on memmove, it seems the compiler had a hard time vectorizing backward copy). If there is no vectorization or the platform does not supported misaligned access, the new implementation will have very significant performance gain (>4x with the number above, and on in-order scaler cores you'd expect 3~8x improvement depending on whether access is aligned and the width of usize).

I inspected the code generated assembly for RISC-V and it seems pretty close in quality to my hand optimsied assembly.