### PR TITLE
Remove apple_versioning.c inclusion

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -193,7 +193,6 @@ mod c {
             ("__absvsi2", "absvsi2.c"),
             ("__addvdi3", "addvdi3.c"),
             ("__addvsi3", "addvsi3.c"),
-            ("apple_versioning", "apple_versioning.c"),
             ("__clzdi2", "clzdi2.c"),
             ("__clzsi2", "clzsi2.c"),
             ("__cmpdi2", "cmpdi2.c"),


### PR DESCRIPTION
According to the README this file isn't used by rust, but it's currently
included which leads to these linker warnings in some cases:

```
ld: warning: linker symbol '$ld$hide$os10.5$___udivti3' hides a non-existent symbol '___udivti3'
ld: warning: linker symbol '$ld$hide$os10.4$___umoddi3' hides a non-existent symbol '___umoddi3'
ld: warning: linker symbol '$ld$hide$os10.5$___umoddi3' hides a non-existent symbol '___umoddi3'
ld: warning: linker symbol '$ld$hide$os10.4$___umodti3' hides a non-existent symbol '___umodti3'
ld: warning: linker symbol '$ld$hide$os10.5$___umodti3' hides a non-existent symbol '___umodti3'
```

This file exclusively contains macros which hides old symbols on Apple
OS versions where they don't exist.

https://github.com/rust-lang/llvm-project/blob/fc10370ef7d91babf512c10505f8f2176bc8519d/compiler-rt/lib/builtins/apple_versioning.c