### PR TITLE
Fix paths for Windows arm64 build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,9 @@ jobs:
         - target: x86_64-pc-windows-gnu
           os: windows-latest
           rust: nightly-x86_64-gnu
+        - target: aarch64-pc-windows-gnu
+          os: windows-latest
+          rust: nightly
     steps:
     - name: Print runner information
       run: uname -a

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,6 @@ jobs:
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-latest
           rust: nightly
-        - target: aarch64-pc-windows-msvc
-          os: [windows-latest, arm64]
-          rust: nightly
         - target: arm-unknown-linux-gnueabi
           os: ubuntu-latest
           rust: nightly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
         - target: x86_64-pc-windows-gnu
           os: windows-latest
           rust: nightly-x86_64-gnu
-        - target: aarch64-pc-windows-gnu
+        - target: aarch64-pc-windows-msvc
           os: windows-latest
           rust: nightly
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,9 @@ jobs:
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-latest
           rust: nightly
+        - target: aarch64-pc-windows-msvc
+          os: [windows-latest, arm64]
+          rust: nightly
         - target: arm-unknown-linux-gnueabi
           os: ubuntu-latest
           rust: nightly
@@ -83,9 +86,6 @@ jobs:
         - target: x86_64-pc-windows-gnu
           os: windows-latest
           rust: nightly-x86_64-gnu
-        - target: aarch64-pc-windows-msvc
-          os: windows-latest
-          rust: nightly
     steps:
     - name: Print runner information
       run: uname -a

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, env, sync::atomic::Ordering};
+use std::{collections::BTreeMap, env, path::PathBuf, sync::atomic::Ordering};
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
@@ -141,8 +141,8 @@ fn generate_aarch64_outlined_atomics() {
         buf += macro_def;
         buf += "}; }\n";
     }
-    let dst = std::env::var("OUT_DIR").unwrap() + "/outlined_atomics.rs";
-    std::fs::write(dst, buf).unwrap();
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    std::fs::write(out_dir.join("outlined_atomics.rs"), buf).unwrap();
 }
 
 #[cfg(feature = "c")]
@@ -612,7 +612,7 @@ mod c {
 
     fn build_aarch64_out_of_line_atomics_libraries(builtins_dir: &Path, cfg: &mut cc::Build) {
         let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-        let outlined_atomics_file = builtins_dir.join("aarch64/lse.S");
+        let outlined_atomics_file = builtins_dir.join("aarch64").join("lse.S");
         println!("cargo:rerun-if-changed={}", outlined_atomics_file.display());
 
         cfg.include(&builtins_dir);


### PR DESCRIPTION
Fixes issue #604 by using `Path::join` to denote a subpath (as opposed to using forward slash).