### PR TITLE
Update libm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Jorge Aparicio <japaricious@gmail.com>"]
 name = "compiler_builtins"
-version = "0.1.45"
+version = "0.1.46"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-lang/compiler-builtins"


### PR DESCRIPTION
Update libm to the latest master to include the fix for https://github.com/rust-lang/libm/issues/242