### PR TITLE
Remove __multc3

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -533,10 +533,6 @@ mod c {
                 ("__fe_getround", "fp_mode.c"),
                 ("__fe_raise_inexact", "fp_mode.c"),
             ]);
-
-            if target_os != "windows" {
-                sources.extend(&[("__multc3", "multc3.c")]);
-            }
         }
 
         if target_arch == "mips" || target_arch == "riscv32" || target_arch == "riscv64" {


### PR DESCRIPTION
This C file doesn't seem to be compiled correctly, as it creates a reference to the x86 specific `__builtin_copysignq` on ARM. This intrinsic is unused and unavailable on Windows because it's for complex numbers Rust doesn't support, so it should be fine to remove.

The inclusion of the file seems to be the cause of some downstream link errors: https://github.com/rust-lang/rust/issues/125619

