### PR TITLE
Stop emitting duplicate symbols for `armv7-linux-androideabi`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -83,7 +83,7 @@ fn main() {
     // rustc target (arm-linux-androideabi).
     if llvm_target[0] == "armv4t"
         || llvm_target[0] == "armv5te"
-        || llvm_target.get(2) == Some(&"androideabi")
+        || target == "arm-linux-androideabi"
     {
         println!("cargo:rustc-cfg=kernel_user_helpers")
     }


### PR DESCRIPTION
The change in 186517b3266a7bb2b2310927f7342ea7f41790c3 was intended to
affect only `arm-linux-androideabi` but also affected
`armv7-linux-androideabi` which is not a pre-ARMv6 architecture.
Fixes #449