### PR TITLE
Get rid of a warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 repository = "https://github.com/rust-lang/compiler-builtins"
 homepage = "https://github.com/rust-lang/compiler-builtins"
 documentation = "https://docs.rs/compiler_builtins"
-edition = "2018"
+edition = "2021"
 description = """
 Compiler intrinsics used by the Rust compiler. Also available for other targets
 if necessary!

--- a/build.rs
+++ b/build.rs
@@ -219,8 +219,6 @@ fn configure_check_cfg() {
 
 #[cfg(feature = "c")]
 mod c {
-    extern crate cc;
-
     use std::collections::{BTreeMap, HashSet};
     use std::env;
     use std::fs::{self, File};

--- a/crates/panic-handler/Cargo.toml
+++ b/crates/panic-handler/Cargo.toml
@@ -2,5 +2,6 @@
 name = "panic-handler"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
I get this error when building the crate using fresh rust:

```
error: `extern crate` is not idiomatic in the new edition
   --> /home/aturkin/redox/compiler-builtins/build.rs:225:5
    |
225 |     extern crate cc;
    |     ^^^^^^^^^^^^^^^^
    |
    = note: `-D unused-extern-crates` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_extern_crates)]`
help: convert it to a `use`
    |
225 |     use cc;
    |     ~~~
```

Indeed 2018 edition documentation says `extern crate` should not be used anymore "in 99% of circumstances". So this PR follows the advice.