### PR TITLE
Suppress some warnings

### DIFF
--- a/src/arm.rs
+++ b/src/arm.rs
@@ -1,4 +1,5 @@
 #![cfg(not(feature = "no-asm"))]
+#![allow(unused_imports)]
 
 use core::intrinsics;
 

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -69,6 +69,7 @@ pub unsafe extern "C" fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
 }
 
 // `bytes` must be a multiple of `mem::size_of::<T>()`
+#[cfg_attr(not(target_has_atomic_load_store = "8"), allow(dead_code))]
 fn memcpy_element_unordered_atomic<T: Copy>(dest: *mut T, src: *const T, bytes: usize) {
     unsafe {
         let n = exact_div(bytes, mem::size_of::<T>());
@@ -81,6 +82,7 @@ fn memcpy_element_unordered_atomic<T: Copy>(dest: *mut T, src: *const T, bytes: 
 }
 
 // `bytes` must be a multiple of `mem::size_of::<T>()`
+#[cfg_attr(not(target_has_atomic_load_store = "8"), allow(dead_code))]
 fn memmove_element_unordered_atomic<T: Copy>(dest: *mut T, src: *const T, bytes: usize) {
     unsafe {
         let n = exact_div(bytes, mem::size_of::<T>());
@@ -103,6 +105,7 @@ fn memmove_element_unordered_atomic<T: Copy>(dest: *mut T, src: *const T, bytes:
 }
 
 // `T` must be a primitive integer type, and `bytes` must be a multiple of `mem::size_of::<T>()`
+#[cfg_attr(not(target_has_atomic_load_store = "8"), allow(dead_code))]
 fn memset_element_unordered_atomic<T>(s: *mut T, c: u8, bytes: usize)
 where
     T: Copy + From<u8> + Shl<u32, Output = T> + BitOr<T, Output = T>,


### PR DESCRIPTION
Found some warnings when checking a libc CI log.

- We use `#![allow(unused_imports)]` for most modules but arm doesn't have.
- `{memcpy,memmove,memset}_element_unordered_atomic` emits a `dead_code` warning when atomic is disabled (e.g. riscv32i-unknown-none-elf)