### PR TITLE
Provide an implementation of `strlen` to be used as a fallback

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(not(feature = "no-asm"), feature(global_asm))]
 #![feature(cfg_target_has_atomic)]
 #![feature(compiler_builtins)]
+#![feature(core_ffi_c)]
 #![feature(core_intrinsics)]
 #![feature(lang_items)]
 #![feature(linkage)]

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -68,6 +68,18 @@ intrinsics! {
     pub unsafe extern "C" fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
         memcmp(s1, s2, n)
     }
+
+    #[mem_builtin]
+    #[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), linkage = "weak")]
+    pub unsafe extern "C" fn strlen(s: *const core::ffi::c_char) -> usize {
+        let mut n = 0;
+        let mut s = s;
+        while *s != 0 {
+            n += 1;
+            s = s.offset(1);
+        }
+        n
+    }
 }
 
 // `bytes` must be a multiple of `mem::size_of::<T>()`


### PR DESCRIPTION
As suggested in https://github.com/rust-lang/rust/pull/94079#issuecomment-1044688919.