### PR TITLE
rv64 implement muldi3 intrinsic

### DIFF
--- a/src/int/mul.rs
+++ b/src/int/mul.rs
@@ -100,6 +100,7 @@ impl_signed_mulo!(i128_overflowing_mul, i128, u128);
 intrinsics! {
     #[maybe_use_optimized_c_shim]
     #[arm_aeabi_alias = __aeabi_lmul]
+    #[cfg(not(target_arch = "riscv64"))]
     pub extern "C" fn __muldi3(a: u64, b: u64) -> u64 {
         a.mul(b)
     }

--- a/src/int/mul.rs
+++ b/src/int/mul.rs
@@ -100,7 +100,7 @@ impl_signed_mulo!(i128_overflowing_mul, i128, u128);
 intrinsics! {
     #[maybe_use_optimized_c_shim]
     #[arm_aeabi_alias = __aeabi_lmul]
-    #[cfg(not(target_arch = "riscv64"))]
+    #[cfg(any(not(any(target_arch = "riscv32", target_arch = "riscv64")), target_feature = "m"))]
     pub extern "C" fn __muldi3(a: u64, b: u64) -> u64 {
         a.mul(b)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,8 @@ pub mod arm;
 ))]
 pub mod arm_linux;
 
-#[cfg(any(target_arch = "riscv32"))]
-pub mod riscv32;
+#[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+pub mod riscv;
 
 #[cfg(target_arch = "x86")]
 pub mod x86;

--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -1,7 +1,6 @@
 intrinsics! {
     // Implementation from gcc
     // https://raw.githubusercontent.com/gcc-mirror/gcc/master/libgcc/config/epiphany/mulsi3.c
-    #[cfg(target_arch = "riscv32")]
     pub extern "C" fn __mulsi3(a: u32, b: u32) -> u32 {
         let (mut a, mut b) = (a, b);
         let mut r = 0;
@@ -17,7 +16,7 @@ intrinsics! {
         r
     }
 
-    #[cfg(target_arch = "riscv64")]
+    #[cfg(not(target_feature = "m"))]
     pub extern "C" fn __muldi3(a: u64, b: u64) -> u64 {
         let (mut a, mut b) = (a, b);
         let mut r = 0;

--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -1,7 +1,24 @@
 intrinsics! {
     // Implementation from gcc
     // https://raw.githubusercontent.com/gcc-mirror/gcc/master/libgcc/config/epiphany/mulsi3.c
+    #[cfg(target_arch = "riscv32")]
     pub extern "C" fn __mulsi3(a: u32, b: u32) -> u32 {
+        let (mut a, mut b) = (a, b);
+        let mut r = 0;
+
+        while a > 0 {
+            if a & 1 > 0 {
+                r += b;
+            }
+            a >>= 1;
+            b <<= 1;
+        }
+
+        r
+    }
+
+    #[cfg(target_arch = "riscv64")]
+    pub extern "C" fn __muldi3(a: u64, b: u64) -> u64 {
         let (mut a, mut b) = (a, b);
         let mut r = 0;
 


### PR DESCRIPTION
This fixes #459.

Implement the __muldi3 intrinsic to prevent infinite recursion during
multiplication on rv64 without the 'm' extension.