### PR TITLE
Update status of 128-bit integers in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ rely on CI.
 - [x] umodsi3.c
 - [x] x86_64/chkstk.S
 
-These builtins are needed to support 128-bit integers, which are in the process of being added to Rust.
+These builtins are needed to support 128-bit integers.
 
 - [x] ashlti3.c
 - [x] ashrti3.c


### PR DESCRIPTION
At this point I think it's reasonable to say that 128-bit integers are no longer "in the process of being added to Rust"; they have been stable for a while now.