### PR TITLE
Remove unused `no-lang-items` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,6 @@ mem = []
 # compiler-rt implementations. Also used for testing
 mangled-names = []
 
-# Don't generate lang items for i128 intrisnics and such
-no-lang-items = []
-
 # Only used in the compiler's build system
 rustc-dep-of-std = ['compiler-builtins', 'core']
 

--- a/testcrate/Cargo.toml
+++ b/testcrate/Cargo.toml
@@ -17,7 +17,7 @@ rand_xoshiro = "0.6"
 [dependencies.compiler_builtins]
 path = ".."
 default-features = false
-features = ["no-lang-items", "public-test-deps"]
+features = ["public-test-deps"]
 
 [target.'cfg(all(target_arch = "arm", not(any(target_env = "gnu", target_env = "musl")), target_os = "linux"))'.dev-dependencies]
 test = { git = "https://github.com/japaric/utest" }


### PR DESCRIPTION
Looks like the last use of this feature was removed in 783430e6ae1ccb0bf6265e4ec81f7c1596dd3eb0.