### PR TITLE
build: Allow building C compiler-rt fallbacks for wasm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,8 +90,8 @@ jobs:
     - run: rustup component add llvm-tools-preview
     - name: Download compiler-rt reference sources
       run: |
-        curl -L -o code.tar.gz https://github.com/rust-lang/llvm-project/archive/rustc/12.0-2021-04-15.tar.gz
-        tar xzf code.tar.gz --strip-components 1 llvm-project-rustc-12.0-2021-04-15/compiler-rt
+        curl -L -o code.tar.gz https://github.com/rust-lang/llvm-project/archive/rustc/13.0-2021-08-08.tar.gz
+        tar xzf code.tar.gz --strip-components 1 llvm-project-rustc-13.0-2021-08-08/compiler-rt
         echo RUST_COMPILER_RT_ROOT=./compiler-rt >> $GITHUB_ENV
       shell: bash
 

--- a/build.rs
+++ b/build.rs
@@ -56,15 +56,10 @@ fn main() {
     if !cfg!(feature = "mangled-names") && cfg!(feature = "c") {
         // Don't use a C compiler for these targets:
         //
-        // * wasm - clang for wasm is somewhat hard to come by and it's
-        //   unlikely that the C is really that much better than our own Rust.
         // * nvptx - everything is bitcode, not compatible with mixed C/Rust
         // * riscv - the rust-lang/rust distribution container doesn't have a C
         //   compiler.
-        if !target.contains("wasm")
-            && !target.contains("nvptx")
-            && (!target.starts_with("riscv") || target.contains("xous"))
-        {
+        if !target.contains("nvptx") && (!target.starts_with("riscv") || target.contains("xous")) {
             #[cfg(feature = "c")]
             c::compile(&llvm_target, &target);
         }

--- a/ci/docker/wasm32-unknown-unknown/Dockerfile
+++ b/ci/docker/wasm32-unknown-unknown/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    gcc libc6-dev ca-certificates
+    gcc clang libc6-dev ca-certificates
 
 ENV CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=true

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -66,6 +66,7 @@ for rlib in $(echo $path); do
       grep -v __x86.get_pc_thunk | \
       grep -v __builtin_cl | \
       grep -v __builtin_ctz | \
+      grep -v __builtin_sadd_overflow | \
       grep 'T __'
 
     if test $? = 0; then


### PR DESCRIPTION
The comment disabling wasm is almost 5 years old, and is outdated:

```
// * wasm - clang for wasm is somewhat hard to come by and it's
//   unlikely that the C is really that much better than our own Rust.
```

Clang for wasm is now much easier to come by, and C fallbacks are needed for e.g. https://github.com/rust-lang/compiler-builtins/issues/561 and https://github.com/rusqlite/rusqlite/pull/1010

For the `__builtin_sadd_overflow` thing, see https://github.com/llvm/llvm-project/pull/69305 and https://github.com/rust-lang/compiler-builtins/issues/167