### PR TITLE
Turn on the mem-unaligned feature for bpf targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -34,7 +34,11 @@ fn main() {
     }
 
     // These targets have hardware unaligned access support.
-    if target.contains("x86_64") || target.contains("i686") || target.contains("aarch64") {
+    if target.contains("x86_64")
+        || target.contains("i686")
+        || target.contains("aarch64")
+        || target.contains("bpf")
+    {
         println!("cargo:rustc-cfg=feature=\"mem-unaligned\"");
     }
 


### PR DESCRIPTION
LLVM started segfaulting with bpf-linker and rustc nightly since rustc bumped compiler-builtins in https://github.com/rust-lang/rust/commit/88f1bf73ee8466d07b1e38755de53a70fc292e20 (see https://github.com/aya-rs/bpf-linker/runs/4276632485?check_suite_focus=true). 

This is the LLVM error:
```
Error: e: 05:02:06 [ERROR] fatal error: "Cannot select: 0x55e970a357d0: i64,ch = AtomicLoad<(load unordered (s64) from %ir.45)> 0x55e970410be8, 0x55e970a358a0\n  0x55e970a358a0: i64,ch = CopyFromReg 0x55e970410be8, Register:i64 %19\n    0x55e970a35490: i64 = Register %19\nIn function: memcpy"
          PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace.
          Stack dump:
          0.	Running pass 'Function Pass Manager' on module 'unroll-loop'.
          1.	Running pass 'BPF DAG->DAG Pattern Instruction Selection' on function '@memcpy'
```

Without `mem-unaligned` the mem functions emit atomic loads which aren't supported by the BPF target in LLVM.