### PR TITLE
Add `ppc_alias` to the `intrinsics!` macro

### DIFF
--- a/src/float/add.rs
+++ b/src/float/add.rs
@@ -203,13 +203,9 @@ intrinsics! {
         add(a, b)
     }
 
-    #[cfg(not(any(feature = "no-f16-f128", target_arch = "powerpc", target_arch = "powerpc64")))]
+    #[ppc_alias = __addkf3]
+    #[cfg(not(feature = "no-f16-f128"))]
     pub extern "C" fn __addtf3(a: f128, b: f128) -> f128 {
-        add(a, b)
-    }
-
-    #[cfg(all(not(feature = "no-f16-f128"), any(target_arch = "powerpc", target_arch = "powerpc64")))]
-    pub extern "C" fn __addkf3(a: f128, b: f128) -> f128 {
         add(a, b)
     }
 

--- a/src/float/cmp.rs
+++ b/src/float/cmp.rs
@@ -172,85 +172,47 @@ intrinsics! {
     }
 }
 
-#[cfg(not(any(
-    feature = "no-f16-f128",
-    target_arch = "powerpc",
-    target_arch = "powerpc64"
-)))]
+#[cfg(not(feature = "no-f16-f128",))]
 intrinsics! {
     #[avr_skip]
+    #[ppc_alias = __lekf2]
     pub extern "C" fn __letf2(a: f128, b: f128) -> i32 {
         cmp(a, b).to_le_abi()
     }
 
     #[avr_skip]
+    #[ppc_alias = __gekf2]
     pub extern "C" fn __getf2(a: f128, b: f128) -> i32 {
         cmp(a, b).to_ge_abi()
     }
 
     #[avr_skip]
+    #[ppc_alias = __unordkf2]
     pub extern "C" fn __unordtf2(a: f128, b: f128) -> i32 {
         unord(a, b) as i32
     }
 
     #[avr_skip]
+    #[ppc_alias = __eqkf2]
     pub extern "C" fn __eqtf2(a: f128, b: f128) -> i32 {
         cmp(a, b).to_le_abi()
     }
 
     #[avr_skip]
+    #[ppc_alias = __ltkf2]
     pub extern "C" fn __lttf2(a: f128, b: f128) -> i32 {
         cmp(a, b).to_le_abi()
     }
 
     #[avr_skip]
+    #[ppc_alias = __nekf2]
     pub extern "C" fn __netf2(a: f128, b: f128) -> i32 {
         cmp(a, b).to_le_abi()
     }
 
     #[avr_skip]
+    #[ppc_alias = __gtkf2]
     pub extern "C" fn __gttf2(a: f128, b: f128) -> i32 {
-        cmp(a, b).to_ge_abi()
-    }
-}
-
-#[cfg(all(
-    not(feature = "no-f16-f128"),
-    any(target_arch = "powerpc", target_arch = "powerpc64")
-))]
-intrinsics! {
-    #[avr_skip]
-    pub extern "C" fn __lekf2(a: f128, b: f128) -> i32 {
-        cmp(a, b).to_le_abi()
-    }
-
-    #[avr_skip]
-    pub extern "C" fn __gekf2(a: f128, b: f128) -> i32 {
-        cmp(a, b).to_ge_abi()
-    }
-
-    #[avr_skip]
-    pub extern "C" fn __unordkf2(a: f128, b: f128) -> i32 {
-        unord(a, b) as i32
-    }
-
-    #[avr_skip]
-    pub extern "C" fn __eqkf2(a: f128, b: f128) -> i32 {
-        cmp(a, b).to_le_abi()
-    }
-
-    #[avr_skip]
-    pub extern "C" fn __ltkf2(a: f128, b: f128) -> i32 {
-        cmp(a, b).to_le_abi()
-    }
-
-    #[avr_skip]
-    pub extern "C" fn __nekf2(a: f128, b: f128) -> i32 {
-        cmp(a, b).to_le_abi()
-    }
-
-    #[avr_skip]
-    pub extern "C" fn __gtkf2(a: f128, b: f128) -> i32 {
         cmp(a, b).to_ge_abi()
     }
 }

--- a/src/float/conv.rs
+++ b/src/float/conv.rs
@@ -262,16 +262,19 @@ intrinsics! {
         float_to_unsigned_int(f)
     }
 
+    #[ppc_alias = __fixunskfsi]
     #[cfg(not(feature = "no-f16-f128"))]
     pub extern "C" fn __fixunstfsi(f: f128) -> u32 {
         float_to_unsigned_int(f)
     }
 
+    #[ppc_alias = __fixunskfdi]
     #[cfg(not(feature = "no-f16-f128"))]
     pub extern "C" fn __fixunstfdi(f: f128) -> u64 {
         float_to_unsigned_int(f)
     }
 
+    #[ppc_alias = __fixunskfti]
     #[cfg(not(feature = "no-f16-f128"))]
     pub extern "C" fn __fixunstfti(f: f128) -> u128 {
         float_to_unsigned_int(f)
@@ -310,16 +313,19 @@ intrinsics! {
         float_to_signed_int(f)
     }
 
+    #[ppc_alias = __fixkfsi]
     #[cfg(not(feature = "no-f16-f128"))]
     pub extern "C" fn __fixtfsi(f: f128) -> i32 {
         float_to_signed_int(f)
     }
 
+    #[ppc_alias = __fixkfdi]
     #[cfg(not(feature = "no-f16-f128"))]
     pub extern "C" fn __fixtfdi(f: f128) -> i64 {
         float_to_signed_int(f)
     }
 
+    #[ppc_alias = __fixkfti]
     #[cfg(not(feature = "no-f16-f128"))]
     pub extern "C" fn __fixtfti(f: f128) -> i128 {
         float_to_signed_int(f)

--- a/src/float/extend.rs
+++ b/src/float/extend.rs
@@ -100,37 +100,22 @@ intrinsics! {
 
     #[avr_skip]
     #[aapcs_on_arm]
-    #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
+    #[ppc_alias = __extendhfkf2]
     pub extern "C" fn __extendhftf2(a: f16) -> f128 {
         extend(a)
     }
 
-    #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
-    pub extern "C" fn __extendhfkf2(a: f16) -> f128 {
-        extend(a)
-    }
-
     #[avr_skip]
     #[aapcs_on_arm]
-    #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
+    #[ppc_alias = __extendsfkf2]
     pub extern "C" fn __extendsftf2(a: f32) -> f128 {
         extend(a)
     }
 
-    #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
-    pub extern "C" fn __extendsfkf2(a: f32) -> f128 {
-        extend(a)
-    }
-
     #[avr_skip]
     #[aapcs_on_arm]
-    #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
+    #[ppc_alias = __extenddfkf2]
     pub extern "C" fn __extenddftf2(a: f64) -> f128 {
-        extend(a)
-    }
-
-    #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
-    pub extern "C" fn __extenddfkf2(a: f64) -> f128 {
         extend(a)
     }
 }

--- a/src/float/mul.rs
+++ b/src/float/mul.rs
@@ -199,14 +199,9 @@ intrinsics! {
         mul(a, b)
     }
 
-    #[cfg(not(any(feature = "no-f16-f128", target_arch = "powerpc", target_arch = "powerpc64")))]
+    #[ppc_alias = __mulkf3]
+    #[cfg(not(feature = "no-f16-f128"))]
     pub extern "C" fn __multf3(a: f128, b: f128) -> f128 {
-        mul(a, b)
-    }
-
-
-    #[cfg(all(not(feature = "no-f16-f128"), any(target_arch = "powerpc", target_arch = "powerpc64")))]
-    pub extern "C" fn __mulkf3(a: f128, b: f128) -> f128 {
         mul(a, b)
     }
 

--- a/src/float/sub.rs
+++ b/src/float/sub.rs
@@ -15,16 +15,15 @@ intrinsics! {
         __adddf3(a, f64::from_repr(b.repr() ^ f64::SIGN_MASK))
     }
 
-    #[cfg(not(any(feature = "no-f16-f128", target_arch = "powerpc", target_arch = "powerpc64")))]
+    #[ppc_alias = __subkf3]
+    #[cfg(not(feature = "no-f16-f128"))]
     pub extern "C" fn __subtf3(a: f128, b: f128) -> f128 {
+        #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
+        use crate::float::add::__addkf3 as __addtf3;
+        #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
         use crate::float::add::__addtf3;
-        __addtf3(a, f128::from_repr(b.repr() ^ f128::SIGN_MASK))
-    }
 
-    #[cfg(all(not(feature = "no-f16-f128"), any(target_arch = "powerpc", target_arch = "powerpc64")))]
-    pub extern "C" fn __subkf3(a: f128, b: f128) -> f128 {
-        use crate::float::add::__addkf3;
-        __addkf3(a, f128::from_repr(b.repr() ^ f128::SIGN_MASK))
+        __addtf3(a, f128::from_repr(b.repr() ^ f128::SIGN_MASK))
     }
 
     #[cfg(target_arch = "arm")]

--- a/src/float/trunc.rs
+++ b/src/float/trunc.rs
@@ -155,37 +155,22 @@ intrinsics! {
 
     #[avr_skip]
     #[aapcs_on_arm]
-    #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
+    #[ppc_alias = __trunckfhf2]
     pub extern "C" fn __trunctfhf2(a: f128) -> f16 {
         trunc(a)
     }
 
-    #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
-    pub extern "C" fn __trunckfhf2(a: f128) -> f16 {
-        trunc(a)
-    }
-
     #[avr_skip]
     #[aapcs_on_arm]
-    #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
+    #[ppc_alias = __trunckfsf2]
     pub extern "C" fn __trunctfsf2(a: f128) -> f32 {
         trunc(a)
     }
 
-    #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
-    pub extern "C" fn __trunckfsf2(a: f128) -> f32 {
-        trunc(a)
-    }
-
     #[avr_skip]
     #[aapcs_on_arm]
-    #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
+    #[ppc_alias = __trunckfdf2]
     pub extern "C" fn __trunctfdf2(a: f128) -> f64 {
-        trunc(a)
-    }
-
-    #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
-    pub extern "C" fn __trunckfdf2(a: f128) -> f64 {
         trunc(a)
     }
 }

--- a/testcrate/tests/conv.rs
+++ b/testcrate/tests/conv.rs
@@ -178,6 +178,13 @@ mod f_to_i {
     #[test]
     #[cfg(not(feature = "no-f16-f128"))]
     fn f128_to_int() {
+        #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
+        use compiler_builtins::float::conv::{
+            __fixkfdi as __fixtfdi, __fixkfsi as __fixtfsi, __fixkfti as __fixtfti,
+            __fixunskfdi as __fixunstfdi, __fixunskfsi as __fixunstfsi,
+            __fixunskfti as __fixunstfti,
+        };
+        #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
         use compiler_builtins::float::conv::{
             __fixtfdi, __fixtfsi, __fixtfti, __fixunstfdi, __fixunstfsi, __fixunstfti,
         };


### PR DESCRIPTION
PowerPC platforms use `kf` rather than `tf` for `f128`. Add a way to alias this in the macro to make the code cleaner.

This also fixes the names of `fixunstf*` and `fixtf*` on Power PC (`fixunskf*` and `fixkf*` are correct).