### PR TITLE
Add compiler-rt fallback for __trunctfsf2 on mips64-musl.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -460,6 +460,7 @@ mod c {
                 ("__fe_getround", "fp_mode.c"),
                 ("__divtf3", "divtf3.c"),
                 ("__trunctfdf2", "trunctfdf2.c"),
+                ("__trunctfsf2", "trunctfsf2.c"),
             ]);
         }
 


### PR DESCRIPTION
Attempting to build a [package](https://github.com/cross-rs/rust-cpp-hello-word) for `mips64-unknown-linux-muslabi64` with a C++ dependency that uses `iostream` currently fails with the missing symbol `__trunctfsf2@@GCC_3.0` from `strtod`. This was done using a toolchain (using this [Dockerfile](https://github.com/cross-rs/cross/blob/f5b467151470425a2a06b4a2bb152d7fc8bbd187/docker/Dockerfile.mips64-unknown-linux-muslabi64)) built from musl-cross-make, and it is confirmed using the same code while linking to libgcc compiles and runs correctly. The external C++ code is:

```cpp
#include <iostream>

extern "C" {
  void hello() {
    std::cout << "Hello, world!" << std::endl;
  }
}
```