### PR TITLE
add weak linkage to the ARM AEABI division functions

### DIFF
--- a/src/arm.rs
+++ b/src/arm.rs
@@ -22,6 +22,7 @@ intrinsics! {
     // custom calling convention which can't be implemented using a normal Rust function.
     #[naked]
     #[cfg(not(target_env = "msvc"))]
+    #[linkage = "weak"]
     pub unsafe extern "C" fn __aeabi_uidivmod() {
         core::arch::asm!(
             "push {{lr}}",
@@ -36,6 +37,7 @@ intrinsics! {
     }
 
     #[naked]
+    #[linkage = "weak"]
     pub unsafe extern "C" fn __aeabi_uldivmod() {
         core::arch::asm!(
             "push {{r4, lr}}",
@@ -52,6 +54,7 @@ intrinsics! {
     }
 
     #[naked]
+    #[linkage = "weak"]
     pub unsafe extern "C" fn __aeabi_idivmod() {
         core::arch::asm!(
             "push {{r0, r1, r4, lr}}",
@@ -65,6 +68,7 @@ intrinsics! {
     }
 
     #[naked]
+    #[linkage = "weak"]
     pub unsafe extern "C" fn __aeabi_ldivmod() {
         core::arch::asm!(
             "push {{r4, lr}}",

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -22,7 +22,7 @@ intrinsics! {
     // custom calling convention which can't be implemented using a normal Rust function.
     #[naked]
     #[cfg(not(target_env = "msvc"))]
-    #[linkage = "weak"]
+    #[cfg_attr(all(not(windows), not(target_vendor="apple")), linkage = "weak")]
     pub unsafe extern "C" fn __aeabi_uidivmod() {
         core::arch::asm!(
             "push {{lr}}",
@@ -37,7 +37,7 @@ intrinsics! {
     }
 
     #[naked]
-    #[linkage = "weak"]
+    #[cfg_attr(all(not(windows), not(target_vendor="apple")), linkage = "weak")]
     pub unsafe extern "C" fn __aeabi_uldivmod() {
         core::arch::asm!(
             "push {{r4, lr}}",
@@ -54,7 +54,7 @@ intrinsics! {
     }
 
     #[naked]
-    #[linkage = "weak"]
+    #[cfg_attr(all(not(windows), not(target_vendor="apple")), linkage = "weak")]
     pub unsafe extern "C" fn __aeabi_idivmod() {
         core::arch::asm!(
             "push {{r0, r1, r4, lr}}",
@@ -68,7 +68,7 @@ intrinsics! {
     }
 
     #[naked]
-    #[linkage = "weak"]
+    #[cfg_attr(all(not(windows), not(target_vendor="apple")), linkage = "weak")]
     pub unsafe extern "C" fn __aeabi_ldivmod() {
         core::arch::asm!(
             "push {{r4, lr}}",


### PR DESCRIPTION
Closes https://github.com/rust-lang/compiler-builtins/issues/477

I know in the issue Amanieu said that *all* functions in this crate should probably get weak linkage when possible, but that seems overkill for my own needs and i didn't want to have to determine when the target will use ELF or not for a lot of functions i'd never heard of.