### PR TITLE
invoke the unreachable intrinsic, not the stable wrapper

### DIFF
--- a/src/int/specialized_div_rem/mod.rs
+++ b/src/int/specialized_div_rem/mod.rs
@@ -72,7 +72,10 @@ mod asymmetric;
 /// impossible to reach by Rust users, unless `compiler-builtins` public division functions or
 /// `core/std::unchecked_div/rem` are directly used without a zero check in front.
 fn zero_div_fn() -> ! {
-    unsafe { core::hint::unreachable_unchecked() }
+    // Calling the intrinsic directly, to avoid the `assert_unsafe_precondition` that cannot be used
+    // here because it involves non-`inline` functions
+    // (https://github.com/rust-lang/compiler-builtins/issues/491).
+    unsafe { core::intrinsics::unreachable() }
 }
 
 const USE_LZ: bool = {


### PR DESCRIPTION
Works around https://github.com/rust-lang/compiler-builtins/issues/491: `hint::unreachable_unchecked` would like to trigger a panic in debug builds, but that would involve non-`inline` functions, so we cannot use it from compiler_builtins any more.