### PR TITLE
Remove 80-bit builtins entirely

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -296,15 +296,6 @@ mod c {
                 ("__truncdfhf2", "truncdfhf2.c"),
                 ("__truncsfhf2", "truncsfhf2.c"),
             ]);
-
-            if target_arch == "x86" || target_arch == "x86_64" {
-                // Only add 80-bit long double sources on x86.
-                sources.extend(&[
-                    ("__divxc3", "divxc3.c"),
-                    ("__mulxc3", "mulxc3.c"),
-                    ("__powixf2", "powixf2.c"),
-                ]);
-            }
         }
 
         // When compiling in rustbuild (the rust-lang/rust repo) this library

--- a/build.rs
+++ b/build.rs
@@ -347,29 +347,12 @@ mod c {
             ]);
         }
 
-        if target_env == "msvc" {
-            if target_arch == "x86_64" {
-                sources.extend(&[("__floatdixf", "x86_64/floatdixf.c")]);
-            }
-        } else {
-            // None of these seem to be used on x86_64 windows, and they've all
-            // got the wrong ABI anyway, so we want to avoid them.
-            if target_os != "windows" {
-                if target_arch == "x86_64" {
-                    sources.extend(&[
-                        ("__floatdixf", "x86_64/floatdixf.c"),
-                        ("__floatundixf", "x86_64/floatundixf.S"),
-                    ]);
-                }
-            }
-
+        if target_env != "msvc" {
             if target_arch == "x86" {
                 sources.extend(&[
                     ("__ashldi3", "i386/ashldi3.S"),
                     ("__ashrdi3", "i386/ashrdi3.S"),
                     ("__divdi3", "i386/divdi3.S"),
-                    ("__floatdixf", "i386/floatdixf.S"),
-                    ("__floatundixf", "i386/floatundixf.S"),
                     ("__lshrdi3", "i386/lshrdi3.S"),
                     ("__moddi3", "i386/moddi3.S"),
                     ("__muldi3", "i386/muldi3.S"),


### PR DESCRIPTION
It turns out that these also don't build on x86 + MSVC. Rather than fixing up the condition, I'm just deleting them entirely. As far as I know, Rust does not support 80-bit floats and has no plan to support them, so we shouldn't need these builtins at all.