### PR TITLE
Add tvOS to build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -320,6 +320,7 @@ mod c {
         // include them.
         if target_os != "ios"
             && target_os != "watchos"
+            && target_os != "tvos"
             && (target_vendor != "apple" || target_arch != "x86")
         {
             sources.extend(&[
@@ -391,6 +392,7 @@ mod c {
         if target_arch == "arm"
             && target_os != "ios"
             && target_os != "watchos"
+            && target_os != "tvos"
             && target_env != "msvc"
         {
             sources.extend(&[


### PR DESCRIPTION
When trying to dig into the issues I'm seeing with https://github.com/rust-lang/rust/pull/115773

This error:
```
  = note: ld: in ...libcompiler_builtins-dec41db284f76766.rlib(6a598989782b7c87-lse_cas1_relax.o), building for tvOS, but linking in object file built for macOS, file '...libcompiler_builtins-dec41db284f76766.rlib' for architecture arm64
```

Lead me to the this `build.rs`, while these changes haven't solved my issue, I feel like `tvos` should be in the same places as `watchos` and `ios`.