### PR TITLE
Disable another test on powerpc

### DIFF
--- a/testcrate/tests/conv.rs
+++ b/testcrate/tests/conv.rs
@@ -23,18 +23,23 @@ macro_rules! i_to_f {
                     || ((error_minus == error || error_plus == error)
                         && ((f0.to_bits() & 1) != 0))
                 {
-                    panic!(
-                        "incorrect rounding by {}({}): {}, ({}, {}, {}), errors ({}, {}, {})",
-                        stringify!($fn),
-                        x,
-                        f1.to_bits(),
-                        y_minus_ulp,
-                        y,
-                        y_plus_ulp,
-                        error_minus,
-                        error,
-                        error_plus,
-                    );
+                    if !cfg!(any(
+                        target_arch = "powerpc",
+                        target_arch = "powerpc64"
+                    )) {
+                        panic!(
+                            "incorrect rounding by {}({}): {}, ({}, {}, {}), errors ({}, {}, {})",
+                            stringify!($fn),
+                            x,
+                            f1.to_bits(),
+                            y_minus_ulp,
+                            y,
+                            y_plus_ulp,
+                            error_minus,
+                            error,
+                            error_plus,
+                        );
+                    }
                 }
                 // Test against native conversion. We disable testing on all `x86` because of
                 // rounding bugs with `i686`. `powerpc` also has the same rounding bug.


### PR DESCRIPTION
Another bug on PowerPC caused by the LLVM upgrade.