### PR TITLE
Drop the `llvm14-builtins-abi` hack

### DIFF
--- a/src/float/conv.rs
+++ b/src/float/conv.rs
@@ -92,12 +92,12 @@ intrinsics! {
         f64::from_bits(int_to_float::u64_to_f64_bits(i))
     }
 
-    #[cfg_attr(any(not(target_feature = "llvm14-builtins-abi"), target_os = "uefi"), unadjusted_on_win64)]
+    #[cfg_attr(target_os = "uefi", unadjusted_on_win64)]
     pub extern "C" fn __floatuntisf(i: u128) -> f32 {
         f32::from_bits(int_to_float::u128_to_f32_bits(i))
     }
 
-    #[cfg_attr(any(not(target_feature = "llvm14-builtins-abi"), target_os = "uefi"), unadjusted_on_win64)]
+    #[cfg_attr(target_os = "uefi", unadjusted_on_win64)]
     pub extern "C" fn __floatuntidf(i: u128) -> f64 {
         f64::from_bits(int_to_float::u128_to_f64_bits(i))
     }
@@ -129,13 +129,13 @@ intrinsics! {
         f64::from_bits(int_to_float::u64_to_f64_bits(i.unsigned_abs()) | sign_bit)
     }
 
-    #[cfg_attr(any(not(target_feature = "llvm14-builtins-abi"), target_os = "uefi"), unadjusted_on_win64)]
+    #[cfg_attr(target_os = "uefi", unadjusted_on_win64)]
     pub extern "C" fn __floattisf(i: i128) -> f32 {
         let sign_bit = ((i >> 127) as u32) << 31;
         f32::from_bits(int_to_float::u128_to_f32_bits(i.unsigned_abs()) | sign_bit)
     }
 
-    #[cfg_attr(any(not(target_feature = "llvm14-builtins-abi"), target_os = "uefi"), unadjusted_on_win64)]
+    #[cfg_attr(target_os = "uefi", unadjusted_on_win64)]
     pub extern "C" fn __floattidf(i: i128) -> f64 {
         let sign_bit = ((i >> 127) as u64) << 63;
         f64::from_bits(int_to_float::u128_to_f64_bits(i.unsigned_abs()) | sign_bit)
@@ -176,8 +176,7 @@ intrinsics! {
         }
     }
 
-    #[cfg_attr(target_feature = "llvm14-builtins-abi", win64_128bit_abi_hack)]
-    #[cfg_attr(not(target_feature = "llvm14-builtins-abi"), unadjusted_on_win64)]
+    #[win64_128bit_abi_hack]
     pub extern "C" fn __fixunssfti(f: f32) -> u128 {
         let fbits = f.to_bits();
         if fbits < 127 << 23 { // >= 0, < 1
@@ -225,8 +224,7 @@ intrinsics! {
         }
     }
 
-    #[cfg_attr(target_feature = "llvm14-builtins-abi", win64_128bit_abi_hack)]
-    #[cfg_attr(not(target_feature = "llvm14-builtins-abi"), unadjusted_on_win64)]
+    #[win64_128bit_abi_hack]
     pub extern "C" fn __fixunsdfti(f: f64) -> u128 {
         let fbits = f.to_bits();
         if fbits < 1023 << 52 { // >= 0, < 1
@@ -279,8 +277,7 @@ intrinsics! {
         }
     }
 
-    #[cfg_attr(target_feature = "llvm14-builtins-abi", win64_128bit_abi_hack)]
-    #[cfg_attr(not(target_feature = "llvm14-builtins-abi"), unadjusted_on_win64)]
+    #[win64_128bit_abi_hack]
     pub extern "C" fn __fixsfti(f: f32) -> i128 {
         let fbits = f.to_bits() & !0 >> 1; // Remove sign bit.
         if fbits < 127 << 23 { // >= 0, < 1
@@ -331,8 +328,7 @@ intrinsics! {
         }
     }
 
-    #[cfg_attr(target_feature = "llvm14-builtins-abi", win64_128bit_abi_hack)]
-    #[cfg_attr(not(target_feature = "llvm14-builtins-abi"), unadjusted_on_win64)]
+    #[win64_128bit_abi_hack]
     pub extern "C" fn __fixdfti(f: f64) -> i128 {
         let fbits = f.to_bits() & !0 >> 1; // Remove sign bit.
         if fbits < 1023 << 52 { // >= 0, < 1


### PR DESCRIPTION
We're updating Rust's minimum to LLVM 14, and would like to remove this fake target feature:
https://github.com/rust-lang/rust/pull/107573#discussion_r1093752878

Instead, we can assume the new ABI unconditionally, apart from the other UEFI exception.
