### PR TITLE
fix: Add (even more) `#[avr_skip]` for floats

### DIFF
--- a/src/float/div.rs
+++ b/src/float/div.rs
@@ -902,11 +902,13 @@ where
 }
 
 intrinsics! {
+    #[avr_skip]
     #[arm_aeabi_alias = __aeabi_fdiv]
     pub extern "C" fn __divsf3(a: f32, b: f32) -> f32 {
         div32(a, b)
     }
 
+    #[avr_skip]
     #[arm_aeabi_alias = __aeabi_ddiv]
     pub extern "C" fn __divdf3(a: f64, b: f64) -> f64 {
         div64(a, b)

--- a/src/float/extend.rs
+++ b/src/float/extend.rs
@@ -70,6 +70,7 @@ where
 }
 
 intrinsics! {
+    #[avr_skip]
     #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_f2d]
     pub extern "C" fn  __extendsfdf2(a: f32) -> f64 {

--- a/src/float/mul.rs
+++ b/src/float/mul.rs
@@ -185,12 +185,14 @@ where
 }
 
 intrinsics! {
+    #[avr_skip]
     #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_fmul]
     pub extern "C" fn __mulsf3(a: f32, b: f32) -> f32 {
         mul(a, b)
     }
 
+    #[avr_skip]
     #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_dmul]
     pub extern "C" fn __muldf3(a: f64, b: f64) -> f64 {

--- a/src/float/pow.rs
+++ b/src/float/pow.rs
@@ -26,10 +26,12 @@ fn pow<F: Float>(a: F, b: i32) -> F {
 }
 
 intrinsics! {
+    #[avr_skip]
     pub extern "C" fn __powisf2(a: f32, b: i32) -> f32 {
         pow(a, b)
     }
 
+    #[avr_skip]
     pub extern "C" fn __powidf2(a: f64, b: i32) -> f64 {
         pow(a, b)
     }

--- a/src/float/sub.rs
+++ b/src/float/sub.rs
@@ -3,11 +3,13 @@ use crate::float::add::__addsf3;
 use crate::float::Float;
 
 intrinsics! {
+    #[avr_skip]
     #[arm_aeabi_alias = __aeabi_fsub]
     pub extern "C" fn __subsf3(a: f32, b: f32) -> f32 {
         __addsf3(a, f32::from_repr(b.repr() ^ f32::SIGN_MASK))
     }
 
+    #[avr_skip]
     #[arm_aeabi_alias = __aeabi_dsub]
     pub extern "C" fn __subdf3(a: f64, b: f64) -> f64 {
         __adddf3(a, f64::from_repr(b.repr() ^ f64::SIGN_MASK))

--- a/src/float/trunc.rs
+++ b/src/float/trunc.rs
@@ -112,6 +112,7 @@ where
 }
 
 intrinsics! {
+    #[avr_skip]
     #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_d2f]
     pub extern "C" fn __truncdfsf2(a: f64) -> f32 {


### PR DESCRIPTION
Tale as old as the world - there's an ABI mismatch: https://github.com/rust-lang/compiler-builtins/pull/527

Fortunately, newest GCCs (from v11, it seems) actually provide most of those intrinsics (even for f64!), so that's pretty cool.

(the only intrinsics not provided by GCC are `__powisf2` & `__powidf2`, but our codegen for AVR doesn't emit those anyway.)

Fixes https://github.com/rust-lang/rust/issues/118079.