### PR TITLE
fix: Add `#[avr_skip]` for floats

### DIFF
--- a/src/float/cmp.rs
+++ b/src/float/cmp.rs
@@ -99,60 +99,74 @@ fn unord<F: Float>(a: F, b: F) -> bool {
 }
 
 intrinsics! {
+    #[avr_skip]
     pub extern "C" fn __lesf2(a: f32, b: f32) -> i32 {
         cmp(a, b).to_le_abi()
     }
 
+    #[avr_skip]
     pub extern "C" fn __gesf2(a: f32, b: f32) -> i32 {
         cmp(a, b).to_ge_abi()
     }
 
+    #[avr_skip]
     #[arm_aeabi_alias = __aeabi_fcmpun]
     pub extern "C" fn __unordsf2(a: f32, b: f32) -> i32 {
         unord(a, b) as i32
     }
 
+    #[avr_skip]
     pub extern "C" fn __eqsf2(a: f32, b: f32) -> i32 {
         cmp(a, b).to_le_abi()
     }
 
+    #[avr_skip]
     pub extern "C" fn __ltsf2(a: f32, b: f32) -> i32 {
         cmp(a, b).to_le_abi()
     }
 
+    #[avr_skip]
     pub extern "C" fn __nesf2(a: f32, b: f32) -> i32 {
         cmp(a, b).to_le_abi()
     }
 
+    #[avr_skip]
     pub extern "C" fn __gtsf2(a: f32, b: f32) -> i32 {
         cmp(a, b).to_ge_abi()
     }
 
+    #[avr_skip]
     pub extern "C" fn __ledf2(a: f64, b: f64) -> i32 {
         cmp(a, b).to_le_abi()
     }
 
+    #[avr_skip]
     pub extern "C" fn __gedf2(a: f64, b: f64) -> i32 {
         cmp(a, b).to_ge_abi()
     }
 
+    #[avr_skip]
     #[arm_aeabi_alias = __aeabi_dcmpun]
     pub extern "C" fn __unorddf2(a: f64, b: f64) -> i32 {
         unord(a, b) as i32
     }
 
+    #[avr_skip]
     pub extern "C" fn __eqdf2(a: f64, b: f64) -> i32 {
         cmp(a, b).to_le_abi()
     }
 
+    #[avr_skip]
     pub extern "C" fn __ltdf2(a: f64, b: f64) -> i32 {
         cmp(a, b).to_le_abi()
     }
 
+    #[avr_skip]
     pub extern "C" fn __nedf2(a: f64, b: f64) -> i32 {
         cmp(a, b).to_le_abi()
     }
 
+    #[avr_skip]
     pub extern "C" fn __gtdf2(a: f64, b: f64) -> i32 {
         cmp(a, b).to_ge_abi()
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -437,12 +437,11 @@ macro_rules! intrinsics {
         intrinsics!($($rest)*);
     );
 
-    // For division and modulo, AVR uses a custom calling convention¹ that does
-    // not match our definitions here. Ideally we would just use hand-written
-    // naked functions, but that's quite a lot of code to port² - so for the
-    // time being we are just ignoring the problematic functions, letting
-    // avr-gcc (which is required to compile to AVR anyway) link them from
-    // libgcc.
+    // For some intrinsics, AVR uses a custom calling convention¹ that does not
+    // match our definitions here. Ideally we would just use hand-written naked
+    // functions, but that's quite a lot of code to port² - so for the time
+    // being we are just ignoring the problematic functions, letting avr-gcc
+    // (which is required to compile to AVR anyway) link them from libgcc.
     //
     // ¹ https://gcc.gnu.org/wiki/avr-gcc (see "Exceptions to the Calling
     //   Convention")


### PR DESCRIPTION
Same story as always, i.e. ABI mismatch:

- https://github.com/rust-lang/compiler-builtins/pull/462
- https://github.com/rust-lang/compiler-builtins/pull/466
- https://github.com/rust-lang/compiler-builtins/pull/513

I've made sure the changes work by rendering a Mandelbrot fractal:

```rust
#[arduino_hal::entry]
fn main() -> ! {
    let dp = arduino_hal::Peripherals::take().unwrap();
    let pins = arduino_hal::pins!(dp);
    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);

    mandelbrot(&mut serial, 60, 40, -2.05, -1.12, 0.47, 1.12, 100);

    loop {
        //
    }
}

fn mandelbrot<T>(
    output: &mut T,
    viewport_width: i64,
    viewport_height: i64,
    x1: f32,
    y1: f32,
    x2: f32,
    y2: f32,
    max_iterations: i64,
) where
    T: uWrite,
{
    for viewport_y in 0..viewport_height {
        let y0 = y1 + (y2 - y1) * ((viewport_y as f32) / (viewport_height as f32));

        for viewport_x in 0..viewport_width {
            let x0 = x1 + (x2 - x1) * ((viewport_x as f32) / (viewport_width as f32));

            let mut x = 0.0;
            let mut y = 0.0;
            let mut iterations = max_iterations;

            while x * x + y * y <= 4.0 && iterations > 0 {
                let xtemp = x * x - y * y + x0;
                y = 2.0 * x * y + y0;
                x = xtemp;
                iterations -= 1;
            }

            let ch = "#%=-:,. "
                .chars()
                .nth((8.0 * ((iterations as f32) / (max_iterations as f32))) as _)
                .unwrap();

            _ = ufmt::uwrite!(output, "{}", ch);
        }

        _ = ufmt::uwriteln!(output, "");
    }
}
```

... where without avr_skips, the code printed an image full of only `#`.

Note that because libgcc doesn't provide implementations for f64, using those (e.g. swapping f32 to f64 in the code above) will cause linking to fail:

```
undefined reference to `__divdf3'
undefined reference to `__muldf3'
undefined reference to `__gedf2'
undefined reference to `__fixunsdfsi'
undefined reference to `__gtdf2'
```

Ideally compiler-builtins could jump right in and provide those, but f64 also require a special calling convention which hasn't been yet exposed through LLVM.

Note that because using 64-bit floats on an 8-bit target is a pretty niche thing to do, and because f64 floats don't work correctly anyway at the moment (due to this ABI mismatch), we're not actually breaking anything by skipping those functions, since any code that currently uses f64 on AVR works by accident.

Closes https://github.com/rust-lang/rust/issues/108489.