### PR TITLE
Fix build error on aarch64_be linux

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -91,7 +91,7 @@ fn main() {
         println!("cargo:rustc-cfg=kernel_user_helpers")
     }
 
-    if llvm_target[0] == "aarch64" {
+    if llvm_target[0].starts_with("aarch64") {
         generate_aarch64_outlined_atomics();
     }
 }


### PR DESCRIPTION
I tried to re-enable the test for aarch64_be-unknown-linux-gnu as a fix for the core_simd bug was released, but ran into the following error.

```
error: couldn't read /home/runner/work/setup-cross-toolchain-action/setup-cross-toolchain-action/rust-cross-toolchain/target/aarch64_be-unknown-linux-gnu/debug/build/compiler_builtins-3cff6482b464b138/out/outlined_atomics.rs: No such file or directory (os error 2)
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/compiler_builtins-0.1.95/src/aarch64_linux.rs:270:1
    |
270 | include!(concat!(env!("OUT_DIR"), "/outlined_atomics.rs"));
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `compiler_builtins` (lib) due to previous error
```
([full log](https://github.com/taiki-e/setup-cross-toolchain-action/actions/runs/5492798351/jobs/10010548512))