### PR TITLE
Enable src/math for all UEFI targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub mod int;
 #[cfg(any(
     all(target_family = "wasm", target_os = "unknown"),
     all(target_arch = "x86_64", target_os = "none"),
-    all(target_arch = "x86_64", target_os = "uefi"),
+    target_os = "uefi",
     all(target_arch = "arm", target_os = "none"),
     all(target_arch = "xtensa", target_os = "none"),
     all(target_arch = "mips", target_os = "none"),

--- a/src/math.rs
+++ b/src/math.rs
@@ -22,7 +22,7 @@ macro_rules! no_mangle {
         not(target_env = "wasi")
     ),
     target_os = "xous",
-    all(target_arch = "x86_64", target_os = "uefi"),
+    target_os = "uefi",
     all(target_arch = "xtensa", target_os = "none"),
     all(target_vendor = "fortanix", target_env = "sgx")
 ))]
@@ -94,7 +94,7 @@ no_mangle! {
         not(target_env = "wasi")
     ),
     target_os = "xous",
-    all(target_arch = "x86_64", target_os = "uefi"),
+    target_os = "uefi",
     all(target_arch = "xtensa", target_os = "none"),
     all(target_vendor = "fortanix", target_env = "sgx"),
     target_os = "windows"


### PR DESCRIPTION
This fixes various math operations on aarch64-unknown-uefi and i686-unknown-uefi.

Fixes https://github.com/rust-lang/compiler-builtins/issues/490.

See also https://github.com/RazrFalcon/tiny-skia/issues/108