### PR TITLE
Import the asm! macro from core::arch

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -560,7 +560,8 @@ mod c {
                         file,
                         "#include \"{}\"",
                         outlined_atomics_file.canonicalize().unwrap().display()
-                    );
+                    )
+                    .unwrap();
                     drop(file);
                     cfg.file(path);
 

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -11,7 +11,7 @@ use core::intrinsics;
 #[naked]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe extern "C" fn __aeabi_uidivmod() {
-    asm!(
+    core::arch::asm!(
         "push {{lr}}",
         "sub sp, sp, #4",
         "mov r2, sp",
@@ -27,7 +27,7 @@ pub unsafe extern "C" fn __aeabi_uidivmod() {
 #[naked]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe extern "C" fn __aeabi_uidivmod() {
-    asm!(
+    core::arch::asm!(
         "push {{lr}}",
         "sub sp, sp, #4",
         "mov r2, sp",
@@ -43,7 +43,7 @@ pub unsafe extern "C" fn __aeabi_uidivmod() {
 #[naked]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe extern "C" fn __aeabi_uldivmod() {
-    asm!(
+    core::arch::asm!(
         "push {{r4, lr}}",
         "sub sp, sp, #16",
         "add r4, sp, #8",
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn __aeabi_uldivmod() {
 #[naked]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe extern "C" fn __aeabi_uldivmod() {
-    asm!(
+    core::arch::asm!(
         "push {{r4, lr}}",
         "sub sp, sp, #16",
         "add r4, sp, #8",
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn __aeabi_uldivmod() {
 #[naked]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe extern "C" fn __aeabi_idivmod() {
-    asm!(
+    core::arch::asm!(
         "push {{r0, r1, r4, lr}}",
         "bl __aeabi_idiv",
         "pop {{r1, r2}}",
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn __aeabi_idivmod() {
 #[naked]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe extern "C" fn __aeabi_idivmod() {
-    asm!(
+    core::arch::asm!(
         "push {{r0, r1, r4, lr}}",
         "bl ___aeabi_idiv",
         "pop {{r1, r2}}",
@@ -109,7 +109,7 @@ pub unsafe extern "C" fn __aeabi_idivmod() {
 #[naked]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe extern "C" fn __aeabi_ldivmod() {
-    asm!(
+    core::arch::asm!(
         "push {{r4, lr}}",
         "sub sp, sp, #16",
         "add r4, sp, #8",
@@ -127,7 +127,7 @@ pub unsafe extern "C" fn __aeabi_ldivmod() {
 #[naked]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe extern "C" fn __aeabi_ldivmod() {
-    asm!(
+    core::arch::asm!(
         "push {{r4, lr}}",
         "sub sp, sp, #16",
         "add r4, sp, #8",

--- a/src/float/div.rs
+++ b/src/float/div.rs
@@ -132,8 +132,9 @@ where
     // This doubles the number of correct binary digits in the approximation
     // with each iteration, so after three iterations, we have about 28 binary
     // digits of accuracy.
-    let mut correction: u32;
-    correction = negate_u32(((reciprocal as u64).wrapping_mul(q31b as u64) >> 32) as u32);
+
+    let mut correction: u32 =
+        negate_u32(((reciprocal as u64).wrapping_mul(q31b as u64) >> 32) as u32);
     reciprocal = ((reciprocal as u64).wrapping_mul(correction as u64) as u64 >> 31) as u32;
     correction = negate_u32(((reciprocal as u64).wrapping_mul(q31b as u64) >> 32) as u32);
     reciprocal = ((reciprocal as u64).wrapping_mul(correction as u64) as u64 >> 31) as u32;
@@ -342,8 +343,9 @@ where
     // This doubles the number of correct binary digits in the approximation
     // with each iteration, so after three iterations, we have about 28 binary
     // digits of accuracy.
-    let mut correction32: u32;
-    correction32 = negate_u32(((recip32 as u64).wrapping_mul(q31b as u64) >> 32) as u32);
+
+    let mut correction32: u32 =
+        negate_u32(((recip32 as u64).wrapping_mul(q31b as u64) >> 32) as u32);
     recip32 = ((recip32 as u64).wrapping_mul(correction32 as u64) >> 31) as u32;
     correction32 = negate_u32(((recip32 as u64).wrapping_mul(q31b as u64) >> 32) as u32);
     recip32 = ((recip32 as u64).wrapping_mul(correction32 as u64) >> 31) as u32;
@@ -359,16 +361,15 @@ where
     // We need to perform one more iteration to get us to 56 binary digits;
     // The last iteration needs to happen with extra precision.
     let q63blo = CastInto::<u32>::cast(b_significand << 11.cast());
-    let correction: u64;
-    let mut reciprocal: u64;
-    correction = negate_u64(
+
+    let correction: u64 = negate_u64(
         (recip32 as u64)
             .wrapping_mul(q31b as u64)
             .wrapping_add((recip32 as u64).wrapping_mul(q63blo as u64) >> 32),
     );
     let c_hi = (correction >> 32) as u32;
     let c_lo = correction as u32;
-    reciprocal = (recip32 as u64)
+    let mut reciprocal: u64 = (recip32 as u64)
         .wrapping_mul(c_hi as u64)
         .wrapping_add((recip32 as u64).wrapping_mul(c_lo as u64) >> 32);
 

--- a/src/int/leading_zeros.rs
+++ b/src/int/leading_zeros.rs
@@ -5,6 +5,7 @@
 
 public_test_dep! {
 /// Returns the number of leading binary zeros in `x`.
+#[allow(dead_code)]
 pub(crate) fn usize_leading_zeros_default(x: usize) -> usize {
     // The basic idea is to test if the higher bits of `x` are zero and bisect the number
     // of leading zeros. It is possible for all branches of the bisection to use the same
@@ -78,6 +79,7 @@ pub(crate) fn usize_leading_zeros_default(x: usize) -> usize {
 
 public_test_dep! {
 /// Returns the number of leading binary zeros in `x`.
+#[allow(dead_code)]
 pub(crate) fn usize_leading_zeros_riscv(x: usize) -> usize {
     let mut x = x;
     // the number of potential leading zeros

--- a/src/int/specialized_div_rem/mod.rs
+++ b/src/int/specialized_div_rem/mod.rs
@@ -184,7 +184,7 @@ unsafe fn u128_by_u64_div_rem(duo: u128, div: u64) -> (u64, u64) {
         // divides the combined registers rdx:rax (`duo` is split into two 64 bit parts to do this)
         // by `div`. The quotient is stored in rax and the remainder in rdx.
         // FIXME: Use the Intel syntax once we drop LLVM 9 support on rust-lang/rust.
-        asm!(
+        core::arch::asm!(
             "div {0}",
             in(reg) div,
             inlateout("rax") duo_lo => quo,
@@ -271,7 +271,7 @@ unsafe fn u64_by_u32_div_rem(duo: u64, div: u32) -> (u32, u32) {
         // divides the combined registers rdx:rax (`duo` is split into two 32 bit parts to do this)
         // by `div`. The quotient is stored in rax and the remainder in rdx.
         // FIXME: Use the Intel syntax once we drop LLVM 9 support on rust-lang/rust.
-        asm!(
+        core::arch::asm!(
             "div {0}",
             in(reg) div,
             inlateout("rax") duo_lo => quo,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@
 #![allow(improper_ctypes, improper_ctypes_definitions)]
 // `mem::swap` cannot be used because it may generate references to memcpy in unoptimized code.
 #![allow(clippy::manual_swap)]
+// Support compiling on both stage0 and stage1 which may differ in supported stable features.
+#![allow(stable_features)]
 
 // We disable #[no_mangle] for tests so that we can verify the test results
 // against the native compiler-rt implementations of the builtins.

--- a/src/mem/x86_64.rs
+++ b/src/mem/x86_64.rs
@@ -20,7 +20,7 @@
 #[cfg(target_feature = "ermsb")]
 pub unsafe fn copy_forward(dest: *mut u8, src: *const u8, count: usize) {
     // FIXME: Use the Intel syntax once we drop LLVM 9 support on rust-lang/rust.
-    asm!(
+    core::arch::asm!(
         "repe movsb (%rsi), (%rdi)",
         inout("rcx") count => _,
         inout("rdi") dest => _,
@@ -35,7 +35,7 @@ pub unsafe fn copy_forward(dest: *mut u8, src: *const u8, count: usize) {
     let qword_count = count >> 3;
     let byte_count = count & 0b111;
     // FIXME: Use the Intel syntax once we drop LLVM 9 support on rust-lang/rust.
-    asm!(
+    core::arch::asm!(
         "repe movsq (%rsi), (%rdi)",
         "mov {byte_count:e}, %ecx",
         "repe movsb (%rsi), (%rdi)",
@@ -52,7 +52,7 @@ pub unsafe fn copy_backward(dest: *mut u8, src: *const u8, count: usize) {
     let qword_count = count >> 3;
     let byte_count = count & 0b111;
     // FIXME: Use the Intel syntax once we drop LLVM 9 support on rust-lang/rust.
-    asm!(
+    core::arch::asm!(
         "std",
         "repe movsq (%rsi), (%rdi)",
         "movl {byte_count:e}, %ecx",
@@ -72,7 +72,7 @@ pub unsafe fn copy_backward(dest: *mut u8, src: *const u8, count: usize) {
 #[cfg(target_feature = "ermsb")]
 pub unsafe fn set_bytes(dest: *mut u8, c: u8, count: usize) {
     // FIXME: Use the Intel syntax once we drop LLVM 9 support on rust-lang/rust.
-    asm!(
+    core::arch::asm!(
         "repe stosb %al, (%rdi)",
         inout("rcx") count => _,
         inout("rdi") dest => _,
@@ -87,7 +87,7 @@ pub unsafe fn set_bytes(dest: *mut u8, c: u8, count: usize) {
     let qword_count = count >> 3;
     let byte_count = count & 0b111;
     // FIXME: Use the Intel syntax once we drop LLVM 9 support on rust-lang/rust.
-    asm!(
+    core::arch::asm!(
         "repe stosq %rax, (%rdi)",
         "mov {byte_count:e}, %ecx",
         "repe stosb %al, (%rdi)",

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -17,7 +17,7 @@ use core::intrinsics;
 #[naked]
 #[no_mangle]
 pub unsafe extern "C" fn ___chkstk_ms() {
-    asm!(
+    core::arch::asm!(
         "push   %ecx",
         "push   %eax",
         "cmp    $0x1000,%eax",
@@ -49,7 +49,7 @@ pub unsafe extern "C" fn ___chkstk_ms() {
 #[naked]
 #[no_mangle]
 pub unsafe extern "C" fn __alloca() {
-    asm!(
+    core::arch::asm!(
         "jmp ___chkstk", // Jump to ___chkstk since fallthrough may be unreliable"
         options(noreturn, att_syntax)
     );
@@ -64,7 +64,7 @@ pub unsafe extern "C" fn __alloca() {
 #[naked]
 #[no_mangle]
 pub unsafe extern "C" fn ___chkstk() {
-    asm!(
+    core::arch::asm!(
         "push   %ecx",
         "cmp    $0x1000,%eax",
         "lea    8(%esp),%ecx", // esp before calling this routine -> ecx

--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -17,7 +17,7 @@ use core::intrinsics;
 #[naked]
 #[no_mangle]
 pub unsafe extern "C" fn ___chkstk_ms() {
-    asm!(
+    core::arch::asm!(
         "push   %rcx",
         "push   %rax",
         "cmp    $0x1000,%rax",
@@ -48,7 +48,7 @@ pub unsafe extern "C" fn ___chkstk_ms() {
 #[naked]
 #[no_mangle]
 pub unsafe extern "C" fn __alloca() {
-    asm!(
+    core::arch::asm!(
         "mov    %rcx,%rax", // x64 _alloca is a normal function with parameter in rcx
         "jmp    ___chkstk", // Jump to ___chkstk since fallthrough may be unreliable"
         options(noreturn, att_syntax)
@@ -64,7 +64,7 @@ pub unsafe extern "C" fn __alloca() {
 #[naked]
 #[no_mangle]
 pub unsafe extern "C" fn ___chkstk() {
-    asm!(
+    core::arch::asm!(
         "push   %rcx",
         "cmp    $0x1000,%rax",
         "lea    16(%rsp),%rcx", // rsp before calling this routine -> rcx


### PR DESCRIPTION
It is going to be removed from the prelude due to the decision in
https://github.com/rust-lang/rust/issues/87228