### PR TITLE
Weak Linkage for "ARM Alias" functions

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -266,6 +266,7 @@ macro_rules! intrinsics {
         #[cfg(target_arch = "arm")]
         pub mod $alias {
             #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
+            #[cfg_attr(all(not(windows), not(target_vendor="apple")), linkage = "weak")]
             pub extern "aapcs" fn $alias( $($argname: $ty),* ) $(-> $ret)? {
                 super::$name($($argname),*)
             }


### PR DESCRIPTION
This adds the weak linkage attribute used in the previous PR (https://github.com/rust-lang/compiler-builtins/pull/385)

```rust
#[cfg_attr(all(not(windows), not(target_vendor="apple")), linkage = "weak")]
```

to the "ARM alias" version of a function generated by the `intrinsics!` macro.

The previous PR didn't catch this case.