### PR TITLE
Attempt to fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
         - target: aarch64-unknown-linux-gnu

--- a/ci/docker/thumbv6m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv6m-none-eabi/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get update && \
     gcc libc6-dev ca-certificates \
     gcc-arm-none-eabi \
     libnewlib-arm-none-eabi
-ENV XARGO=1
+ENV NO_STD=1

--- a/ci/docker/thumbv7em-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabi/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get update && \
     gcc libc6-dev ca-certificates \
     gcc-arm-none-eabi \
     libnewlib-arm-none-eabi
-ENV XARGO=1
+ENV NO_STD=1

--- a/ci/docker/thumbv7em-none-eabihf/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabihf/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get update && \
     gcc libc6-dev ca-certificates \
     gcc-arm-none-eabi \
     libnewlib-arm-none-eabi
-ENV XARGO=1
+ENV NO_STD=1

--- a/ci/docker/thumbv7m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7m-none-eabi/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get update && \
     gcc libc6-dev ca-certificates \
     gcc-arm-none-eabi \
     libnewlib-arm-none-eabi
-ENV XARGO=1
+ENV NO_STD=1


### PR DESCRIPTION
Upstream issue: https://github.com/rust-lang/rust/issues/121552

Now that https://github.com/rust-lang/rust/pull/121421 is merged, we are no longer emitting calls to functions in `core` from compiler builtins. However rustc may still codegen such functions, which will make them appear in the `.rlib`. This shouldn't cause issues since the linker will discard these functions as unreachable.