### PR TITLE
Add CI caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 env:
   RUSTDOCFLAGS: -Dwarnings
   RUSTFLAGS: -Dwarnings
+  RUST_LLVM_VERSION: 18.0-2024-02-13
+  RUST_COMPILER_RT_ROOT: ./compiler-rt
 
 jobs:
   test:
@@ -115,12 +117,18 @@ jobs:
         path: /tmp/.buildx-cache
         key: ${{ matrix.target }}-buildx-${{ github.sha }}
         restore-keys: ${{ matrix.target }}-buildx-
-
+        
+    - name: Cache compiler-rt
+      id: cache-compiler-rt
+      uses: actions/cache@v4
+      with:
+        path: compiler-rt
+        key: ${{ runner.os }}-compiler-rt-${{ env.RUST_LLVM_VERSION }}
     - name: Download compiler-rt reference sources
+      if: steps.cache-compiler-rt.outputs.cache-hit != 'true'
       run: |
-        curl -L -o code.tar.gz https://github.com/rust-lang/llvm-project/archive/rustc/18.0-2024-02-13.tar.gz
-        tar xzf code.tar.gz --strip-components 1 llvm-project-rustc-18.0-2024-02-13/compiler-rt
-        echo RUST_COMPILER_RT_ROOT=./compiler-rt >> $GITHUB_ENV
+        curl -L -o code.tar.gz "https://github.com/rust-lang/llvm-project/archive/rustc/${RUST_LLVM_VERSION}.tar.gz"
+        tar xzf code.tar.gz --strip-components 1 llvm-project-rustc-${RUST_LLVM_VERSION}/compiler-rt
       shell: bash
 
     # Non-linux tests just use our raw script

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,9 @@ jobs:
       shell: bash
     - run: rustup target add ${{ matrix.target }}
     - run: rustup component add llvm-tools-preview
+    - uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ matrix.target }}
     - name: Download compiler-rt reference sources
       run: |
         curl -L -o code.tar.gz https://github.com/rust-lang/llvm-project/archive/rustc/18.0-2024-02-13.tar.gz
@@ -147,6 +150,7 @@ jobs:
     - name: Install nightly `clippy`
       run: |
         rustup set profile minimal && rustup default "nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/clippy)" && rustup component add clippy
+    - uses: Swatinem/rust-cache@v2
     - run: cargo clippy -- -D clippy::all
 
   success:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,6 +108,14 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ matrix.target }}
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      if: matrix.os == 'ubuntu-latest'
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ matrix.target }}-buildx-${{ github.sha }}
+        restore-keys: ${{ matrix.target }}-buildx-
+
     - name: Download compiler-rt reference sources
       run: |
         curl -L -o code.tar.gz https://github.com/rust-lang/llvm-project/archive/rustc/18.0-2024-02-13.tar.gz
@@ -123,9 +131,22 @@ jobs:
         NO_STD: ${{ matrix.no_std }}
         TEST_VERBATIM: ${{ matrix.test_verbatim }}
 
+    # Configure buildx to use Docker layer caching
+    - uses: docker/setup-buildx-action@v3
+      if: matrix.os == 'ubuntu-latest'
+
     # Otherwise we use our docker containers to run builds
     - run: cargo generate-lockfile && ./ci/run-docker.sh ${{ matrix.target }}
       if: matrix.os == 'ubuntu-latest'
+
+    # Workaround to keep Docker cache smaller
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move Docker cache
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   rustfmt:
     name: Rustfmt

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -41,7 +41,19 @@ run() {
       export RUST_COMPILER_RT_ROOT=./compiler-rt
     fi
 
-    docker build \
+    if [ "$GITHUB_ACTIONS" = "true" ]; then
+      # Enable Docker image caching on GHA
+      
+      buildx="buildx"
+      build_args=(
+        "--cache-from" "type=local,src=/tmp/.buildx-cache"
+        "--cache-to" "type=local,dest=/tmp/.buildx-cache-new"
+        "${build_args[@]:-}"
+        "--load"
+      )
+    fi
+
+    docker "${buildx:-}" build \
            -t "builtins-$target" \
            ${build_args[@]:-} \
            "ci/docker/$target"


### PR DESCRIPTION
Rebuilding Docker images currently takes a long time  even though we don't change anything. Add cache in three places:

- Rust dependencies and compiled 
- compiler-rt download
- Docker image build

This saves about 30s-1m on the std targets that use Docker