### PR TITLE
Fix division on AVRs

### DIFF
--- a/src/int/sdiv.rs
+++ b/src/int/sdiv.rs
@@ -9,6 +9,7 @@ macro_rules! sdivmod {
         $($attr:tt),* // attributes
     ) => {
         intrinsics! {
+            #[avr_skip]
             $(
                 #[$attr]
             )*
@@ -50,6 +51,7 @@ macro_rules! sdiv {
         $($attr:tt),* // attributes
     ) => {
         intrinsics! {
+            #[avr_skip]
             $(
                 #[$attr]
             )*
@@ -85,6 +87,7 @@ macro_rules! smod {
         $($attr:tt),* // attributes
     ) => {
         intrinsics! {
+            #[avr_skip]
             $(
                 #[$attr]
             )*

--- a/src/int/udiv.rs
+++ b/src/int/udiv.rs
@@ -18,6 +18,7 @@ intrinsics! {
         u32_div_rem(n, d).1
     }
 
+    #[avr_skip]
     #[maybe_use_optimized_c_shim]
     /// Returns `n / d` and sets `*rem = n % d`
     pub extern "C" fn __udivmodsi4(n: u32, d: u32, rem: Option<&mut u32>) -> u32 {
@@ -28,18 +29,21 @@ intrinsics! {
         quo_rem.0
     }
 
+    #[avr_skip]
     #[maybe_use_optimized_c_shim]
     /// Returns `n / d`
     pub extern "C" fn __udivdi3(n: u64, d: u64) -> u64 {
         u64_div_rem(n, d).0
     }
 
+    #[avr_skip]
     #[maybe_use_optimized_c_shim]
     /// Returns `n % d`
     pub extern "C" fn __umoddi3(n: u64, d: u64) -> u64 {
         u64_div_rem(n, d).1
     }
 
+    #[avr_skip]
     #[maybe_use_optimized_c_shim]
     /// Returns `n / d` and sets `*rem = n % d`
     pub extern "C" fn __udivmoddi4(n: u64, d: u64, rem: Option<&mut u64>) -> u64 {
@@ -77,6 +81,7 @@ intrinsics! {
         }
     }
 
+    #[avr_skip]
     #[win64_128bit_abi_hack]
     /// Returns `n / d` and sets `*rem = n % d`
     pub extern "C" fn __udivmodti4(n: u128, d: u128, rem: Option<&mut u128>) -> u128 {


### PR DESCRIPTION
For division and modulo, AVR uses a custom calling convention that does
not match compiler_builtins' expectations, leading to non-working code¹.

Ideally we'd just use hand-written naked functions (as, afair, ARM
does), but that's a lot of code to port², so hopefully we'll be able to
do it gradually later.

For the time being, I'd suggest not compiling problematic functions for
AVR target - this causes avr-gcc (which is a mandatory part of Rust+AVR
toolchain anyway) to link hand-written assembly from libgcc, which is
confirmed to work.

I've tested the code locally on simavr and the patch seems to be working
correctly :-)

¹ https://github.com/rust-lang/rust/issues/82242,
  https://github.com/rust-lang/rust/issues/83281
² https://github.com/gcc-mirror/gcc/blob/31048012db98f5ec9c2ba537bfd850374bdd771f/libgcc/config/avr/lib1funcs.S

Closes https://github.com/rust-lang/rust/issues/82242
Closes https://github.com/rust-lang/rust/issues/83281