### PR TITLE
enable simple f32/f64 support needed by core library for MIPS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub mod int;
     all(target_arch = "x86_64", target_os = "uefi"),
     all(target_arch = "arm", target_os = "none"),
     all(target_arch = "xtensa", target_os = "none"),
+    all(target_arch = "mips", target_os = "none"),
     target_os = "xous",
     all(target_vendor = "fortanix", target_env = "sgx")
 ))]

--- a/src/math.rs
+++ b/src/math.rs
@@ -136,11 +136,12 @@ no_mangle! {
     fn truncf(x: f32) -> f32;
 }
 
-// only for the thumb*-none-eabi*, riscv32*-none-elf and x86_64-unknown-none targets that lack the floating point instruction set
+// only for the thumb*-none-eabi*, riscv32*-none-elf, x86_64-unknown-none and mips*-unknown-none targets that lack the floating point instruction set
 #[cfg(any(
     all(target_arch = "arm", target_os = "none"),
     all(target_arch = "riscv32", not(target_feature = "f"), target_os = "none"),
-    all(target_arch = "x86_64", target_os = "none")
+    all(target_arch = "x86_64", target_os = "none"),
+    all(target_arch = "mips", target_os = "none"),
 ))]
 no_mangle! {
     fn fmin(x: f64, y: f64) -> f64;


### PR DESCRIPTION
This change allows for simple f32/f64 computations provided by Rust `core` (as opposed to `std`) to be done on MIPS targets. Suitable for bare metal MIPS targets like the PIC32 micro controller.

Would be great if you accept this or a similar change.