### PR TITLE
Use the target_feature "zbb" instead of "b" for RISC-V

### DIFF
--- a/src/int/specialized_div_rem/mod.rs
+++ b/src/int/specialized_div_rem/mod.rs
@@ -95,8 +95,9 @@ const USE_LZ: bool = {
         // LZD or LZCNT on SPARC only exists for the VIS 3 extension and later.
         cfg!(target_feature = "vis3")
     } else if cfg!(any(target_arch = "riscv32", target_arch = "riscv64")) {
-        // The `B` extension on RISC-V determines if a CLZ assembly instruction exists
-        cfg!(target_feature = "b")
+        // The 'Zbb' Basic Bit-Manipulation extension on RISC-V
+        // determines if a CLZ assembly instruction exists
+        cfg!(target_feature = "zbb")
     } else {
         // All other common targets Rust supports should have CLZ instructions
         true


### PR DESCRIPTION
When I first wrote this there was a unified "b" bitmanip extension, but recently it was frozen under multiple smaller extensions, of which Zbb is the correct one (https://github.com/riscv/riscv-bitmanip).
"zbb" is what shows on today's `rustc --target=riscv64gc-unknown-linux-gnu --print target-features`