### PR TITLE
Enable mem for UEFI

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,7 @@ fn main() {
         || (target.contains("sgx") && target.contains("fortanix"))
         || target.contains("-none")
         || target.contains("nvptx")
+        || target.contains("uefi")
     {
         println!("cargo:rustc-cfg=feature=\"mem\"");
     }


### PR DESCRIPTION
I am working on porting std to UEFI. it can now build without the `restricted_std` feature but needs the mem stuff to be useful.

Signed-off-by: Ayush Singh <ayushsingh1325@gmail.com>