### PR TITLE
intrinsics macro: fix non-weak aeabi generation

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -369,7 +369,7 @@ macro_rules! intrinsics {
         #[cfg(target_arch = "arm")]
         pub mod $alias {
             #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-            #[cfg_attr(any(all(not(windows), not(target_vendor="apple"), feature = "weak-intrinsics")), linkage = "weak")]
+            #[cfg_attr(any(all(not(windows), not(target_vendor="apple")), feature = "weak-intrinsics"), linkage = "weak")]
             pub extern "aapcs" fn $alias( $($argname: $ty),* ) $(-> $ret)? {
                 super::$name($($argname),*)
             }


### PR DESCRIPTION
When the `weak-intrinsics` feature landed in https://github.com/rust-lang/compiler-builtins/pull/526, my reading of the intent as [described in the issue](https://github.com/rust-lang/compiler-builtins/issues/525#issuecomment-1555281382) is that the `weak-intrinsics` feature is to be disabled by default, and that when disabled it should essentially be a no-op / no outwardly observable change (though I could be mistaken).

Taking a look at [this particular line](https://github.com/rust-lang/compiler-builtins/pull/526/files#diff-315c02cd05738da173861537577d159833f70f79cfda8cd7cf1a0d7a28ace31bR371), a hypothesis is that this was a typo in terms of parenthesis placement, as we can see that the output of `cargo expand float --target arm-unknown-linux-musleabi` changes before / after that change landed:
- [Before](https://github.com/rust-lang/compiler-builtins/commit/4677881d50f2e2f44ae7720ce19366a78fdf0e77)
- [After](https://github.com/rust-lang/compiler-builtins/commit/af540c9db270987664540fb072ac9366414306d5)

<details>
<summary>
diff between before / after
</summary>

```diff
***************
*** 145,184 ****
          #[cfg(target_arch = "arm")]
          pub mod __addsf3 {
              #[no_mangle]
              pub extern "aapcs" fn __addsf3(a: f32, b: f32) -> f32 {
                  super::__addsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_fadd {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_fadd(a: f32, b: f32) -> f32 {
                  super::__addsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "aapcs" fn __adddf3(a: f64, b: f64) -> f64 {
              add(a, b)
          }
          #[cfg(target_arch = "arm")]
          pub mod __adddf3 {
              #[no_mangle]
              pub extern "aapcs" fn __adddf3(a: f64, b: f64) -> f64 {
                  super::__adddf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_dadd {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_dadd(a: f64, b: f64) -> f64 {
                  super::__adddf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __addsf3vfp(a: f32, b: f32) -> f32 {
              a + b
          }
          pub mod __addsf3vfp {
              #[cfg(target_arch = "arm")]
--- 145,182 ----
***************
*** 309,329 ****
          #[cfg(target_arch = "arm")]
          pub mod __unordsf2 {
              #[no_mangle]
              pub extern "C" fn __unordsf2(a: f32, b: f32) -> i32 {
                  super::__unordsf2(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_fcmpun {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_fcmpun(a: f32, b: f32) -> i32 {
                  super::__unordsf2(a, b)
              }
          }
          pub extern "C" fn __eqsf2(a: f32, b: f32) -> i32 {
              cmp(a, b).to_le_abi()
          }
          pub mod __eqsf2 {
              #[no_mangle]
              pub extern "C" fn __eqsf2(a: f32, b: f32) -> i32 {
--- 307,326 ----
***************
*** 382,402 ****
          #[cfg(target_arch = "arm")]
          pub mod __unorddf2 {
              #[no_mangle]
              pub extern "C" fn __unorddf2(a: f64, b: f64) -> i32 {
                  super::__unorddf2(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_dcmpun {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_dcmpun(a: f64, b: f64) -> i32 {
                  super::__unorddf2(a, b)
              }
          }
          pub extern "C" fn __eqdf2(a: f64, b: f64) -> i32 {
              cmp(a, b).to_le_abi()
          }
          pub mod __eqdf2 {
              #[no_mangle]
              pub extern "C" fn __eqdf2(a: f64, b: f64) -> i32 {
--- 379,398 ----
***************
*** 703,780 ****
          #[cfg(target_arch = "arm")]
          pub mod __floatunsisf {
              #[no_mangle]
              pub extern "C" fn __floatunsisf(i: u32) -> f32 {
                  super::__floatunsisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_ui2f {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_ui2f(i: u32) -> f32 {
                  super::__floatunsisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __floatunsidf(i: u32) -> f64 {
              f64::from_bits(int_to_float::u32_to_f64_bits(i))
          }
          #[cfg(target_arch = "arm")]
          pub mod __floatunsidf {
              #[no_mangle]
              pub extern "C" fn __floatunsidf(i: u32) -> f64 {
                  super::__floatunsidf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_ui2d {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_ui2d(i: u32) -> f64 {
                  super::__floatunsidf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __floatundisf(i: u64) -> f32 {
              f32::from_bits(int_to_float::u64_to_f32_bits(i))
          }
          #[cfg(target_arch = "arm")]
          pub mod __floatundisf {
              #[no_mangle]
              pub extern "C" fn __floatundisf(i: u64) -> f32 {
                  super::__floatundisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_ul2f {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_ul2f(i: u64) -> f32 {
                  super::__floatundisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __floatundidf(i: u64) -> f64 {
              f64::from_bits(int_to_float::u64_to_f64_bits(i))
          }
          #[cfg(target_arch = "arm")]
          pub mod __floatundidf {
              #[no_mangle]
              pub extern "C" fn __floatundidf(i: u64) -> f64 {
                  super::__floatundidf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_ul2d {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_ul2d(i: u64) -> f64 {
                  super::__floatundidf(i)
              }
          }
          pub extern "C" fn __floatuntisf(i: u128) -> f32 {
              f32::from_bits(int_to_float::u128_to_f32_bits(i))
          }
          pub mod __floatuntisf {
              #[no_mangle]
              pub extern "C" fn __floatuntisf(i: u128) -> f32 {
--- 699,772 ----
***************
*** 798,878 ****
          #[cfg(target_arch = "arm")]
          pub mod __floatsisf {
              #[no_mangle]
              pub extern "C" fn __floatsisf(i: i32) -> f32 {
                  super::__floatsisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_i2f {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_i2f(i: i32) -> f32 {
                  super::__floatsisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __floatsidf(i: i32) -> f64 {
              let sign_bit = ((i >> 31) as u64) << 63;
              f64::from_bits(int_to_float::u32_to_f64_bits(i.unsigned_abs()) | sign_bit)
          }
          #[cfg(target_arch = "arm")]
          pub mod __floatsidf {
              #[no_mangle]
              pub extern "C" fn __floatsidf(i: i32) -> f64 {
                  super::__floatsidf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_i2d {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_i2d(i: i32) -> f64 {
                  super::__floatsidf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __floatdisf(i: i64) -> f32 {
              let sign_bit = ((i >> 63) as u32) << 31;
              f32::from_bits(int_to_float::u64_to_f32_bits(i.unsigned_abs()) | sign_bit)
          }
          #[cfg(target_arch = "arm")]
          pub mod __floatdisf {
              #[no_mangle]
              pub extern "C" fn __floatdisf(i: i64) -> f32 {
                  super::__floatdisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_l2f {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_l2f(i: i64) -> f32 {
                  super::__floatdisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __floatdidf(i: i64) -> f64 {
              let sign_bit = ((i >> 63) as u64) << 63;
              f64::from_bits(int_to_float::u64_to_f64_bits(i.unsigned_abs()) | sign_bit)
          }
          #[cfg(target_arch = "arm")]
          pub mod __floatdidf {
              #[no_mangle]
              pub extern "C" fn __floatdidf(i: i64) -> f64 {
                  super::__floatdidf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_l2d {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_l2d(i: i64) -> f64 {
                  super::__floatdidf(i)
              }
          }
          pub extern "C" fn __floattisf(i: i128) -> f32 {
              let sign_bit = ((i >> 127) as u32) << 31;
              f32::from_bits(int_to_float::u128_to_f32_bits(i.unsigned_abs()) | sign_bit)
          }
          pub mod __floattisf {
              #[no_mangle]
--- 790,866 ----
***************
*** 908,928 ****
          #[cfg(target_arch = "arm")]
          pub mod __fixunssfsi {
              #[no_mangle]
              pub extern "C" fn __fixunssfsi(f: f32) -> u32 {
                  super::__fixunssfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_f2uiz {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_f2uiz(f: f32) -> u32 {
                  super::__fixunssfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __fixunssfdi(f: f32) -> u64 {
              let fbits = f.to_bits();
              if fbits < 127 << 23 {
                  0
              } else if fbits < 191 << 23 {
--- 896,915 ----
***************
*** 938,958 ****
          #[cfg(target_arch = "arm")]
          pub mod __fixunssfdi {
              #[no_mangle]
              pub extern "C" fn __fixunssfdi(f: f32) -> u64 {
                  super::__fixunssfdi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_f2ulz {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_f2ulz(f: f32) -> u64 {
                  super::__fixunssfdi(f)
              }
          }
          pub extern "C" fn __fixunssfti(f: f32) -> u128 {
              let fbits = f.to_bits();
              if fbits < 127 << 23 {
                  0
              } else if fbits < 255 << 23 {
                  let m = 1 << 127 | (fbits as u128) << 104;
--- 925,944 ----
***************
*** 988,1008 ****
          #[cfg(target_arch = "arm")]
          pub mod __fixunsdfsi {
              #[no_mangle]
              pub extern "C" fn __fixunsdfsi(f: f64) -> u32 {
                  super::__fixunsdfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_d2uiz {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_d2uiz(f: f64) -> u32 {
                  super::__fixunsdfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __fixunsdfdi(f: f64) -> u64 {
              let fbits = f.to_bits();
              if fbits < 1023 << 52 {
                  0
              } else if fbits < 1087 << 52 {
--- 974,993 ----
***************
*** 1018,1038 ****
          #[cfg(target_arch = "arm")]
          pub mod __fixunsdfdi {
              #[no_mangle]
              pub extern "C" fn __fixunsdfdi(f: f64) -> u64 {
                  super::__fixunsdfdi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_d2ulz {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_d2ulz(f: f64) -> u64 {
                  super::__fixunsdfdi(f)
              }
          }
          pub extern "C" fn __fixunsdfti(f: f64) -> u128 {
              let fbits = f.to_bits();
              if fbits < 1023 << 52 {
                  0
              } else if fbits < 1151 << 52 {
                  let m = 1 << 127 | (fbits as u128) << 75;
--- 1003,1022 ----
***************
*** 1069,1089 ****
          #[cfg(target_arch = "arm")]
          pub mod __fixsfsi {
              #[no_mangle]
              pub extern "C" fn __fixsfsi(f: f32) -> i32 {
                  super::__fixsfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_f2iz {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_f2iz(f: f32) -> i32 {
                  super::__fixsfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __fixsfdi(f: f32) -> i64 {
              let fbits = f.to_bits() & !0 >> 1;
              if fbits < 127 << 23 {
                  0
              } else if fbits < 190 << 23 {
--- 1053,1072 ----
***************
*** 1100,1120 ****
          #[cfg(target_arch = "arm")]
          pub mod __fixsfdi {
              #[no_mangle]
              pub extern "C" fn __fixsfdi(f: f32) -> i64 {
                  super::__fixsfdi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_f2lz {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_f2lz(f: f32) -> i64 {
                  super::__fixsfdi(f)
              }
          }
          pub extern "C" fn __fixsfti(f: f32) -> i128 {
              let fbits = f.to_bits() & !0 >> 1;
              if fbits < 127 << 23 {
                  0
              } else if fbits < 254 << 23 {
                  let m = 1 << 127 | (fbits as u128) << 104;
--- 1083,1102 ----
***************
*** 1152,1172 ****
          #[cfg(target_arch = "arm")]
          pub mod __fixdfsi {
              #[no_mangle]
              pub extern "C" fn __fixdfsi(f: f64) -> i32 {
                  super::__fixdfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_d2iz {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_d2iz(f: f64) -> i32 {
                  super::__fixdfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __fixdfdi(f: f64) -> i64 {
              let fbits = f.to_bits() & !0 >> 1;
              if fbits < 1023 << 52 {
                  0
              } else if fbits < 1086 << 52 {
--- 1134,1153 ----
***************
*** 1183,1203 ****
          #[cfg(target_arch = "arm")]
          pub mod __fixdfdi {
              #[no_mangle]
              pub extern "C" fn __fixdfdi(f: f64) -> i64 {
                  super::__fixdfdi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_d2lz {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_d2lz(f: f64) -> i64 {
                  super::__fixdfdi(f)
              }
          }
          pub extern "C" fn __fixdfti(f: f64) -> i128 {
              let fbits = f.to_bits() & !0 >> 1;
              if fbits < 1023 << 52 {
                  0
              } else if fbits < 1150 << 52 {
                  let m = 1 << 127 | (fbits as u128) << 75;
--- 1164,1183 ----
***************
*** 1487,1526 ****
          #[cfg(target_arch = "arm")]
          pub mod __divsf3 {
              #[no_mangle]
              pub extern "C" fn __divsf3(a: f32, b: f32) -> f32 {
                  super::__divsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_fdiv {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_fdiv(a: f32, b: f32) -> f32 {
                  super::__divsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __divdf3(a: f64, b: f64) -> f64 {
              div64(a, b)
          }
          #[cfg(target_arch = "arm")]
          pub mod __divdf3 {
              #[no_mangle]
              pub extern "C" fn __divdf3(a: f64, b: f64) -> f64 {
                  super::__divdf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_ddiv {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_ddiv(a: f64, b: f64) -> f64 {
                  super::__divdf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __divsf3vfp(a: f32, b: f32) -> f32 {
              a / b
          }
          pub mod __divsf3vfp {
              #[cfg(target_arch = "arm")]
--- 1467,1504 ----
***************
*** 1607,1627 ****
          #[cfg(target_arch = "arm")]
          pub mod __extendsfdf2 {
              #[no_mangle]
              pub extern "aapcs" fn __extendsfdf2(a: f32) -> f64 {
                  super::__extendsfdf2(a)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_f2d {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_f2d(a: f32) -> f64 {
                  super::__extendsfdf2(a)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __extendsfdf2vfp(a: f32) -> f64 {
              a as f64
          }
          pub mod __extendsfdf2vfp {
              #[cfg(target_arch = "arm")]
--- 1585,1604 ----
***************
*** 1764,1803 ****
          #[cfg(target_arch = "arm")]
          pub mod __mulsf3 {
              #[no_mangle]
              pub extern "aapcs" fn __mulsf3(a: f32, b: f32) -> f32 {
                  super::__mulsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_fmul {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_fmul(a: f32, b: f32) -> f32 {
                  super::__mulsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "aapcs" fn __muldf3(a: f64, b: f64) -> f64 {
              mul(a, b)
          }
          #[cfg(target_arch = "arm")]
          pub mod __muldf3 {
              #[no_mangle]
              pub extern "aapcs" fn __muldf3(a: f64, b: f64) -> f64 {
                  super::__muldf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_dmul {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_dmul(a: f64, b: f64) -> f64 {
                  super::__muldf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __mulsf3vfp(a: f32, b: f32) -> f32 {
              a * b
          }
          pub mod __mulsf3vfp {
              #[cfg(target_arch = "arm")]
--- 1741,1778 ----
***************
*** 1869,1908 ****
          #[cfg(target_arch = "arm")]
          pub mod __subsf3 {
              #[no_mangle]
              pub extern "C" fn __subsf3(a: f32, b: f32) -> f32 {
                  super::__subsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_fsub {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_fsub(a: f32, b: f32) -> f32 {
                  super::__subsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __subdf3(a: f64, b: f64) -> f64 {
              __adddf3(a, f64::from_repr(b.repr() ^ f64::SIGN_MASK))
          }
          #[cfg(target_arch = "arm")]
          pub mod __subdf3 {
              #[no_mangle]
              pub extern "C" fn __subdf3(a: f64, b: f64) -> f64 {
                  super::__subdf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_dsub {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_dsub(a: f64, b: f64) -> f64 {
                  super::__subdf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __subsf3vfp(a: f32, b: f32) -> f32 {
              a - b
          }
          pub mod __subsf3vfp {
              #[cfg(target_arch = "arm")]
--- 1844,1881 ----
***************
*** 2019,2039 ****
          #[cfg(target_arch = "arm")]
          pub mod __truncdfsf2 {
              #[no_mangle]
              pub extern "aapcs" fn __truncdfsf2(a: f64) -> f32 {
                  super::__truncdfsf2(a)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_d2f {
              #[no_mangle]
-             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_d2f(a: f64) -> f32 {
                  super::__truncdfsf2(a)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __truncdfsf2vfp(a: f64) -> f32 {
              a as f32
          }
          pub mod __truncdfsf2vfp {
              #[cfg(target_arch = "arm")]
--- 1992,2011 ----

```
</details>

We encountered this when attempting to update a project from rust 1.70 -> 1.71, where [1.71 pulled in](https://github.com/rust-lang/rust/commit/0e89b1b5feb0fbcab01ee2a49f61df3b91df13a9) `compiler-builtins` 0.1.92 / the aforementioned change.  **I've excised some of the output** so this is not the full contents, but we essentially see this error at link time:
```
In function `__aeabi_fsub':
libgcc/config/arm/ieee754-sf.S:65: multiple definition of `__aeabi_fsub'
(compiler_builtins-96d2e1afe42011d5.compiler_builtins.2dcd5efbeb8186c6-cgu.167.rcgu.o):/cargo/registry/src/index.crates.io-6f17d22bba15001f/compiler_builtins-0.1.92/src/float/sub.rs:8: first defined here
```

And that error is repeated for `__aeabi_fadd`, `__aeabi_ui2f`, `__aeabi_ul2f`, `__aeabi_l2f`.

We can see that when applying the fix in this PR that this undoes the delta from above:
<details>
<summary>
diff between current / fix
</summary>

```diff
***************
*** 145,182 ****
--- 145,184 ----
          #[cfg(target_arch = "arm")]
          pub mod __addsf3 {
              #[no_mangle]
              pub extern "aapcs" fn __addsf3(a: f32, b: f32) -> f32 {
                  super::__addsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_fadd {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_fadd(a: f32, b: f32) -> f32 {
                  super::__addsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "aapcs" fn __adddf3(a: f64, b: f64) -> f64 {
              add(a, b)
          }
          #[cfg(target_arch = "arm")]
          pub mod __adddf3 {
              #[no_mangle]
              pub extern "aapcs" fn __adddf3(a: f64, b: f64) -> f64 {
                  super::__adddf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_dadd {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_dadd(a: f64, b: f64) -> f64 {
                  super::__adddf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __addsf3vfp(a: f32, b: f32) -> f32 {
              a + b
          }
          pub mod __addsf3vfp {
              #[cfg(target_arch = "arm")]
***************
*** 307,326 ****
--- 309,329 ----
          #[cfg(target_arch = "arm")]
          pub mod __unordsf2 {
              #[no_mangle]
              pub extern "C" fn __unordsf2(a: f32, b: f32) -> i32 {
                  super::__unordsf2(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_fcmpun {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_fcmpun(a: f32, b: f32) -> i32 {
                  super::__unordsf2(a, b)
              }
          }
          pub extern "C" fn __eqsf2(a: f32, b: f32) -> i32 {
              cmp(a, b).to_le_abi()
          }
          pub mod __eqsf2 {
              #[no_mangle]
              pub extern "C" fn __eqsf2(a: f32, b: f32) -> i32 {
***************
*** 379,398 ****
--- 382,402 ----
          #[cfg(target_arch = "arm")]
          pub mod __unorddf2 {
              #[no_mangle]
              pub extern "C" fn __unorddf2(a: f64, b: f64) -> i32 {
                  super::__unorddf2(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_dcmpun {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_dcmpun(a: f64, b: f64) -> i32 {
                  super::__unorddf2(a, b)
              }
          }
          pub extern "C" fn __eqdf2(a: f64, b: f64) -> i32 {
              cmp(a, b).to_le_abi()
          }
          pub mod __eqdf2 {
              #[no_mangle]
              pub extern "C" fn __eqdf2(a: f64, b: f64) -> i32 {
***************
*** 699,772 ****
--- 703,780 ----
          #[cfg(target_arch = "arm")]
          pub mod __floatunsisf {
              #[no_mangle]
              pub extern "C" fn __floatunsisf(i: u32) -> f32 {
                  super::__floatunsisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_ui2f {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_ui2f(i: u32) -> f32 {
                  super::__floatunsisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __floatunsidf(i: u32) -> f64 {
              f64::from_bits(int_to_float::u32_to_f64_bits(i))
          }
          #[cfg(target_arch = "arm")]
          pub mod __floatunsidf {
              #[no_mangle]
              pub extern "C" fn __floatunsidf(i: u32) -> f64 {
                  super::__floatunsidf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_ui2d {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_ui2d(i: u32) -> f64 {
                  super::__floatunsidf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __floatundisf(i: u64) -> f32 {
              f32::from_bits(int_to_float::u64_to_f32_bits(i))
          }
          #[cfg(target_arch = "arm")]
          pub mod __floatundisf {
              #[no_mangle]
              pub extern "C" fn __floatundisf(i: u64) -> f32 {
                  super::__floatundisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_ul2f {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_ul2f(i: u64) -> f32 {
                  super::__floatundisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __floatundidf(i: u64) -> f64 {
              f64::from_bits(int_to_float::u64_to_f64_bits(i))
          }
          #[cfg(target_arch = "arm")]
          pub mod __floatundidf {
              #[no_mangle]
              pub extern "C" fn __floatundidf(i: u64) -> f64 {
                  super::__floatundidf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_ul2d {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_ul2d(i: u64) -> f64 {
                  super::__floatundidf(i)
              }
          }
          pub extern "C" fn __floatuntisf(i: u128) -> f32 {
              f32::from_bits(int_to_float::u128_to_f32_bits(i))
          }
          pub mod __floatuntisf {
              #[no_mangle]
              pub extern "C" fn __floatuntisf(i: u128) -> f32 {
***************
*** 790,866 ****
--- 798,878 ----
          #[cfg(target_arch = "arm")]
          pub mod __floatsisf {
              #[no_mangle]
              pub extern "C" fn __floatsisf(i: i32) -> f32 {
                  super::__floatsisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_i2f {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_i2f(i: i32) -> f32 {
                  super::__floatsisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __floatsidf(i: i32) -> f64 {
              let sign_bit = ((i >> 31) as u64) << 63;
              f64::from_bits(int_to_float::u32_to_f64_bits(i.unsigned_abs()) | sign_bit)
          }
          #[cfg(target_arch = "arm")]
          pub mod __floatsidf {
              #[no_mangle]
              pub extern "C" fn __floatsidf(i: i32) -> f64 {
                  super::__floatsidf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_i2d {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_i2d(i: i32) -> f64 {
                  super::__floatsidf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __floatdisf(i: i64) -> f32 {
              let sign_bit = ((i >> 63) as u32) << 31;
              f32::from_bits(int_to_float::u64_to_f32_bits(i.unsigned_abs()) | sign_bit)
          }
          #[cfg(target_arch = "arm")]
          pub mod __floatdisf {
              #[no_mangle]
              pub extern "C" fn __floatdisf(i: i64) -> f32 {
                  super::__floatdisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_l2f {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_l2f(i: i64) -> f32 {
                  super::__floatdisf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __floatdidf(i: i64) -> f64 {
              let sign_bit = ((i >> 63) as u64) << 63;
              f64::from_bits(int_to_float::u64_to_f64_bits(i.unsigned_abs()) | sign_bit)
          }
          #[cfg(target_arch = "arm")]
          pub mod __floatdidf {
              #[no_mangle]
              pub extern "C" fn __floatdidf(i: i64) -> f64 {
                  super::__floatdidf(i)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_l2d {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_l2d(i: i64) -> f64 {
                  super::__floatdidf(i)
              }
          }
          pub extern "C" fn __floattisf(i: i128) -> f32 {
              let sign_bit = ((i >> 127) as u32) << 31;
              f32::from_bits(int_to_float::u128_to_f32_bits(i.unsigned_abs()) | sign_bit)
          }
          pub mod __floattisf {
              #[no_mangle]
***************
*** 896,915 ****
--- 908,928 ----
          #[cfg(target_arch = "arm")]
          pub mod __fixunssfsi {
              #[no_mangle]
              pub extern "C" fn __fixunssfsi(f: f32) -> u32 {
                  super::__fixunssfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_f2uiz {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_f2uiz(f: f32) -> u32 {
                  super::__fixunssfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __fixunssfdi(f: f32) -> u64 {
              let fbits = f.to_bits();
              if fbits < 127 << 23 {
                  0
              } else if fbits < 191 << 23 {
***************
*** 925,944 ****
--- 938,958 ----
          #[cfg(target_arch = "arm")]
          pub mod __fixunssfdi {
              #[no_mangle]
              pub extern "C" fn __fixunssfdi(f: f32) -> u64 {
                  super::__fixunssfdi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_f2ulz {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_f2ulz(f: f32) -> u64 {
                  super::__fixunssfdi(f)
              }
          }
          pub extern "C" fn __fixunssfti(f: f32) -> u128 {
              let fbits = f.to_bits();
              if fbits < 127 << 23 {
                  0
              } else if fbits < 255 << 23 {
                  let m = 1 << 127 | (fbits as u128) << 104;
***************
*** 974,993 ****
--- 988,1008 ----
          #[cfg(target_arch = "arm")]
          pub mod __fixunsdfsi {
              #[no_mangle]
              pub extern "C" fn __fixunsdfsi(f: f64) -> u32 {
                  super::__fixunsdfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_d2uiz {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_d2uiz(f: f64) -> u32 {
                  super::__fixunsdfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __fixunsdfdi(f: f64) -> u64 {
              let fbits = f.to_bits();
              if fbits < 1023 << 52 {
                  0
              } else if fbits < 1087 << 52 {
***************
*** 1003,1022 ****
--- 1018,1038 ----
          #[cfg(target_arch = "arm")]
          pub mod __fixunsdfdi {
              #[no_mangle]
              pub extern "C" fn __fixunsdfdi(f: f64) -> u64 {
                  super::__fixunsdfdi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_d2ulz {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_d2ulz(f: f64) -> u64 {
                  super::__fixunsdfdi(f)
              }
          }
          pub extern "C" fn __fixunsdfti(f: f64) -> u128 {
              let fbits = f.to_bits();
              if fbits < 1023 << 52 {
                  0
              } else if fbits < 1151 << 52 {
                  let m = 1 << 127 | (fbits as u128) << 75;
***************
*** 1053,1072 ****
--- 1069,1089 ----
          #[cfg(target_arch = "arm")]
          pub mod __fixsfsi {
              #[no_mangle]
              pub extern "C" fn __fixsfsi(f: f32) -> i32 {
                  super::__fixsfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_f2iz {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_f2iz(f: f32) -> i32 {
                  super::__fixsfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __fixsfdi(f: f32) -> i64 {
              let fbits = f.to_bits() & !0 >> 1;
              if fbits < 127 << 23 {
                  0
              } else if fbits < 190 << 23 {
***************
*** 1083,1102 ****
--- 1100,1120 ----
          #[cfg(target_arch = "arm")]
          pub mod __fixsfdi {
              #[no_mangle]
              pub extern "C" fn __fixsfdi(f: f32) -> i64 {
                  super::__fixsfdi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_f2lz {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_f2lz(f: f32) -> i64 {
                  super::__fixsfdi(f)
              }
          }
          pub extern "C" fn __fixsfti(f: f32) -> i128 {
              let fbits = f.to_bits() & !0 >> 1;
              if fbits < 127 << 23 {
                  0
              } else if fbits < 254 << 23 {
                  let m = 1 << 127 | (fbits as u128) << 104;
***************
*** 1134,1153 ****
--- 1152,1172 ----
          #[cfg(target_arch = "arm")]
          pub mod __fixdfsi {
              #[no_mangle]
              pub extern "C" fn __fixdfsi(f: f64) -> i32 {
                  super::__fixdfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_d2iz {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_d2iz(f: f64) -> i32 {
                  super::__fixdfsi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __fixdfdi(f: f64) -> i64 {
              let fbits = f.to_bits() & !0 >> 1;
              if fbits < 1023 << 52 {
                  0
              } else if fbits < 1086 << 52 {
***************
*** 1164,1183 ****
--- 1183,1203 ----
          #[cfg(target_arch = "arm")]
          pub mod __fixdfdi {
              #[no_mangle]
              pub extern "C" fn __fixdfdi(f: f64) -> i64 {
                  super::__fixdfdi(f)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_d2lz {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_d2lz(f: f64) -> i64 {
                  super::__fixdfdi(f)
              }
          }
          pub extern "C" fn __fixdfti(f: f64) -> i128 {
              let fbits = f.to_bits() & !0 >> 1;
              if fbits < 1023 << 52 {
                  0
              } else if fbits < 1150 << 52 {
                  let m = 1 << 127 | (fbits as u128) << 75;
***************
*** 1615,1652 ****
--- 1635,1674 ----
          #[cfg(target_arch = "arm")]
          pub mod __divsf3 {
              #[no_mangle]
              pub extern "C" fn __divsf3(a: f32, b: f32) -> f32 {
                  super::__divsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_fdiv {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_fdiv(a: f32, b: f32) -> f32 {
                  super::__divsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __divdf3(a: f64, b: f64) -> f64 {
              div64(a, b)
          }
          #[cfg(target_arch = "arm")]
          pub mod __divdf3 {
              #[no_mangle]
              pub extern "C" fn __divdf3(a: f64, b: f64) -> f64 {
                  super::__divdf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_ddiv {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_ddiv(a: f64, b: f64) -> f64 {
                  super::__divdf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __divsf3vfp(a: f32, b: f32) -> f32 {
              a / b
          }
          pub mod __divsf3vfp {
              #[cfg(target_arch = "arm")]
***************
*** 1733,1752 ****
--- 1755,1775 ----
          #[cfg(target_arch = "arm")]
          pub mod __extendsfdf2 {
              #[no_mangle]
              pub extern "aapcs" fn __extendsfdf2(a: f32) -> f64 {
                  super::__extendsfdf2(a)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_f2d {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_f2d(a: f32) -> f64 {
                  super::__extendsfdf2(a)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __extendsfdf2vfp(a: f32) -> f64 {
              a as f64
          }
          pub mod __extendsfdf2vfp {
              #[cfg(target_arch = "arm")]
***************
*** 1889,1926 ****
--- 1912,1951 ----
          #[cfg(target_arch = "arm")]
          pub mod __mulsf3 {
              #[no_mangle]
              pub extern "aapcs" fn __mulsf3(a: f32, b: f32) -> f32 {
                  super::__mulsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_fmul {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_fmul(a: f32, b: f32) -> f32 {
                  super::__mulsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "aapcs" fn __muldf3(a: f64, b: f64) -> f64 {
              mul(a, b)
          }
          #[cfg(target_arch = "arm")]
          pub mod __muldf3 {
              #[no_mangle]
              pub extern "aapcs" fn __muldf3(a: f64, b: f64) -> f64 {
                  super::__muldf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_dmul {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_dmul(a: f64, b: f64) -> f64 {
                  super::__muldf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __mulsf3vfp(a: f32, b: f32) -> f32 {
              a * b
          }
          pub mod __mulsf3vfp {
              #[cfg(target_arch = "arm")]
***************
*** 1992,2029 ****
--- 2017,2056 ----
          #[cfg(target_arch = "arm")]
          pub mod __subsf3 {
              #[no_mangle]
              pub extern "C" fn __subsf3(a: f32, b: f32) -> f32 {
                  super::__subsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_fsub {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_fsub(a: f32, b: f32) -> f32 {
                  super::__subsf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __subdf3(a: f64, b: f64) -> f64 {
              __adddf3(a, f64::from_repr(b.repr() ^ f64::SIGN_MASK))
          }
          #[cfg(target_arch = "arm")]
          pub mod __subdf3 {
              #[no_mangle]
              pub extern "C" fn __subdf3(a: f64, b: f64) -> f64 {
                  super::__subdf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_dsub {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_dsub(a: f64, b: f64) -> f64 {
                  super::__subdf3(a, b)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __subsf3vfp(a: f32, b: f32) -> f32 {
              a - b
          }
          pub mod __subsf3vfp {
              #[cfg(target_arch = "arm")]
***************
*** 2140,2159 ****
--- 2167,2187 ----
          #[cfg(target_arch = "arm")]
          pub mod __truncdfsf2 {
              #[no_mangle]
              pub extern "aapcs" fn __truncdfsf2(a: f64) -> f32 {
                  super::__truncdfsf2(a)
              }
          }
          #[cfg(target_arch = "arm")]
          pub mod __aeabi_d2f {
              #[no_mangle]
+             #[linkage = "weak"]
              pub extern "aapcs" fn __aeabi_d2f(a: f64) -> f32 {
                  super::__truncdfsf2(a)
              }
          }
          #[cfg(target_arch = "arm")]
          pub extern "C" fn __truncdfsf2vfp(a: f64) -> f32 {
              a as f32
          }
          pub mod __truncdfsf2vfp {
              #[cfg(target_arch = "arm")]

```
</details>

Also of note is that building a 1.71 rust compiler whose only difference was to pull in this change ended up resolving the multiple definitions error we encountered above.

I'm curious on if there's any prior art in potentially adding automated testing around this fix within `testcrate`, not sure if there are any insightful ideas around this?

If it is preferred I make an issue for this or any other modifications to the contribution process, please just let me know, thanks in advance!