### PR TITLE
Document origins of the multiplication method being used here.

### DIFF
--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -1,5 +1,18 @@
 intrinsics! {
-    // Implementation from gcc
+    // Ancient Egyptian/Ethiopian/Russian multiplication method
+    // see https://en.wikipedia.org/wiki/Ancient_Egyptian_multiplication
+    //
+    // This is a long-available stock algorithm; e.g. it is documented in
+    // Knuth's "The Art of Computer Programming" volume 2 (under the section
+    // "Evaluation of Powers") since at least the 2nd edition (1981).
+    //
+    // The main attraction of this method is that it implements (software)
+    // multiplication atop four simple operations: doubling, halving, checking
+    // if a value is even/odd, and addition. This is *not* considered to be the
+    // fastest multiplication method, but it may be amongst the simplest (and
+    // smallest with respect to code size).
+    //
+    // for reference, see also implementation from gcc
     // https://raw.githubusercontent.com/gcc-mirror/gcc/master/libgcc/config/epiphany/mulsi3.c
     pub extern "C" fn __mulsi3(a: u32, b: u32) -> u32 {
         let (mut a, mut b) = (a, b);

--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -14,6 +14,9 @@ intrinsics! {
     //
     // for reference, see also implementation from gcc
     // https://raw.githubusercontent.com/gcc-mirror/gcc/master/libgcc/config/epiphany/mulsi3.c
+    //
+    // and from LLVM (in relatively readable RISC-V assembly):
+    // https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/riscv/int_mul_impl.inc
     pub extern "C" fn __mulsi3(a: u32, b: u32) -> u32 {
         let (mut a, mut b) = (a, b);
         let mut r = 0;


### PR DESCRIPTION
Many of us have been discussing the matter of where this riscv32.rs code originated.

I think it is fair to say that Rust leadership agrees that it is *not correct development practice* to cross-reference GPL'ed code while developing an algorithm.

But the question nonetheless arose: What do you do about code like riscv32.rs, where the code in question would come out much the same way regardless of whether you looked at GPL'ed source or not? Even if we threw it away, we would probably end up replacing it with something that [looks nearly equivalent](https://github.com/rust-lang/compiler-builtins/issues/319#issuecomment-903175560); so how would a copyright infringement argument play out in practice?

@wesleywiser and @pnkfelix met with a lawyer.

And then @pnkfelix did some follow-up reading on the *Scènes à faire* doctrine of copyright law.

It seems evident to us that a very important detail is that the algorithm defined in this code not only would be considered "stock" (i.e. not a original work) from the viewpoint of us discussing the matter today, but it would *also* have been considered "stock" at the time it was originally authored **within GCC itself**, since the method has been well known to ancient mathematicians *in 1800 BC*, and has been documented as a standard algorithm since (at least) the 1981 AD publication of Knuth TAOCP volume 2.

Therefore, I am taking the steps of:
 * Documenting the method being used
 * Providing the *motivation* for using this method (simplicity, and *maybe* code size, but certainly not overall efficiency)
 * Linking to external material (wikipedia and TAOCP) that establishes this method as a stock algorithm for many decades


I believe all of these things should be sufficient to:

Close #319