### PR TITLE
Add the weak-intrinsics feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,17 @@ rustc-dep-of-std = ['compiler-builtins', 'core']
 # are not normally public but are required by the `testcrate`
 public-test-deps = []
 
+# Marks all intrinsics functions with weak linkage so that they can be
+# replaced at link time by another implementation. This is particularly useful
+# for mixed Rust/C++ binaries that want to use the C++ intrinsics, otherwise
+# linking against the Rust stdlib will replace those from the compiler-rt
+# library.
+#
+# Unlike the "c" feature, the intrinsics are still provided by the Rust
+# implementations and each will be used unless a stronger symbol replaces
+# it during linking.
+weak-intrinsics = []
+
 [[example]]
 name = "intrinsics"
 required-features = ["compiler-builtins"]

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -20,9 +20,9 @@ macro_rules! bl {
 intrinsics! {
     // NOTE This function and the ones below are implemented using assembly because they are using a
     // custom calling convention which can't be implemented using a normal Rust function.
+    #[cfg_attr(all(not(windows), not(target_vendor="apple")), weak)]
     #[naked]
     #[cfg(not(target_env = "msvc"))]
-    #[cfg_attr(all(not(windows), not(target_vendor="apple")), linkage = "weak")]
     pub unsafe extern "C" fn __aeabi_uidivmod() {
         core::arch::asm!(
             "push {{lr}}",
@@ -36,8 +36,8 @@ intrinsics! {
         );
     }
 
+    #[cfg_attr(all(not(windows), not(target_vendor="apple")), weak)]
     #[naked]
-    #[cfg_attr(all(not(windows), not(target_vendor="apple")), linkage = "weak")]
     pub unsafe extern "C" fn __aeabi_uldivmod() {
         core::arch::asm!(
             "push {{r4, lr}}",
@@ -53,8 +53,8 @@ intrinsics! {
         );
     }
 
+    #[cfg_attr(all(not(windows), not(target_vendor="apple")), weak)]
     #[naked]
-    #[cfg_attr(all(not(windows), not(target_vendor="apple")), linkage = "weak")]
     pub unsafe extern "C" fn __aeabi_idivmod() {
         core::arch::asm!(
             "push {{r0, r1, r4, lr}}",
@@ -67,8 +67,8 @@ intrinsics! {
         );
     }
 
+    #[cfg_attr(all(not(windows), not(target_vendor="apple")), weak)]
     #[naked]
-    #[cfg_attr(all(not(windows), not(target_vendor="apple")), linkage = "weak")]
     pub unsafe extern "C" fn __aeabi_ldivmod() {
         core::arch::asm!(
             "push {{r4, lr}}",
@@ -88,14 +88,14 @@ intrinsics! {
     // with custom implementation.
     // FIXME: The `*4` and `*8` variants should be defined as aliases.
 
+    #[weak]
     #[cfg(not(target_os = "ios"))]
-    #[linkage = "weak"]
     pub unsafe extern "aapcs" fn __aeabi_memcpy(dest: *mut u8, src: *const u8, n: usize) {
         ::mem::memcpy(dest, src, n);
     }
 
+    #[weak]
     #[cfg(not(target_os = "ios"))]
-    #[linkage = "weak"]
     pub unsafe extern "aapcs" fn __aeabi_memcpy4(dest: *mut u8, src: *const u8, n: usize) {
         // We are guaranteed 4-alignment, so accessing at u32 is okay.
         let mut dest = dest as *mut u32;
@@ -112,39 +112,39 @@ intrinsics! {
         __aeabi_memcpy(dest as *mut u8, src as *const u8, n);
     }
 
+    #[weak]
     #[cfg(not(target_os = "ios"))]
-    #[linkage = "weak"]
     pub unsafe extern "aapcs" fn __aeabi_memcpy8(dest: *mut u8, src: *const u8, n: usize) {
         __aeabi_memcpy4(dest, src, n);
     }
 
+    #[weak]
     #[cfg(not(target_os = "ios"))]
-    #[linkage = "weak"]
     pub unsafe extern "aapcs" fn __aeabi_memmove(dest: *mut u8, src: *const u8, n: usize) {
         ::mem::memmove(dest, src, n);
     }
 
+    #[weak]
     #[cfg(not(any(target_os = "ios", target_env = "msvc")))]
-    #[linkage = "weak"]
     pub unsafe extern "aapcs" fn __aeabi_memmove4(dest: *mut u8, src: *const u8, n: usize) {
         __aeabi_memmove(dest, src, n);
     }
 
+    #[weak]
     #[cfg(not(any(target_os = "ios", target_env = "msvc")))]
-    #[linkage = "weak"]
     pub unsafe extern "aapcs" fn __aeabi_memmove8(dest: *mut u8, src: *const u8, n: usize) {
         __aeabi_memmove(dest, src, n);
     }
 
+    #[weak]
     #[cfg(not(target_os = "ios"))]
-    #[linkage = "weak"]
     pub unsafe extern "aapcs" fn __aeabi_memset(dest: *mut u8, n: usize, c: i32) {
         // Note the different argument order
         ::mem::memset(dest, c, n);
     }
 
+    #[weak]
     #[cfg(not(target_os = "ios"))]
-    #[linkage = "weak"]
     pub unsafe extern "aapcs" fn __aeabi_memset4(dest: *mut u8, n: usize, c: i32) {
         let mut dest = dest as *mut u32;
         let mut n = n;
@@ -161,26 +161,26 @@ intrinsics! {
         __aeabi_memset(dest as *mut u8, n, byte as i32);
     }
 
+    #[weak]
     #[cfg(not(target_os = "ios"))]
-    #[linkage = "weak"]
     pub unsafe extern "aapcs" fn __aeabi_memset8(dest: *mut u8, n: usize, c: i32) {
         __aeabi_memset4(dest, n, c);
     }
 
+    #[weak]
     #[cfg(not(target_os = "ios"))]
-    #[linkage = "weak"]
     pub unsafe extern "aapcs" fn __aeabi_memclr(dest: *mut u8, n: usize) {
         __aeabi_memset(dest, n, 0);
     }
 
+    #[weak]
     #[cfg(not(any(target_os = "ios", target_env = "msvc")))]
-    #[linkage = "weak"]
     pub unsafe extern "aapcs" fn __aeabi_memclr4(dest: *mut u8, n: usize) {
         __aeabi_memset4(dest, n, 0);
     }
 
+    #[weak]
     #[cfg(not(any(target_os = "ios", target_env = "msvc")))]
-    #[linkage = "weak"]
     pub unsafe extern "aapcs" fn __aeabi_memclr8(dest: *mut u8, n: usize) {
         __aeabi_memset4(dest, n, 0);
     }

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -20,15 +20,15 @@ use core::ops::{BitOr, Shl};
 mod impls;
 
 intrinsics! {
+    #[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), weak)]
     #[mem_builtin]
-    #[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), linkage = "weak")]
     pub unsafe extern "C" fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
         impls::copy_forward(dest, src, n);
         dest
     }
 
+    #[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), weak)]
     #[mem_builtin]
-    #[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), linkage = "weak")]
     pub unsafe extern "C" fn memmove(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
         let delta = (dest as usize).wrapping_sub(src as usize);
         if delta >= n {
@@ -41,27 +41,27 @@ intrinsics! {
         dest
     }
 
+    #[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), weak)]
     #[mem_builtin]
-    #[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), linkage = "weak")]
     pub unsafe extern "C" fn memset(s: *mut u8, c: crate::mem::c_int, n: usize) -> *mut u8 {
         impls::set_bytes(s, c as u8, n);
         s
     }
 
+    #[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), weak)]
     #[mem_builtin]
-    #[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), linkage = "weak")]
     pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
         impls::compare_bytes(s1, s2, n)
     }
 
+    #[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), weak)]
     #[mem_builtin]
-    #[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), linkage = "weak")]
     pub unsafe extern "C" fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
         memcmp(s1, s2, n)
     }
 
+    #[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), weak)]
     #[mem_builtin]
-    #[cfg_attr(not(all(target_os = "windows", target_env = "gnu")), linkage = "weak")]
     pub unsafe extern "C" fn strlen(s: *const core::ffi::c_char) -> usize {
         impls::c_string_length(s)
     }


### PR DESCRIPTION
When enabled, the weak-intrinsics feature will cause all intrinsics functions to be marked with weak linkage (i.e. `#[linkage = "weak"]) so that they can be replaced at link time by a stronger symbol.

This can be set to use C++ intrinsics from the compiler-rt library, as it will avoid Rust's implementation replacing the compiler-rt implementation as long as the compiler-rt symbols are linked as strong symbols. Typically this requires the compiler-rt library to be explicitly specified in the link command.

Addresses https://github.com/rust-lang/compiler-builtins/issues/525.