### PR TITLE
Include Linux atomic emulation on androideabi

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -69,8 +69,11 @@ fn main() {
         println!("cargo:rustc-cfg=thumb_1")
     }
 
-    // Only emit the ARM Linux atomic emulation on pre-ARMv6 architectures.
-    if llvm_target[0] == "armv4t" || llvm_target[0] == "armv5te" {
+    // Only emit the ARM Linux atomic emulation on pre-ARMv6 architectures. This
+    // includes the old androideabi. It is deprecated but it is available as a
+    // rustc target (arm-linux-androideabi).
+    if llvm_target[0] == "armv4t" || llvm_target[0] == "armv5te" || llvm_target[2] == "androideabi"
+    {
         println!("cargo:rustc-cfg=kernel_user_helpers")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,11 @@ pub mod mem;
 #[cfg(target_arch = "arm")]
 pub mod arm;
 
-#[cfg(all(kernel_user_helpers, target_os = "linux", target_arch = "arm"))]
+#[cfg(all(
+    kernel_user_helpers,
+    any(target_os = "linux", target_os = "android"),
+    target_arch = "arm"
+))]
 pub mod arm_linux;
 
 #[cfg(any(target_arch = "riscv32"))]


### PR DESCRIPTION
The old `androideabi` uses `armv5` and thus also needs the atomic emulation and because Android is basically Linux it can use the same implementation.

This has been verified by taking a old `libgcc` from a ndk toolchain to a dissassembler:
<details><summary><code>__sync_fetch_and_add_4</code> as an example</summary>
<p>

```
00000000 <__sync_fetch_and_add_4>:
       0: f8 40 2d e9  	push	{r3, r4, r5, r6, r7, lr}
       4: 28 60 9f e5  	ldr	r6, [pc, #40]
       8: 00 50 a0 e1  	mov	r5, r0
       c: 01 70 a0 e1  	mov	r7, r1
      10: 00 40 95 e5  	ldr	r4, [r5]
      14: 05 20 a0 e1  	mov	r2, r5
      18: 04 00 a0 e1  	mov	r0, r4
      1c: 07 10 84 e0  	add	r1, r4, r7
      20: 36 ff 2f e1  	blx	r6
      24: 00 00 50 e3  	cmp	r0, #0
      28: f8 ff ff 1a  	bne	#-32 <__sync_fetch_and_add_4+0x10>
      2c: 04 00 a0 e1  	mov	r0, r4
      30: f8 80 bd e8  	pop	{r3, r4, r5, r6, r7, pc}

00000034 <$d>:
      34:	c0 0f ff ff	.word	0xffff0fc0
```

`0xffff0fc0` being the address of the kuser function `kuser_cmpxchg`.

</p>
</details>

Reason for this change: https://github.com/rust-lang/rust/pull/85806#issuecomment-851030534