### PR TITLE
Fix math libraries not being linked on some platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,9 +45,6 @@ mod macros;
 pub mod float;
 pub mod int;
 
-// For some reason, we still get clippy error `clippy::deprecated_cfg_attr` even though, we have
-// used `allow(clippy::all)` in the file. So, we are disabling the clippy check for this file.
-#[cfg(not(clippy))]
 pub mod math;
 pub mod mem;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,14 +45,6 @@ mod macros;
 pub mod float;
 pub mod int;
 
-#[cfg(any(
-    all(target_family = "wasm", target_os = "unknown"),
-    target_os = "uefi",
-    target_os = "none",
-    target_os = "xous",
-    all(target_vendor = "fortanix", target_env = "sgx"),
-    target_os = "windows"
-))]
 pub mod math;
 pub mod mem;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,9 @@ mod macros;
 pub mod float;
 pub mod int;
 
+// For some reason, we still get clippy error `clippy::deprecated_cfg_attr` even though, we have
+// used `allow(clippy::all)` in the file. So, we are disabling the clippy check for this file.
+#[cfg(not(clippy))]
 pub mod math;
 pub mod mem;
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,4 +1,6 @@
 #[allow(dead_code)]
+#[allow(unused_imports)]
+#[allow(clippy::all)]
 #[path = "../libm/src/math/mod.rs"]
 mod libm;
 


### PR DESCRIPTION
This is a continuation/fix of 018616e. In that commit, we made it add the math functions to all platforms (except apple-targets and windows), and use `weak` linking, so that it can be used if the system doesn't have those functions.

Didn't notice `mod math` was behind another set of `cfg`, so removed it as well here.

There is an issue with clippy, so disabled it on the file as a whole