### PR TITLE
Extend the intrinsics exported for Xtensa no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ pub mod int;
     all(target_arch = "x86_64", target_os = "none"),
     all(target_arch = "x86_64", target_os = "uefi"),
     all(target_arch = "arm", target_os = "none"),
+    all(target_arch = "xtensa", target_os = "none"),
     target_os = "xous",
     all(target_vendor = "fortanix", target_env = "sgx")
 ))]

--- a/src/math.rs
+++ b/src/math.rs
@@ -86,7 +86,11 @@ no_mangle! {
     fn tanf(n: f32) -> f32;
 }
 
-#[cfg(any(target_os = "xous", target_os = "uefi"))]
+#[cfg(any(
+    target_os = "xous",
+    target_os = "uefi",
+    all(target_arch = "xtensa", target_os = "none"),
+))]
 no_mangle! {
     fn sqrtf(x: f32) -> f32;
     fn sqrt(x: f64) -> f64;
@@ -94,6 +98,7 @@ no_mangle! {
 
 #[cfg(any(
     all(target_vendor = "fortanix", target_env = "sgx"),
+    all(target_arch = "xtensa", target_os = "none"),
     target_os = "xous",
     target_os = "uefi"
 ))]


### PR DESCRIPTION
Builds on top of #436 to make more software intrinsics available to the no_std targets.

Closes https://github.com/esp-rs/rust/issues/155