### PR TITLE
Expose minimal floating point symbols for x86_64-unknown-none

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod int;
 
 #[cfg(any(
     all(target_family = "wasm", target_os = "unknown"),
+    all(target_arch = "x86_64", target_os = "none"),
     all(target_arch = "x86_64", target_os = "uefi"),
     all(target_arch = "arm", target_os = "none"),
     target_os = "xous",

--- a/src/math.rs
+++ b/src/math.rs
@@ -106,10 +106,11 @@ no_mangle! {
     fn truncf(x: f32) -> f32;
 }
 
-// only for the thumb*-none-eabi* targets and riscv32*-none-elf targets that lack the floating point instruction set
+// only for the thumb*-none-eabi*, riscv32*-none-elf and x86_64-unknown-none targets that lack the floating point instruction set
 #[cfg(any(
     all(target_arch = "arm", target_os = "none"),
-    all(target_arch = "riscv32", not(target_feature = "f"), target_os = "none")
+    all(target_arch = "riscv32", not(target_feature = "f"), target_os = "none"),
+    all(target_arch = "x86_64", target_os = "none")
 ))]
 no_mangle! {
     fn fmin(x: f64, y: f64) -> f64;


### PR DESCRIPTION
Closes https://github.com/rust-lang/compiler-builtins/issues/509.

CC: @haraldh, @mikeleany (`x86_64-unknown-none` target maintainers)