### PR TITLE
Skip assembly implementations on the UEFI targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -465,7 +465,8 @@ mod c {
         }
 
         // Remove the assembly implementations that won't compile for the target
-        if llvm_target[0] == "thumbv6m" || llvm_target[0] == "thumbv8m.base" {
+        if llvm_target[0] == "thumbv6m" || llvm_target[0] == "thumbv8m.base" || target_os == "uefi"
+        {
             let mut to_remove = Vec::new();
             for (k, v) in sources.map.iter() {
                 if v.ends_with(".S") {


### PR DESCRIPTION
The UEFI targets link with `/SAFESEH`. That requires that objects have a symbol called [`@feat.00`]. Clang adds that symbol for COFF targets if the input is a C file, but not if the input is an ASM file. That doesn't prevent compiler_builtins or rustc from building, but using the resulting rustc to compile something that references one of the objects lacking `@feat.00` will result in a linker error.

Fix by removing all the `.S` implementations when `target_os == uefi`.

[`@feat.00`]: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#the-sxdata-section

This is a partial fix for https://github.com/rust-lang/rust/issues/104326