### PR TITLE
Disable broken powerpc64 test

### DIFF
--- a/testcrate/tests/cmp.rs
+++ b/testcrate/tests/cmp.rs
@@ -22,6 +22,8 @@ macro_rules! cmp {
     };
 }
 
+// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
+#[cfg(not(target_arch = "powerpc64"))]
 #[test]
 fn float_comparisons() {
     use compiler_builtins::float::cmp::{

--- a/testcrate/tests/conv.rs
+++ b/testcrate/tests/conv.rs
@@ -95,6 +95,8 @@ macro_rules! f_to_i {
     };
 }
 
+// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
+#[cfg(not(target_arch = "powerpc64"))]
 #[test]
 fn float_to_int() {
     use compiler_builtins::float::conv::{

--- a/testcrate/tests/misc.rs
+++ b/testcrate/tests/misc.rs
@@ -111,6 +111,8 @@ macro_rules! extend {
     };
 }
 
+// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
+#[cfg(not(target_arch = "powerpc64"))]
 #[test]
 fn float_extend() {
     use compiler_builtins::float::extend::__extendsfdf2;


### PR DESCRIPTION
Seems to be a bug in LLVM 13, tracked in https://github.com/rust-lang/rust/issues/88520.