### PR TITLE
Fix building on AVR

### DIFF
--- a/src/float/sub.rs
+++ b/src/float/sub.rs
@@ -1,18 +1,16 @@
-use crate::float::add::__adddf3;
-use crate::float::add::__addsf3;
 use crate::float::Float;
 
 intrinsics! {
     #[avr_skip]
     #[arm_aeabi_alias = __aeabi_fsub]
     pub extern "C" fn __subsf3(a: f32, b: f32) -> f32 {
-        __addsf3(a, f32::from_repr(b.repr() ^ f32::SIGN_MASK))
+        crate::float::add::__addsf3(a, f32::from_repr(b.repr() ^ f32::SIGN_MASK))
     }
 
     #[avr_skip]
     #[arm_aeabi_alias = __aeabi_dsub]
     pub extern "C" fn __subdf3(a: f64, b: f64) -> f64 {
-        __adddf3(a, f64::from_repr(b.repr() ^ f64::SIGN_MASK))
+        crate::float::add::__adddf3(a, f64::from_repr(b.repr() ^ f64::SIGN_MASK))
     }
 
     #[ppc_alias = __subkf3]


### PR DESCRIPTION
As `__adddf3` and `__addsf3` are marked with `#[avr_skip]` they don't exist on AVR. This PR ensures any usage of them is within `#[avr_skip]` intrinsics.