### PR TITLE
Correct SPDX identifier to "MIT OR (Apache-2.0 AND NCSA)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Jorge Aparicio <japaricious@gmail.com>"]
 name = "compiler_builtins"
 version = "0.1.85"
-license = "MIT/Apache-2.0"
+license = "MIT OR (Apache-2.0 AND NCSA)"
 readme = "README.md"
 repository = "https://github.com/rust-lang/compiler-builtins"
 homepage = "https://github.com/rust-lang/compiler-builtins"


### PR DESCRIPTION
The `Cargo.toml` file specifies the license as `MIT/Apache-2.0`. This library, however, inherited LLVM's `MIT/NCSA` licensing. LLVM has since switched to `MIT OR NCSA OR (Apache-2.0 WITH LLVM-exception)`, so it's probably possible to re-license this crate to `MIT/Apache-2.0`, however, the fact is that this hasn't happened yet, since the Readme still says that contributors license their contributions under `MIT/NCSA`. This implies that all contributors would need to agree to license their code under `Apache-2.0` first.

This would make the license of this repo `MIT/NCSA`, but the crate also directly bundles `libm`, which uses `MIT/Apache-2.0`. Combining the two, we get `MIT OR (Apache-2.0 AND NCSA)`.

This issue is being discussed in #307. This PR implements what I believe to be the correct solution to this problem. Please exercise caution, as I am not a lawyer.