### PR TITLE
add c_unwind feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 #![feature(linkage)]
 #![feature(naked_functions)]
 #![feature(repr_simd)]
+#![feature(c_unwind)]
 #![no_builtins]
 #![no_std]
 #![allow(unused_features)]


### PR DESCRIPTION
The `c_unwind` feature is special in that just enabling the feature has a side-effect of treating all `extern "C"` functions different, in terms of how unwinding is handled. This crate has lots of `extern "C"` functions and is very sensitive to unwinding (in the sense that no panic code may be called from this crate), so it seems like a good idea to ensure that compiler-builtins works with this feature before stabilizing (Cc https://github.com/rust-lang/rust/pull/116088).

So... let's see what all the extra checks in CI here say. This may require a patch like [this](https://github.com/rust-lang/rust/pull/116088/commits/91d98c77a2551e837024dd3d0d428a9fcf3bbae0), or maybe not.

Cc @nbdd0121 