### PR TITLE
Add __chkstk for aarch64-unknown-uefi

### DIFF
--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -1,0 +1,22 @@
+#![allow(unused_imports)]
+
+use core::intrinsics;
+
+intrinsics! {
+    #[naked]
+    #[cfg(all(target_os = "uefi", not(feature = "no-asm")))]
+    pub unsafe extern "C" fn __chkstk() {
+        core::arch::asm!(
+            ".p2align 2",
+            "lsl    x16, x15, #4",
+            "mov    x17, sp",
+            "1:",
+            "sub    x17, x17, 4096",
+            "subs   x16, x16, 4096",
+            "ldr    xzr, [x17]",
+            "b.gt   1b",
+            "ret",
+            options(noreturn)
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,9 @@ pub mod mem;
 #[cfg(target_arch = "arm")]
 pub mod arm;
 
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64;
+
 #[cfg(all(target_arch = "aarch64", target_os = "linux", not(feature = "no-asm"),))]
 pub mod aarch64_linux;
 


### PR DESCRIPTION
This is based on compiler-rt/lib/builtins/aarch64/chkstk.S: https://github.com/llvm/llvm-project/commit/f8e19b37995751f7913692bf9eed8ebb14a95f2d