### PR TITLE
Add a way to test more targets on non-linux machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.rs.bk
 Cargo.lock
 target
+compiler-rt
+*.tar.gz

--- a/README.md
+++ b/README.md
@@ -78,6 +78,26 @@ features = ["c"]
 [8]: http://en.cppreference.com/w/cpp/language/implicit_conversion
 [9]: https://doc.rust-lang.org/std/primitive.i32.html
 
+## Testing
+
+The easiest way to test locally is using Docker. This can be done by running
+`./ci/run-docker.sh [target]`. If no target is specified, all targets will be
+run.
+
+In order to run the full test suite, you will also need the C compiler runtime
+to test against, located in a directory called `compiler-rt`. This can be
+obtained with the following:
+
+```sh
+curl -L -o rustc-llvm-18.0.tar.gz https://github.com/rust-lang/llvm-project/archive/rustc/18.0-2024-02-13.tar.gz
+tar xzf rustc-llvm-18.0.tar.gz --strip-components 1 llvm-project-rustc-18.0-2024-02-13/compiler-rt
+````
+
+Local targets may also be tested with `./ci/run.sh [target]`.
+
+Note that testing may not work on all hosts, in which cases it is acceptable to
+rely on CI.
+
 ## Progress
 
 - [x] adddf3.c

--- a/build.rs
+++ b/build.rs
@@ -572,7 +572,9 @@ mod c {
         // rust-lang/rust.
         let root = match env::var_os("RUST_COMPILER_RT_ROOT") {
             Some(s) => PathBuf::from(s),
-            None => panic!("RUST_COMPILER_RT_ROOT is not set"),
+            None => {
+                panic!("RUST_COMPILER_RT_ROOT is not set. You may need to download compiler-rt.")
+            }
         };
         if !root.exists() {
             panic!("RUST_COMPILER_RT_ROOT={} does not exist", root.display());

--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc libc6-dev ca-certificates \

--- a/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc libc6-dev ca-certificates \

--- a/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc libc6-dev ca-certificates \

--- a/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc libc6-dev ca-certificates \

--- a/ci/docker/i586-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i586-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc-multilib libc6-dev ca-certificates

--- a/ci/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i686-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc-multilib libc6-dev ca-certificates

--- a/ci/docker/mips-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/mips-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
+++ b/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
+++ b/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/ci/docker/mipsel-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/ci/docker/thumbv6m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv6m-none-eabi/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc libc6-dev ca-certificates \

--- a/ci/docker/thumbv7em-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabi/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc libc6-dev ca-certificates \

--- a/ci/docker/thumbv7em-none-eabihf/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabihf/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc libc6-dev ca-certificates \

--- a/ci/docker/thumbv7m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7m-none-eabi/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc libc6-dev ca-certificates \

--- a/ci/docker/wasm32-unknown-unknown/Dockerfile
+++ b/ci/docker/wasm32-unknown-unknown/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:20.04
+ARG IMAGE=ubuntu:20.04
+FROM $IMAGE
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc clang libc6-dev ca-certificates

--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE=ubuntu:18.04
+FROM $IMAGE
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc libc6-dev ca-certificates

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -3,7 +3,7 @@
 # Small script to run tests for a target (or all targets) inside all the
 # respective docker images.
 
-set -eux
+set -euxo pipefail
 
 run() {
     local target="$1"


### PR DESCRIPTION
Allow using the `rust-lang/rust:nightly` docker image to run tests in cases where the host rust and cargo cannot be used, such as non-linux hosts.

Additionally, prefix image tags and the target directory with `builtins-` to reduce the chance of an accidental conflict, and fix shellcheck warnings.