### PR TITLE
Disable some PPC64 tests which are failing due to an LLVM(?) bug

### DIFF
--- a/testcrate/tests/mem.rs
+++ b/testcrate/tests/mem.rs
@@ -230,6 +230,8 @@ fn memmove_backward_aligned() {
     }
 }
 
+// PowerPC tests are failing: https://github.com/rust-lang/rust/issues/99853
+#[cfg(not(target_arch = "powerpc64"))]
 #[test]
 fn memset_backward_misaligned_nonaligned_start() {
     let mut arr = gen_arr::<32>();
@@ -242,6 +244,8 @@ fn memset_backward_misaligned_nonaligned_start() {
     }
 }
 
+// PowerPC tests are failing: https://github.com/rust-lang/rust/issues/99853
+#[cfg(not(target_arch = "powerpc64"))]
 #[test]
 fn memset_backward_misaligned_aligned_start() {
     let mut arr = gen_arr::<32>();
@@ -254,6 +258,8 @@ fn memset_backward_misaligned_aligned_start() {
     }
 }
 
+// PowerPC tests are failing: https://github.com/rust-lang/rust/issues/99853
+#[cfg(not(target_arch = "powerpc64"))]
 #[test]
 fn memset_backward_aligned() {
     let mut arr = gen_arr::<32>();


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/99853