### PR TITLE
build: compile memory intrinsics on xous

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -30,6 +30,7 @@ fn main() {
         || target.contains("-none")
         || target.contains("nvptx")
         || target.contains("uefi")
+        || target.contains("xous")
     {
         println!("cargo:rustc-cfg=feature=\"mem\"");
     }


### PR DESCRIPTION
Like SGX, Xous does not have any libc to link against. As a result, memory intrinsics need to be available as part of `compiler_builtins`

This will enable us to build for Xous as part of `-Zbuild-std` as referenced in https://github.com/rust-lang/rust/pull/104101#discussion_r1288530982