### PR TITLE
Skip using int_util.c on UEFI targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -201,7 +201,6 @@ mod c {
             ("__cmpdi2", "cmpdi2.c"),
             ("__ctzdi2", "ctzdi2.c"),
             ("__ctzsi2", "ctzsi2.c"),
-            ("__int_util", "int_util.c"),
             ("__mulvdi3", "mulvdi3.c"),
             ("__mulvsi3", "mulvsi3.c"),
             ("__negdi2", "negdi2.c"),
@@ -215,6 +214,15 @@ mod c {
             ("__subvsi3", "subvsi3.c"),
             ("__ucmpdi2", "ucmpdi2.c"),
         ]);
+
+        // UEFI is treated as a windows target when compiling with
+        // clang, and int_util.c includes stdlib.h for windows targets
+        // even though we are compiling with `-ffreestanding`. That
+        // header may not be present might be incompatible, so skip this
+        // file on UEFI targets.
+        if target_os != "uefi" {
+            sources.extend(&[("__int_util", "int_util.c")]);
+        }
 
         if consider_float_intrinsics {
             sources.extend(&[


### PR DESCRIPTION
`int_util.c` includes `stdlib.h` if `_WIN32` is defined. When compiling the UEFI targets with clang they are treated as Windows targets (e.g. if the Rust target is `x86_64-unknown-uefi`, the clang target is `x86_64-unknown-windows-gnu`). So `stdlib.h` gets included, even though we are compilling with `-ffreestanding` and don't want `stdlib.h` to be used. That file may not be present, or an incompatible version might be installed leading to typedef redefinition errors.

Fix by not using `int_util.c` if `target_os == uefi`.

This is a partial fix for https://github.com/rust-lang/rust/issues/104326.