### PR TITLE
Add tests for verbatim paths on windows builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         - target: aarch64-pc-windows-msvc
           os: windows-latest
           rust: nightly
-          test_unc: 1
+          test_verbatim: 1
           no_std: 1
         - target: arm-unknown-linux-gnueabi
           os: ubuntu-latest
@@ -83,19 +83,19 @@ jobs:
         - target: i686-pc-windows-msvc
           os: windows-latest
           rust: nightly
-          test_unc: 1
+          test_verbatim: 1
         - target: x86_64-pc-windows-msvc
           os: windows-latest
           rust: nightly
-          test_unc: 1
+          test_verbatim: 1
         - target: i686-pc-windows-gnu
           os: windows-latest
           rust: nightly-i686-gnu
-          test_unc: 1
+          test_verbatim: 1
         - target: x86_64-pc-windows-gnu
           os: windows-latest
           rust: nightly-x86_64-gnu
-          test_unc: 1
+          test_verbatim: 1
     steps:
     - name: Print runner information
       run: uname -a
@@ -120,7 +120,7 @@ jobs:
       shell: bash
       env:
         NO_STD: ${{ matrix.no_std }}
-        TEST_UNC: ${{ matrix.test_unc }}
+        TEST_VERBATIM: ${{ matrix.test_verbatim }}
 
     # Otherwise we use our docker containers to run builds
     - run: cargo generate-lockfile && ./ci/run-docker.sh ${{ matrix.target }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,11 +91,9 @@ jobs:
         - target: i686-pc-windows-gnu
           os: windows-latest
           rust: nightly-i686-gnu
-          test_verbatim: 1
         - target: x86_64-pc-windows-gnu
           os: windows-latest
           rust: nightly-x86_64-gnu
-          test_verbatim: 1
     steps:
     - name: Print runner information
       run: uname -a

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,7 @@ jobs:
         - target: x86_64-pc-windows-msvc
           os: windows-latest
           rust: nightly
+          test_unc: 1
         - target: i686-pc-windows-gnu
           os: windows-latest
           rust: nightly-i686-gnu

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,9 +91,11 @@ jobs:
         - target: i686-pc-windows-gnu
           os: windows-latest
           rust: nightly-i686-gnu
+          test_unc: 1
         - target: x86_64-pc-windows-gnu
           os: windows-latest
           rust: nightly-x86_64-gnu
+          test_unc: 1
     steps:
     - name: Print runner information
       run: uname -a

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,11 @@ jobs:
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-latest
           rust: nightly
+        - target: aarch64-pc-windows-msvc
+          os: windows-latest
+          rust: nightly
+          test_unc: 1
+          no_std: 1
         - target: arm-unknown-linux-gnueabi
           os: ubuntu-latest
           rust: nightly
@@ -78,6 +83,7 @@ jobs:
         - target: i686-pc-windows-msvc
           os: windows-latest
           rust: nightly
+          test_unc: 1
         - target: x86_64-pc-windows-msvc
           os: windows-latest
           rust: nightly
@@ -109,6 +115,9 @@ jobs:
     - run: ./ci/run.sh ${{ matrix.target }}
       if: matrix.os != 'ubuntu-latest'
       shell: bash
+      env:
+        NO_STD: ${{ matrix.no_std }}
+        TEST_UNC: ${{ matrix.test_unc }}
 
     # Otherwise we use our docker containers to run builds
     - run: cargo generate-lockfile && ./ci/run-docker.sh ${{ matrix.target }}

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -33,15 +33,17 @@ else
 fi
 
 if [ "${TEST_UNC:-}" = "1" ]; then
-    run="cargo build --manifest-path testcrate/Cargo.toml --target $target --target-dir \\\\?\\$TEMP\\test_unc"
-    $run
-    $run --release
-    $run --features c
-    $run --features c --release
-    $run --features no-asm
-    $run --features no-asm --release
-    $run --features no-f16-f128
-    $run --features no-f16-f128 --release
+    function run() {
+        cmd.exe /c cargo build --manifest-path testcrate/Cargo.toml --target $target --target-dir "\\\\?\\%TEMP%\\test_unc" "$@"
+    }
+    run
+    run --release
+    run --features c
+    run --features c --release
+    run --features no-asm
+    run --features no-asm --release
+    run --features no-f16-f128
+    run --features no-f16-f128 --release
 fi
 
 if [ -d /builtins-target ]; then

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -32,6 +32,18 @@ else
     $run --features no-f16-f128 --release
 fi
 
+if [ "${TEST_UNC:-}" = "1" ]; then
+    run="cargo build --manifest-path testcrate/Cargo.toml --target $target --target-dir \"\\\\?\\$(pwd)\""
+    $run
+    $run --release
+    $run --features c
+    $run --features c --release
+    $run --features no-asm
+    $run --features no-asm --release
+    $run --features no-f16-f128
+    $run --features no-f16-f128 --release
+fi
+
 if [ -d /builtins-target ]; then
     rlib_paths=/builtins-target/"${target}"/debug/deps/libcompiler_builtins-*.rlib
 else

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -32,9 +32,9 @@ else
     $run --features no-f16-f128 --release
 fi
 
-if [ "${TEST_UNC:-}" = "1" ]; then
-    path=$(cmd.exe "/C echo \\\\?\\%cd%\\testcrate\\target_unc")
-    run="cargo test --manifest-path testcrate/Cargo.toml --target $target --target-dir $path"
+if [ "${TEST_VERBATIM:-}" = "1" ]; then
+    verb_path=$(cmd.exe //C echo \\\\?\\%cd%\\testcrate\\target2)
+    run="cargo test --manifest-path testcrate/Cargo.toml --target $target --target-dir $verb_path"
     $run
     $run --release
     $run --features c

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -34,7 +34,7 @@ fi
 
 if [ "${TEST_VERBATIM:-}" = "1" ]; then
     verb_path=$(cmd.exe //C echo \\\\?\\%cd%\\testcrate\\target2)
-    run="cargo test --manifest-path testcrate/Cargo.toml --target $target --target-dir $verb_path"
+    run="cargo build --manifest-path testcrate/Cargo.toml --target $target --target-dir $verb_path"
     $run
     $run --release
     $run --features c

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -34,15 +34,7 @@ fi
 
 if [ "${TEST_VERBATIM:-}" = "1" ]; then
     verb_path=$(cmd.exe //C echo \\\\?\\%cd%\\testcrate\\target2)
-    run="cargo build --manifest-path testcrate/Cargo.toml --target $target --target-dir $verb_path"
-    $run
-    $run --release
-    $run --features c
-    $run --features c --release
-    $run --features no-asm
-    $run --features no-asm --release
-    $run --features no-f16-f128
-    $run --features no-f16-f128 --release
+    cargo build --manifest-path testcrate/Cargo.toml --target $target --target-dir $verb_path --features c
 fi
 
 if [ -d /builtins-target ]; then

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -33,7 +33,7 @@ else
 fi
 
 if [ "${TEST_UNC:-}" = "1" ]; then
-    run="cargo build --manifest-path testcrate/Cargo.toml --target $target --target-dir \"\\\\?\\$(pwd)\""
+    run="cargo build --manifest-path testcrate/Cargo.toml --target $target --target-dir \\\\?\\$TEMP\\test_unc"
     $run
     $run --release
     $run --features c

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -33,17 +33,16 @@ else
 fi
 
 if [ "${TEST_UNC:-}" = "1" ]; then
-    function run() {
-        cmd.exe /c cargo build --manifest-path "testcrate\\Cargo.toml" --target $target --target-dir "\\\\?\\%TEMP%\\test_unc" "$@"
-    }
-    run
-    run --release
-    run --features c
-    run --features c --release
-    run --features no-asm
-    run --features no-asm --release
-    run --features no-f16-f128
-    run --features no-f16-f128 --release
+    path=$(cmd.exe "/C echo \\\\?\\%cd%\\testcrate\\target_unc")
+    run="cargo test --manifest-path testcrate/Cargo.toml --target $target --target-dir $path"
+    $run
+    $run --release
+    $run --features c
+    $run --features c --release
+    $run --features no-asm
+    $run --features no-asm --release
+    $run --features no-f16-f128
+    $run --features no-f16-f128 --release
 fi
 
 if [ -d /builtins-target ]; then

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -34,7 +34,7 @@ fi
 
 if [ "${TEST_UNC:-}" = "1" ]; then
     function run() {
-        cmd.exe /c cargo build --manifest-path testcrate/Cargo.toml --target $target --target-dir "\\\\?\\%TEMP%\\test_unc" "$@"
+        cmd.exe /c cargo build --manifest-path "testcrate\\Cargo.toml" --target $target --target-dir "\\\\?\\%TEMP%\\test_unc" "$@"
     }
     run
     run --release


### PR DESCRIPTION
This adds test building for windows targets if `--target-dir` gets set to a verbatim path. This is due to the fact that verbatim or verbatim unc paths have an additional requirement of having all path separators to be backslashes as opposed to be permissive of forward and back slashes.

This was made in response to #609 / #604.