### PR TITLE
Fix panic due to overflow in riscv.rs and int/shift.rs

### DIFF
--- a/src/int/shift.rs
+++ b/src/int/shift.rs
@@ -12,7 +12,7 @@ trait Ashl: DInt {
         } else {
             Self::from_lo_hi(
                 self.lo().wrapping_shl(shl),
-                self.lo().logical_shr(n_h - shl) | self.hi().wrapping_shl(shl),
+                self.lo().logical_shr(n_h.wrapping_sub(shl)) | self.hi().wrapping_shl(shl),
             )
         }
     }
@@ -36,7 +36,7 @@ trait Ashr: DInt {
             self
         } else {
             Self::from_lo_hi(
-                self.lo().logical_shr(shr) | self.hi().wrapping_shl(n_h - shr),
+                self.lo().logical_shr(shr) | self.hi().wrapping_shl(n_h.wrapping_sub(shr)),
                 self.hi().wrapping_shr(shr),
             )
         }
@@ -57,7 +57,7 @@ trait Lshr: DInt {
             self
         } else {
             Self::from_lo_hi(
-                self.lo().logical_shr(shr) | self.hi().wrapping_shl(n_h - shr),
+                self.lo().logical_shr(shr) | self.hi().wrapping_shl(n_h.wrapping_sub(shr)),
                 self.hi().logical_shr(shr),
             )
         }

--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -19,11 +19,11 @@ intrinsics! {
     // https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/riscv/int_mul_impl.inc
     pub extern "C" fn __mulsi3(a: u32, b: u32) -> u32 {
         let (mut a, mut b) = (a, b);
-        let mut r = 0;
+        let mut r: u32 = 0;
 
         while a > 0 {
             if a & 1 > 0 {
-                r += b;
+                r = r.wrapping_add(b);
             }
             a >>= 1;
             b <<= 1;
@@ -35,11 +35,11 @@ intrinsics! {
     #[cfg(not(target_feature = "m"))]
     pub extern "C" fn __muldi3(a: u64, b: u64) -> u64 {
         let (mut a, mut b) = (a, b);
-        let mut r = 0;
+        let mut r: u64 = 0;
 
         while a > 0 {
             if a & 1 > 0 {
-                r += b;
+                r = r.wrapping_add(b);
             }
             a >>= 1;
             b <<= 1;


### PR DESCRIPTION
I ran into this while testing `riscv32i-unknown-none-elf` with `-Z build-std=core,alloc`.
```
panicked at 'attempt to add with overflow', /Users/taiki/.cargo/registry/src/index.crates.io-6f17d22bba15001f/compiler_builtins-0.1.87/src/riscv.rs:42:17
```

(Can be reproduced by cloning [semihosting repo](https://github.com/taiki-e/semihosting), comment out [this line](https://github.com/taiki-e/semihosting/blob/249ad13cd8faa4346a29afa48dfdb9c5b6a3f6d0/tools/no-std.sh#L257), and run `./tools/no-std riscv32i-unknown-none-elf`)