### PR TITLE
Ensure shift instrinsic arguments match width of compiler-rt's.

### DIFF
--- a/src/int/shift.rs
+++ b/src/int/shift.rs
@@ -78,8 +78,8 @@ intrinsics! {
     #[avr_skip]
     #[maybe_use_optimized_c_shim]
     #[arm_aeabi_alias = __aeabi_llsl]
-    pub extern "C" fn __ashldi3(a: u64, b: u32) -> u64 {
-        a.ashl(b)
+    pub extern "C" fn __ashldi3(a: u64, b: core::ffi::c_uint) -> u64 {
+        a.ashl(b as u32)
     }
 
     #[avr_skip]
@@ -96,8 +96,8 @@ intrinsics! {
     #[avr_skip]
     #[maybe_use_optimized_c_shim]
     #[arm_aeabi_alias = __aeabi_lasr]
-    pub extern "C" fn __ashrdi3(a: i64, b: u32) -> i64 {
-        a.ashr(b)
+    pub extern "C" fn __ashrdi3(a: i64, b: core::ffi::c_uint) -> i64 {
+        a.ashr(b as u32)
     }
 
     #[avr_skip]
@@ -114,8 +114,8 @@ intrinsics! {
     #[avr_skip]
     #[maybe_use_optimized_c_shim]
     #[arm_aeabi_alias = __aeabi_llsr]
-    pub extern "C" fn __lshrdi3(a: u64, b: u32) -> u64 {
-        a.lshr(b)
+    pub extern "C" fn __lshrdi3(a: u64, b: core::ffi::c_uint) -> u64 {
+        a.lshr(b as u32)
     }
 
     #[avr_skip]


### PR DESCRIPTION
This fixes [#520](https://github.com/rust-lang/compiler-builtins/issues/520). I tested this locally and confirmed this fixes my issue, along with the additional changes listed in the below sections _just for testing_.

I realized while working on this patch that as far as `compiler-builtins` is concerned, only the shift instrinsics are affected by 16-bit vs 32-bit mismatch. This dates back to a [patch](https://github.com/llvm/llvm-project/commit/4d41df64828195aa24cddc5d34d3f446ca7bb6d1) by @aykevl in 2020.

It is very possible that the msp430 backend generates code w/ incorrect width for other instrinsics changed in the above patch. However, I don't know a good way to sift these out w/ tests, Rust or otherwise. Perhaps https://github.com/rust-lang/rust/issues/107612 could be useful here? `mspdebug` has a simulator; it's [how](https://github.com/rust-lang/rust/issues/107612#issuecomment-1472377638) I was able to get a test case for #520.

## `compiler-builtins` patches

```diff
diff --git a/src/lib.rs b/src/lib.rs
index 71f249c..dabe076 100644
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 #![no_builtins]
 #![no_std]
 #![allow(unused_features)]
+#![allow(unexpected_cfgs)]
 // We use `u128` in a whole bunch of places which we currently agree with the
 // compiler on ABIs and such, so we should be "good enough" for now and changes
 // to the `u128` ABI will be reflected here.
```

Without this, for some reason Rust bails with `-D warnings`, due to https://github.com/rust-lang/rust/issues/96472 when I'm using `compiler-builtins` as a path dep (but not when using a crates.io dep... huh...).

## `rust` patches

```diff
diff --git a/Cargo.lock b/Cargo.lock
index 449f0c73588..c8a69ff7d5a 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,9 +868,7 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f867ce54c09855ccd135ad4a50c777182a0c7af5ff20a8f537617bd648b10d50"
+version = "0.1.90"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",
diff --git a/Cargo.toml b/Cargo.toml
index 15cbb2659c9..8fa9b040bfa 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,12 @@ gimli.debug = 0
 miniz_oxide.debug = 0
 object.debug = 0
 
+[profile.release.package.core]
+opt-level = 's'
+
+[profile.release.package.alloc]
+opt-level = 's'
+
 [patch.crates-io]
 # See comments in `src/tools/rustc-workspace-hack/README.md` for what's going on
 # here
@@ -114,6 +120,7 @@ rustc-workspace-hack = { path = 'src/tools/rustc-workspace-hack' }
 rustc-std-workspace-core = { path = 'library/rustc-std-workspace-core' }
 rustc-std-workspace-alloc = { path = 'library/rustc-std-workspace-alloc' }
 rustc-std-workspace-std = { path = 'library/rustc-std-workspace-std' }
+compiler_builtins = { version="0.1.87", path = '../compiler-builtins' }
 
 [patch."https://github.com/rust-lang/rust-clippy"]
 clippy_lints = { path = "src/tools/clippy/clippy_lints" }
diff --git a/library/backtrace b/library/backtrace
--- a/library/backtrace
+++ b/library/backtrace
@@ -1 +1 @@
-Subproject commit 07872f28cd8a65c3c7428811548dc85f1f2fb05b
+Subproject commit 07872f28cd8a65c3c7428811548dc85f1f2fb05b-dirty
```

Use local `compiler-builtins` with my patch, work around some _unrelated_ LLVM assertion failures at `opt-level=3`.