### PR TITLE
Add CI testing for AArch64 Darwin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+        - target: aarch64-apple-darwin
+          os: macos-latest
+          rust: nightly
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-latest
           rust: nightly


### PR DESCRIPTION
The Apple ARM silicon has been around for a while now and hopefully will become Rust Tier 1 at some point. Add it to CI since it is distinct enough from aarch64-linux and x86_86-darwin that there may be differences.