### PR TITLE
Add a fix for aarch64-darwin and enable it in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+        - target: aarch64-apple-darwin
+          os: macos-14
+          rust: nightly
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-latest
           rust: nightly
@@ -81,6 +84,8 @@ jobs:
           os: windows-latest
           rust: nightly-x86_64-gnu
     steps:
+    - name: Print runner information
+      run: uname -a
     - uses: actions/checkout@v4
       with:
         submodules: true

--- a/testcrate/tests/lse.rs
+++ b/testcrate/tests/lse.rs
@@ -1,8 +1,5 @@
 #![feature(decl_macro)] // so we can use pub(super)
-#![cfg(all(
-    any(target_arch = "aarch64", target_arch = "arm64ec"),
-    not(feature = "no-asm")
-))]
+#![cfg(all(target_arch = "aarch64", target_os = "linux", not(feature = "no-asm")))]
 
 /// Translate a byte size to a Rust type.
 macro int_ty {


### PR DESCRIPTION
This includes two commits:

###  Change aarch64_linux module and lse tests to have the same gating

Trying to run testcrate on non-linux aarch64 currently hits a compilation error. Make this test linux-only, to be consistent with the `aarch64_linux` module that it depends on.

Additionally, enable the `aarch64_linux` module for `target_arch = "arm64ec"` to be the same as these tests.

### Add CI testing for AArch64 Darwin

The Apple ARM silicon has been around for a while now and hopefully will become Rust Tier 1 at some point. Add it to CI since it is distinct enough from aarch64-linux and x86_86-darwin that there may be differences.


