### PR TITLE
Remove unused __rust_* shift intrinsics

### DIFF
--- a/src/int/shift.rs
+++ b/src/int/shift.rs
@@ -113,20 +113,4 @@ intrinsics! {
     pub extern "C" fn __lshrti3(a: u128, b: u32) -> u128 {
         a.lshr(b)
     }
-
-    pub extern "C" fn __rust_i128_shlo(a: i128, b: u128) -> (i128, bool) {
-        (__ashlti3(a as _, b as _) as _, b >= 128)
-    }
-
-    pub extern "C" fn __rust_u128_shlo(a: u128, b: u128) -> (u128, bool) {
-        (__ashlti3(a, b as _), b >= 128)
-    }
-
-    pub extern "C" fn __rust_i128_shro(a: i128, b: u128) -> (i128, bool) {
-        (__ashrti3(a, b as _), b >= 128)
-    }
-
-    pub extern "C" fn __rust_u128_shro(a: u128, b: u128) -> (u128, bool) {
-        (__lshrti3(a, b as _), b >= 128)
-    }
 }

--- a/testcrate/tests/shift.rs
+++ b/testcrate/tests/shift.rs
@@ -17,28 +17,11 @@ macro_rules! shift {
     };
 }
 
-macro_rules! overflowing_shift {
-    ($($i:ty, $fn_std:ident, $fn_builtins:ident);*;) => {
-        $(
-            fuzz_shift(|x: $i, s: u32| {
-                let tmp0: $i = x.$fn_std(s);
-                let (tmp1, o1): ($i, bool) = $fn_builtins(x, s.into());
-                if tmp0 != tmp1 || o1 {
-                    panic!(
-                        "{}({}, {}): std: {}, builtins: {}",
-                        stringify!($fn_builtins), x, s, tmp0, tmp1
-                    );
-                }
-            });
-        )*
-    };
-}
-
 #[test]
 fn shift() {
     use compiler_builtins::int::shift::{
         __ashldi3, __ashlsi3, __ashlti3, __ashrdi3, __ashrsi3, __ashrti3, __lshrdi3, __lshrsi3,
-        __lshrti3, __rust_i128_shlo, __rust_i128_shro, __rust_u128_shlo, __rust_u128_shro,
+        __lshrti3,
     };
     shift!(
         u32, wrapping_shl, __ashlsi3;
@@ -50,11 +33,5 @@ fn shift() {
         u32, wrapping_shr, __lshrsi3;
         u64, wrapping_shr, __lshrdi3;
         u128, wrapping_shr, __lshrti3;
-    );
-    overflowing_shift!(
-        u128, wrapping_shl, __rust_u128_shlo;
-        i128, wrapping_shl, __rust_i128_shlo;
-        u128, wrapping_shr, __rust_u128_shro;
-        i128, wrapping_shr, __rust_i128_shro;
     );
 }


### PR DESCRIPTION
They are rust specific and used by neither cg_llvm nor cg_clif.