### PR TITLE
Only add 80-bit long double source on x86

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -290,17 +290,23 @@ mod c {
             sources.extend(&[
                 ("__divdc3", "divdc3.c"),
                 ("__divsc3", "divsc3.c"),
-                ("__divxc3", "divxc3.c"),
                 ("__extendhfsf2", "extendhfsf2.c"),
                 ("__muldc3", "muldc3.c"),
                 ("__mulsc3", "mulsc3.c"),
-                ("__mulxc3", "mulxc3.c"),
                 ("__negdf2", "negdf2.c"),
                 ("__negsf2", "negsf2.c"),
-                ("__powixf2", "powixf2.c"),
                 ("__truncdfhf2", "truncdfhf2.c"),
                 ("__truncsfhf2", "truncsfhf2.c"),
             ]);
+
+            if target_arch == "x86" || target_arch == "x86_64" {
+                // Only add 80-bit long double sources on x86.
+                sources.extend(&[
+                    ("__divxc3", "divxc3.c"),
+                    ("__mulxc3", "mulxc3.c"),
+                    ("__powixf2", "powixf2.c"),
+                ]);
+            }
         }
 
         // When compiling in rustbuild (the rust-lang/rust repo) this library


### PR DESCRIPTION
These no longer build on other architectures with LLVM 18. In previous versions they used an incorrect float layout.