### PR TITLE
add lib.miri.rs file for miri-test-libstd

### DIFF
--- a/src/lib.miri.rs
+++ b/src/lib.miri.rs
@@ -1,0 +1,5 @@
+//! Grep bootstrap for `MIRI_REPLACE_LIBRS_IF_NOT_TEST` to learn what this is about.
+#![no_std]
+#![feature(rustc_private)]
+extern crate compiler_builtins as real;
+pub use real::*;


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/123317 we added `lib.miri.rs` files for core, alloc, and std to enable `cargo miri test` on those crates. Bootstrap has a comment that explains what this is about:
```
            // This hack helps bootstrap run standard library tests in Miri. The issue is as
            // follows: when running `cargo miri test` on libcore, cargo builds a local copy of core
            // and makes it a dependency of the integration test crate. This copy duplicates all the
            // lang items, so the build fails. (Regular testing avoids this because the sysroot is a
            // literal copy of what `cargo build` produces, but since Miri builds its own sysroot
            // this does not work for us.) So we need to make it so that the locally built libcore
            // contains all the items from `core`, but does not re-define them -- we want to replace
            // the entire crate but a re-export of the sysroot crate. We do this by swapping out the
            // source file: if `MIRI_REPLACE_LIBRS_IF_NOT_TEST` is set and we are building a
            // `lib.rs` file, and a `lib.miri.rs` file exists in the same folder, we build that
            // instead. But crucially we only do that for the library, not the test builds.
```

compiler_builtins has the same issue -- it defines global symbols via `extern "C" fn`, and then Miri [complains](https://github.com/rust-lang/miri-test-libstd/issues/59) that the same function is defined multiple times and calls to that function elsewhere are ambiguous.

This can be fixed by adding a lib.miri.rs here as well.

Fixes https://github.com/rust-lang/miri-test-libstd/issues/59