### PR TITLE
Add __chkstk on i686-pc-windows-gnu.

### DIFF
--- a/src/x86.rs
+++ b/src/x86.rs
@@ -14,8 +14,21 @@ intrinsics! {
         target_env = "gnu",
         not(feature = "no-asm")
     ))]
+    pub unsafe extern "C" fn __chkstk() {
+        core::arch::asm!(
+            "jmp __alloca", // Jump to __alloca since fallthrough may be unreliable"
+            options(noreturn, att_syntax)
+        );
+    }
+
+    #[naked]
+    #[cfg(all(
+        windows,
+        target_env = "gnu",
+        not(feature = "no-asm")
+    ))]
     pub unsafe extern "C" fn _alloca() {
-        // _chkstk and _alloca are the same function
+        // __chkstk and _alloca are the same function
         core::arch::asm!(
             "push   %ecx",
             "cmp    $0x1000,%eax",


### PR DESCRIPTION
libLLVMSupport.a(DynamicLibrary.cpp.obj) references `___chkstk`, which is an alias of `__alloca` in libgcc.  This crate provided `__alloca`, but libgcc's implementation was also pulled in by the linker due to the reference to `___chkstk`, causing a multiple definition linker error. Providing that symbol here prevents that.

Fixes #585

The reference to `___chkstk` is due to https://github.com/llvm/llvm-project/blob/ccc02563f4d620d4d29a1cbd2c463871cc54745b/llvm/lib/Support/Windows/explicit_symbols.inc#L16-L18 (or possibly the reference above to `__chkstk` due to i386 name rules adding another underscore), not due to the compiler actually generating calls to it.