### PR TITLE
Enable `unadjusted_on_win64` for UEFI in some cases

### DIFF
--- a/src/float/conv.rs
+++ b/src/float/conv.rs
@@ -92,12 +92,12 @@ intrinsics! {
         f64::from_bits(int_to_float::u64_to_f64_bits(i))
     }
 
-    #[cfg_attr(not(target_feature = "llvm14-builtins-abi"), unadjusted_on_win64)]
+    #[cfg_attr(any(not(target_feature = "llvm14-builtins-abi"), target_os = "uefi"), unadjusted_on_win64)]
     pub extern "C" fn __floatuntisf(i: u128) -> f32 {
         f32::from_bits(int_to_float::u128_to_f32_bits(i))
     }
 
-    #[cfg_attr(not(target_feature = "llvm14-builtins-abi"), unadjusted_on_win64)]
+    #[cfg_attr(any(not(target_feature = "llvm14-builtins-abi"), target_os = "uefi"), unadjusted_on_win64)]
     pub extern "C" fn __floatuntidf(i: u128) -> f64 {
         f64::from_bits(int_to_float::u128_to_f64_bits(i))
     }
@@ -129,13 +129,13 @@ intrinsics! {
         f64::from_bits(int_to_float::u64_to_f64_bits(i.unsigned_abs()) | sign_bit)
     }
 
-    #[cfg_attr(not(target_feature = "llvm14-builtins-abi"), unadjusted_on_win64)]
+    #[cfg_attr(any(not(target_feature = "llvm14-builtins-abi"), target_os = "uefi"), unadjusted_on_win64)]
     pub extern "C" fn __floattisf(i: i128) -> f32 {
         let sign_bit = ((i >> 127) as u32) << 31;
         f32::from_bits(int_to_float::u128_to_f32_bits(i.unsigned_abs()) | sign_bit)
     }
 
-    #[cfg_attr(not(target_feature = "llvm14-builtins-abi"), unadjusted_on_win64)]
+    #[cfg_attr(any(not(target_feature = "llvm14-builtins-abi"), target_os = "uefi"), unadjusted_on_win64)]
     pub extern "C" fn __floattidf(i: i128) -> f64 {
         let sign_bit = ((i >> 127) as u64) << 63;
         f64::from_bits(int_to_float::u128_to_f64_bits(i.unsigned_abs()) | sign_bit)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -174,7 +174,7 @@ macro_rules! intrinsics {
 
         $($rest:tt)*
     ) => (
-        #[cfg(all(windows, target_pointer_width = "64"))]
+        #[cfg(all(any(windows, all(target_os = "uefi", target_arch = "x86_64")), target_pointer_width = "64"))]
         intrinsics! {
             $(#[$($attr)*])*
             pub extern "unadjusted" fn $name( $($argname: $ty),* ) $(-> $ret)? {
@@ -182,7 +182,7 @@ macro_rules! intrinsics {
             }
         }
 
-        #[cfg(not(all(windows, target_pointer_width = "64")))]
+        #[cfg(not(all(any(windows, all(target_os = "uefi", target_arch = "x86_64")), target_pointer_width = "64")))]
         intrinsics! {
             $(#[$($attr)*])*
             pub extern $abi fn $name( $($argname: $ty),* ) $(-> $ret)? {


### PR DESCRIPTION
The conversion functions from i128/u128 to f32/f64 have the `unadjusted_on_win64` attribute, but it is disabled starting with LLVM14. This seems to be the correct thing to do for Win64, but for some reason x86_64-unknown-uefi is different, despite generally using the same ABI as Win64.