### PR TITLE
Add lgamma_r and lgammaf_r to MinGW

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub mod int;
     all(target_arch = "mips", target_os = "none"),
     target_os = "xous",
     all(target_vendor = "fortanix", target_env = "sgx"),
-    target_env = "msvc"
+    target_os = "windows"
 ))]
 pub mod math;
 pub mod mem;

--- a/src/math.rs
+++ b/src/math.rs
@@ -96,7 +96,7 @@ no_mangle! {
     all(target_arch = "x86_64", target_os = "uefi"),
     all(target_arch = "xtensa", target_os = "none"),
     all(target_vendor = "fortanix", target_env = "sgx"),
-    target_env = "msvc"
+    target_os = "windows"
 ))]
 intrinsics! {
     pub extern "C" fn lgamma_r(x: f64, s: &mut i32) -> f64 {


### PR DESCRIPTION
Sorry for the many PRs. Looks like it's missing from MinGW (`*-pc-windows-gnu` and `*-pc-windows-gnullvm`) as well (https://github.com/rust-lang/rust/pull/99747#issuecomment-1659227726).

[Another source](https://www.gnu.org/software/gnulib/manual/html_node/lgamma_005fr.html)