### PR TITLE
Add support for arm64ec

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -461,7 +461,7 @@ mod c {
             ]);
         }
 
-        if target_arch == "aarch64" && consider_float_intrinsics {
+        if (target_arch == "aarch64" || target_arch == "arm64ec") && consider_float_intrinsics {
             sources.extend(&[
                 ("__comparetf2", "comparetf2.c"),
                 ("__extenddftf2", "extenddftf2.c"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub mod mem;
 #[cfg(target_arch = "arm")]
 pub mod arm;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
 pub mod aarch64;
 
 #[cfg(all(target_arch = "aarch64", target_os = "linux", not(feature = "no-asm"),))]

--- a/testcrate/tests/lse.rs
+++ b/testcrate/tests/lse.rs
@@ -1,5 +1,8 @@
 #![feature(decl_macro)] // so we can use pub(super)
-#![cfg(all(target_arch = "aarch64", not(feature = "no-asm")))]
+#![cfg(all(
+    any(target_arch = "aarch64", target_arch = "arm64ec"),
+    not(feature = "no-asm")
+))]
 
 /// Translate a byte size to a Rust type.
 macro int_ty {


### PR DESCRIPTION
The Rust Compiler has recently added support for ARM64EC (<https://github.com/rust-lang/rust/pull/119199>), so this change adds support for ARM64EC to compiler-builtins by enabling the same code as AArch64.