### PR TITLE
Always have math functions but with `weak` linking attribute if we can

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -16,6 +16,7 @@ macro_rules! no_mangle {
     }
 }
 
+#[cfg(all(not(windows), not(target_vendor = "apple")))]
 no_mangle! {
     fn acos(x: f64) -> f64;
     fn asin(x: f64) -> f64;

--- a/src/math.rs
+++ b/src/math.rs
@@ -7,6 +7,7 @@ macro_rules! no_mangle {
     ($(fn $fun:ident($($iid:ident : $ity:ty),+) -> $oty:ty;)+) => {
         intrinsics! {
             $(
+                #[cfg_attr(all(not(windows), not(target_vendor = "apple")), weak)]
                 pub extern "C" fn $fun($($iid: $ity),+) -> $oty {
                     self::libm::$fun($($iid),+)
                 }
@@ -15,17 +16,6 @@ macro_rules! no_mangle {
     }
 }
 
-#[cfg(any(
-    all(
-        target_family = "wasm",
-        target_os = "unknown",
-        not(target_env = "wasi")
-    ),
-    target_os = "xous",
-    target_os = "uefi",
-    all(target_arch = "xtensa", target_os = "none"),
-    all(target_vendor = "fortanix", target_env = "sgx")
-))]
 no_mangle! {
     fn acos(x: f64) -> f64;
     fn asin(x: f64) -> f64;
@@ -41,10 +31,6 @@ no_mangle! {
     fn log10f(x: f32) -> f32;
     fn log(x: f64) -> f64;
     fn logf(x: f32) -> f32;
-    fn fmin(x: f64, y: f64) -> f64;
-    fn fminf(x: f32, y: f32) -> f32;
-    fn fmax(x: f64, y: f64) -> f64;
-    fn fmaxf(x: f32, y: f32) -> f32;
     fn round(x: f64) -> f64;
     fn roundf(x: f32) -> f32;
     fn rint(x: f64) -> f64;
@@ -52,8 +38,6 @@ no_mangle! {
     fn sin(x: f64) -> f64;
     fn pow(x: f64, y: f64) -> f64;
     fn powf(x: f32, y: f32) -> f32;
-    fn fmod(x: f64, y: f64) -> f64;
-    fn fmodf(x: f32, y: f32) -> f32;
     fn acosf(n: f32) -> f32;
     fn atan2f(a: f32, b: f32) -> f32;
     fn atanf(n: f32) -> f32;
@@ -85,67 +69,17 @@ no_mangle! {
     fn cbrtf(n: f32) -> f32;
     fn hypotf(x: f32, y: f32) -> f32;
     fn tanf(n: f32) -> f32;
-}
 
-#[cfg(any(
-    all(
-        target_family = "wasm",
-        target_os = "unknown",
-        not(target_env = "wasi")
-    ),
-    target_os = "xous",
-    target_os = "uefi",
-    all(target_arch = "xtensa", target_os = "none"),
-    all(target_vendor = "fortanix", target_env = "sgx"),
-    target_os = "windows"
-))]
-intrinsics! {
-    pub extern "C" fn lgamma_r(x: f64, s: &mut i32) -> f64 {
-        let r = self::libm::lgamma_r(x);
-        *s = r.1;
-        r.0
-    }
-
-    pub extern "C" fn lgammaf_r(x: f32, s: &mut i32) -> f32 {
-        let r = self::libm::lgammaf_r(x);
-        *s = r.1;
-        r.0
-    }
-}
-
-#[cfg(any(
-    target_os = "xous",
-    target_os = "uefi",
-    all(target_arch = "xtensa", target_os = "none"),
-))]
-no_mangle! {
     fn sqrtf(x: f32) -> f32;
     fn sqrt(x: f64) -> f64;
-}
 
-#[cfg(any(
-    all(target_vendor = "fortanix", target_env = "sgx"),
-    all(target_arch = "xtensa", target_os = "none"),
-    target_os = "xous",
-    target_os = "uefi"
-))]
-no_mangle! {
     fn ceil(x: f64) -> f64;
     fn ceilf(x: f32) -> f32;
     fn floor(x: f64) -> f64;
     fn floorf(x: f32) -> f32;
     fn trunc(x: f64) -> f64;
     fn truncf(x: f32) -> f32;
-}
 
-// only for the thumb*-none-eabi*, riscv32*-none-elf, x86_64-unknown-none and mips*-unknown-none targets that lack the floating point instruction set
-#[cfg(any(
-    all(target_arch = "arm", target_os = "none"),
-    all(target_arch = "riscv32", not(target_feature = "f"), target_os = "none"),
-    all(target_arch = "x86_64", target_os = "none"),
-    all(target_arch = "mips", target_os = "none"),
-))]
-no_mangle! {
     fn fmin(x: f64, y: f64) -> f64;
     fn fminf(x: f32, y: f32) -> f32;
     fn fmax(x: f64, y: f64) -> f64;
@@ -154,4 +88,20 @@ no_mangle! {
     fn fmod(x: f64, y: f64) -> f64;
     // `f32 % f32`
     fn fmodf(x: f32, y: f32) -> f32;
+}
+
+intrinsics! {
+    #[cfg_attr(all(not(windows), not(target_vendor = "apple")), weak)]
+    pub extern "C" fn lgamma_r(x: f64, s: &mut i32) -> f64 {
+        let r = self::libm::lgamma_r(x);
+        *s = r.1;
+        r.0
+    }
+
+    #[cfg_attr(all(not(windows), not(target_vendor = "apple")), weak)]
+    pub extern "C" fn lgammaf_r(x: f32, s: &mut i32) -> f32 {
+        let r = self::libm::lgammaf_r(x);
+        *s = r.1;
+        r.0
+    }
 }


### PR DESCRIPTION
This is a replacement for https://github.com/rust-lang/libm/pull/290

This fixes crashes during compilations for targets that don't have math symbols by default.

So, we will provide them libm symbols, but mark it as `weak` (if its supported), so that the linker will choose the system builtin functions, since those are sometimes more optimized.
If the linker couldn't find those, it will go with `libm` implementation.