### PR TITLE
Add xtensa to list of soft math targets.

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -21,6 +21,7 @@ macro_rules! no_mangle {
         not(target_env = "wasi")
     ),
     all(target_arch = "x86_64", target_os = "uefi"),
+    all(target_arch = "xtensa", target_os = "none"),
     all(target_vendor = "fortanix", target_env = "sgx")
 ))]
 no_mangle! {
@@ -69,6 +70,7 @@ no_mangle! {
         target_os = "unknown",
         not(target_env = "wasi")
     ),
+    all(target_arch = "xtensa", target_os = "none"),
     all(target_vendor = "fortanix", target_env = "sgx")
 ))]
 no_mangle! {


### PR DESCRIPTION
I am right in thinking these software impls only get used if there isn't hardware accelerated support for the current target? I.e some xtensa chips will be able to accelerate `fma` for example, adding this change wouldn't stop that from happening on chips that support those hardware instructions,  right?