### PR TITLE
Add avr_skip for __udivti3 & __umodti3

### DIFF
--- a/src/int/udiv.rs
+++ b/src/int/udiv.rs
@@ -57,6 +57,7 @@ intrinsics! {
     // Note: we use block configuration and not `if cfg!(...)`, because we need to entirely disable
     // the existence of `u128_div_rem` to get 32-bit SPARC to compile, see `u128_divide_sparc` docs.
 
+    #[avr_skip]
     #[win64_128bit_abi_hack]
     /// Returns `n / d`
     pub extern "C" fn __udivti3(n: u128, d: u128) -> u128 {
@@ -68,6 +69,7 @@ intrinsics! {
         }
     }
 
+    #[avr_skip]
     #[win64_128bit_abi_hack]
     /// Returns `n % d`
     pub extern "C" fn __umodti3(n: u128, d: u128) -> u128 {


### PR DESCRIPTION
I've forgotten to guard those two before and they also don't work at the moment (as confirmed by simavr).

A bit unfortunately, libgcc doesn't provide those functions, making i128/u128 division/modulo non-working on AVR (addition, subtraction and multiplication all seem to be working, as confirmed by random testing, so there's that, at least; hopefully no one plans to divide 128 bit numbers on AVRs 😛).