### PR TITLE
fix: Add `#[avr_skip]` for `__addsf3` & `__adddf3`

### DIFF
--- a/src/float/add.rs
+++ b/src/float/add.rs
@@ -189,12 +189,14 @@ where
 }
 
 intrinsics! {
+    #[avr_skip]
     #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_fadd]
     pub extern "C" fn __addsf3(a: f32, b: f32) -> f32 {
         add(a, b)
     }
 
+    #[avr_skip]
     #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_dadd]
     pub extern "C" fn __adddf3(a: f64, b: f64) -> f64 {


### PR DESCRIPTION
Follow up to https://github.com/rust-lang/compiler-builtins/pull/527 & https://github.com/rust-lang/compiler-builtins/pull/558 - [it looks like](https://github.com/Rahix/avr-hal/issues/541) I've originally forgotten about two more 😅 