### PR TITLE
This enables math module for riscv32 targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,11 +45,8 @@ pub mod int;
 
 #[cfg(any(
     all(target_family = "wasm", target_os = "unknown"),
-    all(target_arch = "x86_64", target_os = "none"),
     target_os = "uefi",
-    all(target_arch = "arm", target_os = "none"),
-    all(target_arch = "xtensa", target_os = "none"),
-    all(target_arch = "mips", target_os = "none"),
+    target_os = "none",
     target_os = "xous",
     all(target_vendor = "fortanix", target_env = "sgx"),
     target_os = "windows"


### PR DESCRIPTION
This is likely a bug fix since in math.rs there are already config attributes that are mentioning this target.

I was pointed here from https://github.com/esp-rs/esp-hal/issues/881