### PR TITLE
Build C code for `xous` operating system

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -58,9 +58,11 @@ fn main() {
         //   unlikely that the C is really that much better than our own Rust.
         // * nvptx - everything is bitcode, not compatible with mixed C/Rust
         // * riscv - the rust-lang/rust distribution container doesn't have a C
-        //   compiler nor is cc-rs ready for compilation to riscv (at this
-        //   time). This can probably be removed in the future
-        if !target.contains("wasm") && !target.contains("nvptx") && !target.starts_with("riscv") {
+        //   compiler.
+        if !target.contains("wasm")
+            && !target.contains("nvptx")
+            && (!target.starts_with("riscv") || target.contains("xous"))
+        {
             #[cfg(feature = "c")]
             c::compile(&llvm_target, &target);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub mod int;
     all(target_family = "wasm", target_os = "unknown"),
     all(target_arch = "x86_64", target_os = "uefi"),
     all(target_arch = "arm", target_os = "none"),
+    target_os = "xous",
     all(target_vendor = "fortanix", target_env = "sgx")
 ))]
 pub mod math;

--- a/src/math.rs
+++ b/src/math.rs
@@ -20,6 +20,7 @@ macro_rules! no_mangle {
         target_os = "unknown",
         not(target_env = "wasi")
     ),
+    target_os = "xous",
     all(target_arch = "x86_64", target_os = "uefi"),
     all(target_arch = "xtensa", target_os = "none"),
     all(target_vendor = "fortanix", target_env = "sgx")
@@ -70,6 +71,7 @@ no_mangle! {
         target_os = "unknown",
         not(target_env = "wasi")
     ),
+    target_os = "xous",
     all(target_arch = "xtensa", target_os = "none"),
     all(target_vendor = "fortanix", target_env = "sgx")
 ))]
@@ -93,7 +95,16 @@ no_mangle! {
     fn tanf(n: f32) -> f32;
 }
 
-#[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]
+#[cfg(target_os = "xous")]
+no_mangle! {
+    fn sqrtf(x: f32) -> f32;
+    fn sqrt(x: f64) -> f64;
+}
+
+#[cfg(any(
+    all(target_vendor = "fortanix", target_env = "sgx"),
+    target_os = "xous"
+))]
 no_mangle! {
     fn ceil(x: f64) -> f64;
     fn ceilf(x: f32) -> f32;


### PR DESCRIPTION
Xous is a new Tier 3 target:

```
$ rustc +nightly --print target-list | rg xous
riscv32imac-unknown-xous-elf
$
```

Xous has no C library at all, and relies on `compiler-builtins` to provide most floating-point math functions. These patches enable C code on this platform.

Note that `cc-rs` still needs to be updated to support `riscv32imac-unknown-xous-elf` -- for now any packages will need to set the `CC` environment variable to point to a valid C compiler.