### PR TITLE
update to edition 2018, allow internal_features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 repository = "https://github.com/rust-lang/compiler-builtins"
 homepage = "https://github.com/rust-lang/compiler-builtins"
 documentation = "https://docs.rs/compiler_builtins"
+edition = "2018"
 description = """
 Compiler intrinsics used by the Rust compiler. Also available for other targets
 if necessary!

--- a/examples/intrinsics.rs
+++ b/examples/intrinsics.rs
@@ -5,6 +5,7 @@
 
 #![allow(unused_features)]
 #![allow(stable_features)] // bench_black_box feature is stable, leaving for backcompat
+#![allow(internal_features)]
 #![cfg_attr(thumb, no_main)]
 #![deny(dead_code)]
 #![feature(bench_black_box)]

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -91,7 +91,7 @@ intrinsics! {
     #[weak]
     #[cfg(not(target_os = "ios"))]
     pub unsafe extern "aapcs" fn __aeabi_memcpy(dest: *mut u8, src: *const u8, n: usize) {
-        ::mem::memcpy(dest, src, n);
+        crate::mem::memcpy(dest, src, n);
     }
 
     #[weak]
@@ -121,7 +121,7 @@ intrinsics! {
     #[weak]
     #[cfg(not(target_os = "ios"))]
     pub unsafe extern "aapcs" fn __aeabi_memmove(dest: *mut u8, src: *const u8, n: usize) {
-        ::mem::memmove(dest, src, n);
+        crate::mem::memmove(dest, src, n);
     }
 
     #[weak]
@@ -140,7 +140,7 @@ intrinsics! {
     #[cfg(not(target_os = "ios"))]
     pub unsafe extern "aapcs" fn __aeabi_memset(dest: *mut u8, n: usize, c: i32) {
         // Note the different argument order
-        ::mem::memset(dest, c, n);
+        crate::mem::memset(dest, c, n);
     }
 
     #[weak]

--- a/src/float/add.rs
+++ b/src/float/add.rs
@@ -1,5 +1,5 @@
-use float::Float;
-use int::{CastInto, Int};
+use crate::float::Float;
+use crate::int::{CastInto, Int};
 
 /// Returns `a + b`
 fn add<F: Float>(a: F, b: F) -> F

--- a/src/float/cmp.rs
+++ b/src/float/cmp.rs
@@ -1,7 +1,7 @@
 #![allow(unreachable_code)]
 
-use float::Float;
-use int::Int;
+use crate::float::Float;
+use crate::int::Int;
 
 #[derive(Clone, Copy)]
 enum Result {

--- a/src/float/div.rs
+++ b/src/float/div.rs
@@ -2,8 +2,8 @@
 // `return`s makes it clear where function exit points are
 #![allow(clippy::needless_return)]
 
-use float::Float;
-use int::{CastInto, DInt, HInt, Int};
+use crate::float::Float;
+use crate::int::{CastInto, DInt, HInt, Int};
 
 fn div32<F: Float>(a: F, b: F) -> F
 where

--- a/src/float/extend.rs
+++ b/src/float/extend.rs
@@ -1,5 +1,5 @@
-use float::Float;
-use int::{CastInto, Int};
+use crate::float::Float;
+use crate::int::{CastInto, Int};
 
 /// Generic conversion from a narrower to a wider IEEE-754 floating-point type
 fn extend<F: Float, R: Float>(a: F) -> R

--- a/src/float/mul.rs
+++ b/src/float/mul.rs
@@ -1,5 +1,5 @@
-use float::Float;
-use int::{CastInto, DInt, HInt, Int};
+use crate::float::Float;
+use crate::int::{CastInto, DInt, HInt, Int};
 
 fn mul<F: Float>(a: F, b: F) -> F
 where

--- a/src/float/pow.rs
+++ b/src/float/pow.rs
@@ -1,5 +1,5 @@
-use float::Float;
-use int::Int;
+use crate::float::Float;
+use crate::int::Int;
 
 /// Returns `a` raised to the power `b`
 fn pow<F: Float>(a: F, b: i32) -> F {

--- a/src/float/sub.rs
+++ b/src/float/sub.rs
@@ -1,6 +1,6 @@
-use float::add::__adddf3;
-use float::add::__addsf3;
-use float::Float;
+use crate::float::add::__adddf3;
+use crate::float::add::__addsf3;
+use crate::float::Float;
 
 intrinsics! {
     #[arm_aeabi_alias = __aeabi_fsub]

--- a/src/float/trunc.rs
+++ b/src/float/trunc.rs
@@ -1,5 +1,5 @@
-use float::Float;
-use int::{CastInto, Int};
+use crate::float::Float;
+use crate::int::{CastInto, Int};
 
 fn trunc<F: Float, R: Float>(a: F) -> R
 where

--- a/src/int/addsub.rs
+++ b/src/int/addsub.rs
@@ -1,4 +1,4 @@
-use int::{DInt, Int};
+use crate::int::{DInt, Int};
 
 trait UAddSub: DInt {
     fn uadd(self, other: Self) -> Self {

--- a/src/int/mul.rs
+++ b/src/int/mul.rs
@@ -1,4 +1,4 @@
-use int::{DInt, HInt, Int};
+use crate::int::{DInt, HInt, Int};
 
 trait Mul: DInt
 where

--- a/src/int/sdiv.rs
+++ b/src/int/sdiv.rs
@@ -1,4 +1,4 @@
-use int::udiv::*;
+use crate::int::udiv::*;
 
 macro_rules! sdivmod {
     (

--- a/src/int/shift.rs
+++ b/src/int/shift.rs
@@ -1,4 +1,4 @@
-use int::{DInt, HInt, Int};
+use crate::int::{DInt, HInt, Int};
 
 trait Ashl: DInt {
     /// Returns `a << b`, requires `b < Self::BITS`

--- a/src/int/specialized_div_rem/binary_long.rs
+++ b/src/int/specialized_div_rem/binary_long.rs
@@ -13,9 +13,13 @@ macro_rules! impl_binary_long {
         $n:tt, // the number of bits in a $iX or $uX
         $uX:ident, // unsigned integer type for the inputs and outputs of `$fn`
         $iX:ident // signed integer type with same bitwidth as `$uX`
+        $(, $fun_attr:meta)* // attributes for the function
     ) => {
         /// Computes the quotient and remainder of `duo` divided by `div` and returns them as a
         /// tuple.
+        $(
+            #[$fun_attr]
+        )*
         pub fn $fn(duo: $uX, div: $uX) -> ($uX, $uX) {
             let mut duo = duo;
             // handle edge cases before calling `$normalization_shift`

--- a/src/int/specialized_div_rem/mod.rs
+++ b/src/int/specialized_div_rem/mod.rs
@@ -306,5 +306,6 @@ impl_binary_long!(
     u32_normalization_shift,
     32,
     u32,
-    i32
+    i32,
+    allow(dead_code)
 );

--- a/src/int/udiv.rs
+++ b/src/int/udiv.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "public-test-deps"))]
-pub(crate) use int::specialized_div_rem::*;
+pub(crate) use crate::int::specialized_div_rem::*;
 
 #[cfg(feature = "public-test-deps")]
-pub use int::specialized_div_rem::*;
+pub use crate::int::specialized_div_rem::*;
 
 intrinsics! {
     #[maybe_use_optimized_c_shim]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 #![no_builtins]
 #![no_std]
 #![allow(unused_features)]
+#![allow(internal_features)]
 // We use `u128` in a whole bunch of places which we currently agree with the
 // compiler on ABIs and such, so we should be "good enough" for now and changes
 // to the `u128` ABI will be reflected here.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -321,10 +321,10 @@ macro_rules! intrinsics {
             #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
             #[cfg_attr(feature = "weak-intrinsics", linkage = "weak")]
             pub extern $abi fn $name( $($argname: $ty),* )
-                -> ::macros::win64_128bit_abi_hack::U64x2
+                -> $crate::macros::win64_128bit_abi_hack::U64x2
             {
                 let e: $($ret)? = super::$name($($argname),*);
-                ::macros::win64_128bit_abi_hack::U64x2::from(e)
+                $crate::macros::win64_128bit_abi_hack::U64x2::from(e)
             }
         }
 
@@ -540,7 +540,7 @@ pub mod win64_128bit_abi_hack {
 
     impl From<i128> for U64x2 {
         fn from(i: i128) -> U64x2 {
-            use int::DInt;
+            use crate::int::DInt;
             let j = i as u128;
             U64x2(j.lo(), j.hi())
         }
@@ -548,7 +548,7 @@ pub mod win64_128bit_abi_hack {
 
     impl From<u128> for U64x2 {
         fn from(i: u128) -> U64x2 {
-            use int::DInt;
+            use crate::int::DInt;
             U64x2(i.lo(), i.hi())
         }
     }

--- a/src/math.rs
+++ b/src/math.rs
@@ -2,6 +2,7 @@
 #[path = "../libm/src/math/mod.rs"]
 mod libm;
 
+#[allow(unused_macros)]
 macro_rules! no_mangle {
     ($(fn $fun:ident($($iid:ident : $ity:ty),+) -> $oty:ty;)+) => {
         intrinsics! {


### PR DESCRIPTION
Crate was on 2015 edition, so update to 2018. Can be changed to 2021 (probably not. libm is submodule on 2018 edition, how that worked before?).

Also adds `#![allow(internal_features)]` recently added in https://github.com/rust-lang/rust/pull/108955, without it build stops on recent nightly.