### PR TITLE
Build with `-Werror=implicit-function-declaration`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -327,6 +327,8 @@ mod c {
             // in https://github.com/rust-lang/compiler-rt/blob/c8fbcb3/cmake/config-ix.cmake#L19.
             cfg.flag_if_supported("-fomit-frame-pointer");
             cfg.define("VISIBILITY_HIDDEN", None);
+            // Avoid implicitly creating references to undefined functions
+            cfg.flag("-Werror=implicit-function-declaration");
         }
 
         // int_util.c tries to include stdlib.h if `_WIN32` is defined,


### PR DESCRIPTION
To fail-fast in situations like
https://github.com/rust-lang/rust/issues/125619, where an upstream
source compiles but creates a link error way downstream.
