### PR TITLE
Disable libm on x86 without sse2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,9 @@ mod macros;
 pub mod float;
 pub mod int;
 
+// Disabled on x86 without sse2 due to ABI issues
+// <https://github.com/rust-lang/rust/issues/114479>
+#[cfg(not(all(target_arch = "x86", not(target_feature = "sse2"))))]
 pub mod math;
 pub mod mem;
 


### PR DESCRIPTION
In <https://github.com/rust-lang/compiler-builtins/pull/594>, symbols for the Rust port of libm were made always weakly available. This seems to be causing problems on platforms with ABI issues, as explained at <https://github.com/rust-lang/rust/pull/125016#issuecomment-2174572661>.

Disable Rust libm on x86 without sse2 to mitigate this.