### PR TITLE
Add `#[linkage = "weak"]` attribute to all `mem` instrinics.

### DIFF
--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -20,12 +20,14 @@ use core::ops::{BitOr, Shl};
 mod impls;
 
 #[cfg_attr(all(feature = "mem", not(feature = "mangled-names")), no_mangle)]
+#[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), linkage = "weak")]
 pub unsafe extern "C" fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
     impls::copy_forward(dest, src, n);
     dest
 }
 
 #[cfg_attr(all(feature = "mem", not(feature = "mangled-names")), no_mangle)]
+#[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), linkage = "weak")]
 pub unsafe extern "C" fn memmove(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
     let delta = (dest as usize).wrapping_sub(src as usize);
     if delta >= n {
@@ -39,12 +41,14 @@ pub unsafe extern "C" fn memmove(dest: *mut u8, src: *const u8, n: usize) -> *mu
 }
 
 #[cfg_attr(all(feature = "mem", not(feature = "mangled-names")), no_mangle)]
+#[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), linkage = "weak")]
 pub unsafe extern "C" fn memset(s: *mut u8, c: c_int, n: usize) -> *mut u8 {
     impls::set_bytes(s, c as u8, n);
     s
 }
 
 #[cfg_attr(all(feature = "mem", not(feature = "mangled-names")), no_mangle)]
+#[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), linkage = "weak")]
 pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
     let mut i = 0;
     while i < n {
@@ -59,6 +63,7 @@ pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
 }
 
 #[cfg_attr(all(feature = "mem", not(feature = "mangled-names")), no_mangle)]
+#[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), linkage = "weak")]
 pub unsafe extern "C" fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
     memcmp(s1, s2, n)
 }


### PR DESCRIPTION
Following on from https://github.com/rust-lang/compiler-builtins/pull/379, in particular this comment https://github.com/rust-lang/compiler-builtins/pull/379#issuecomment-812807350. 

The rational for such a change is to provide a simple way to override the builtin memcpy routines, in particular `no_std` targets because the `mem` feature of `compiler-builtins` is always enabled for those targets and cannot be disabled.

