### PR TITLE
Do not use atomic reads on platforms without atomic support in LLVM. Fixes #441.

### DIFF
--- a/src/float/pow.rs
+++ b/src/float/pow.rs
@@ -5,7 +5,7 @@ use int::Int;
 fn pow<F: Float>(a: F, b: i32) -> F {
     let mut a = a;
     let recip = b < 0;
-    let mut pow = i32::abs_diff(b, 0);
+    let mut pow = Int::abs_diff(b, 0);
     let mut mul = F::ONE;
     loop {
         if (pow & 1) != 0 {


### PR DESCRIPTION
I still would like to test this patch against my own code, and I've asked for [clarification](https://github.com/rust-lang/wg-cargo-std-aware/issues/77) on how to do that. However, I _have_ confirmed this fix works locally by building `libcore`. The command used to build in both cases was:

```
RUSTFLAGS="-C opt-level=s" RUSTC_WRAPPER=/home/william/.cargo/bin/sccache LD_LIBRARY_PATH=/home/william/Projects/toolchains/build-llvm-toolchain/build-llvm/lib/ /home/william/Projects/toolchains/rust/x.py build --config config.toml --target msp430-none-elf --stage 1 library/test
```

# Before Patch

```
Building stage1 std artifacts (x86_64-unknown-linux-gnu -> msp430-none-elf)
   Compiling compiler_builtins v0.1.52
   Compiling core v0.0.0 (/home/william/Projects/toolchains/rust/library/core)
   Compiling rustc-std-workspace-core v1.99.0 (/home/william/Projects/toolchains/rust/library/rustc-std-workspace-core)
LLVM ERROR: Cannot select: t3: i16,ch = AtomicLoad<(load unordered (s16) from %ir.49)> t0, t2
  t2: i16,ch = CopyFromReg t0, Register:i16 %19
    t1: i16 = Register %19
   Compiling alloc v0.0.0 (/home/william/Projects/toolchains/rust/library/alloc)
In function: memcpy
error: could not compile `compiler_builtins`
warning: build failed, waiting for other jobs to finish...
error: build failed
Build completed unsuccessfully in 0:06:01
```

# After Patch

The patch points to my local `compiler_builtins` with this PR's Commits:

```diff
diff --git a/Cargo.lock b/Cargo.lock
index 51ed441d0db..b7afe6d8c87 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,9 +678,7 @@ dependencies = [

 [[package]]
 name = "compiler_builtins"
-version = "0.1.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6591c2442ee984e2b264638a8b5e7ae44fd47b32d28e3a08e2e9c3cdb0c2fb0"
+version = "0.1.53"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",
diff --git a/Cargo.toml b/Cargo.toml
index cae48d79517..34a16c26fcc 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,5 +131,7 @@ rustc-std-workspace-core = { path = 'library/rustc-std-workspace-core' }
 rustc-std-workspace-alloc = { path = 'library/rustc-std-workspace-alloc' }
 rustc-std-workspace-std = { path = 'library/rustc-std-workspace-std' }

+compiler_builtins = { path = "../compiler-builtins" }
+
 [patch."https://github.com/rust-lang/rust-clippy"]
 clippy_lints = { path = "src/tools/clippy/clippy_lints" }
diff --git a/library/backtrace b/library/backtrace
--- a/library/backtrace
+++ b/library/backtrace
@@ -1 +1 @@
-Subproject commit b02ed04a7e915659eea6fb1607df469b84a30638
+Subproject commit b02ed04a7e915659eea6fb1607df469b84a30638-dirty
```

```
Building stage1 std artifacts (x86_64-unknown-linux-gnu -> msp430-none-elf)
   Compiling compiler_builtins v0.1.53 (/home/william/Projects/toolchains/compiler-builtins)
   Compiling core v0.0.0 (/home/william/Projects/toolchains/rust/library/core)
   Compiling rustc-std-workspace-core v1.99.0 (/home/william/Projects/toolchains/rust/library/rustc-std-workspace-core)
   Compiling alloc v0.0.0 (/home/william/Projects/toolchains/rust/library/alloc)
    Finished release [optimized] target(s) in 3.30s
Copying stage1 std from stage1 (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-gnu / msp430-none-elf)
Build completed successfully in 0:01:08
```

I would like to test this against my own code, but this is probably "good enough" for merging if you don't want/need any further changes.