### PR TITLE
Implement remaining __clz*i2 intrinsics

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ rely on CI.
 - [x] bswapdi2.c
 - [x] bswapsi2.c
 - [x] bswapti2.c
+- [x] clzdi2.c
+- [x] clzsi2.c
+- [x] clzti2.c
 - [x] comparedf2.c
 - [x] comparesf2.c
 - [x] divdf3.c
@@ -325,9 +328,6 @@ These builtins are never called by LLVM.
 - ~~arm/switch32.S~~
 - ~~arm/switch8.S~~
 - ~~arm/switchu8.S~~
-- ~~clzdi2.c~~
-- ~~clzsi2.c~~
-- ~~clzti2.c~~
 - ~~cmpdi2.c~~
 - ~~cmpti2.c~~
 - ~~ctzdi2.c~~

--- a/build.rs
+++ b/build.rs
@@ -164,8 +164,6 @@ fn configure_check_cfg() {
         "__bswapsi2",
         "__bswapdi2",
         "__bswapti2",
-        "__clzsi2",
-        "__clzdi2",
         "__divdi3",
         "__divsi3",
         "__divmoddi4",
@@ -346,8 +344,6 @@ mod c {
             ("__absvsi2", "absvsi2.c"),
             ("__addvdi3", "addvdi3.c"),
             ("__addvsi3", "addvsi3.c"),
-            ("__clzdi2", "clzdi2.c"),
-            ("__clzsi2", "clzsi2.c"),
             ("__cmpdi2", "cmpdi2.c"),
             ("__ctzdi2", "ctzdi2.c"),
             ("__ctzsi2", "ctzsi2.c"),
@@ -435,8 +431,6 @@ mod c {
                 ("__aeabi_frsub", "arm/aeabi_frsub.c"),
                 ("__bswapdi2", "arm/bswapdi2.S"),
                 ("__bswapsi2", "arm/bswapsi2.S"),
-                ("__clzdi2", "arm/clzdi2.S"),
-                ("__clzsi2", "arm/clzsi2.S"),
                 ("__divmodsi4", "arm/divmodsi4.S"),
                 ("__divsi3", "arm/divsi3.S"),
                 ("__modsi3", "arm/modsi3.S"),
@@ -572,9 +566,6 @@ mod c {
                 }
             }
             sources.remove(&to_remove);
-
-            // But use some generic implementations where possible
-            sources.extend(&[("__clzdi2", "clzdi2.c"), ("__clzsi2", "clzsi2.c")])
         }
 
         if llvm_target[0] == "thumbv7m" || llvm_target[0] == "thumbv7em" {

--- a/build.rs
+++ b/build.rs
@@ -165,6 +165,7 @@ fn configure_check_cfg() {
         "__bswapdi2",
         "__bswapti2",
         "__clzsi2",
+        "__clzdi2",
         "__divdi3",
         "__divsi3",
         "__divmoddi4",
@@ -382,7 +383,6 @@ mod c {
             sources.extend(&[
                 ("__absvti2", "absvti2.c"),
                 ("__addvti3", "addvti3.c"),
-                ("__clzti2", "clzti2.c"),
                 ("__cmpti2", "cmpti2.c"),
                 ("__ctzti2", "ctzti2.c"),
                 ("__ffsti2", "ffsti2.c"),

--- a/src/int/leading_zeros.rs
+++ b/src/int/leading_zeros.rs
@@ -3,10 +3,12 @@
 // adding a zero check at the beginning, but `__clzsi2` has a precondition that `x != 0`.
 // Compilers will insert the check for zero in cases where it is needed.
 
+use crate::int::{CastInto, Int};
+
 public_test_dep! {
 /// Returns the number of leading binary zeros in `x`.
 #[allow(dead_code)]
-pub(crate) fn usize_leading_zeros_default(x: usize) -> usize {
+pub(crate) fn leading_zeros_default<T: Int + CastInto<usize>>(x: T) -> usize {
     // The basic idea is to test if the higher bits of `x` are zero and bisect the number
     // of leading zeros. It is possible for all branches of the bisection to use the same
     // code path by conditionally shifting the higher parts down to let the next bisection
@@ -16,46 +18,47 @@ pub(crate) fn usize_leading_zeros_default(x: usize) -> usize {
     // because it simplifies the final bisection step.
     let mut x = x;
     // the number of potential leading zeros
-    let mut z = usize::MAX.count_ones() as usize;
+    let mut z = T::BITS as usize;
     // a temporary
-    let mut t: usize;
-    #[cfg(target_pointer_width = "64")]
-    {
+    let mut t: T;
+
+    const { assert!(T::BITS <= 64) };
+    if T::BITS >= 64 {
         t = x >> 32;
-        if t != 0 {
+        if t != T::ZERO {
             z -= 32;
             x = t;
         }
     }
-    #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
-    {
+    if T::BITS >= 32 {
         t = x >> 16;
-        if t != 0 {
+        if t != T::ZERO {
             z -= 16;
             x = t;
         }
     }
+    const { assert!(T::BITS >= 16) };
     t = x >> 8;
-    if t != 0 {
+    if t != T::ZERO {
         z -= 8;
         x = t;
     }
     t = x >> 4;
-    if t != 0 {
+    if t != T::ZERO {
         z -= 4;
         x = t;
     }
     t = x >> 2;
-    if t != 0 {
+    if t != T::ZERO {
         z -= 2;
         x = t;
     }
     // the last two bisections are combined into one conditional
     t = x >> 1;
-    if t != 0 {
+    if t != T::ZERO {
         z - 2
     } else {
-        z - x
+        z - x.cast()
     }
 
     // We could potentially save a few cycles by using the LUT trick from
@@ -80,12 +83,12 @@ pub(crate) fn usize_leading_zeros_default(x: usize) -> usize {
 public_test_dep! {
 /// Returns the number of leading binary zeros in `x`.
 #[allow(dead_code)]
-pub(crate) fn usize_leading_zeros_riscv(x: usize) -> usize {
+pub(crate) fn leading_zeros_riscv<T: Int + CastInto<usize>>(x: T) -> usize {
     let mut x = x;
     // the number of potential leading zeros
-    let mut z = usize::MAX.count_ones() as usize;
+    let mut z = T::BITS;
     // a temporary
-    let mut t: usize;
+    let mut t: u32;
 
     // RISC-V does not have a set-if-greater-than-or-equal instruction and
     // `(x >= power-of-two) as usize` will get compiled into two instructions, but this is
@@ -95,11 +98,11 @@ pub(crate) fn usize_leading_zeros_riscv(x: usize) -> usize {
     // right). If we try to save an instruction by using `x < imm` for each bisection, we
     // have to shift `x` left and compare with powers of two approaching `usize::MAX + 1`,
     // but the immediate will never fit into 12 bits and never save an instruction.
-    #[cfg(target_pointer_width = "64")]
-    {
+    const { assert!(T::BITS <= 64) };
+    if T::BITS >= 64 {
         // If the upper 32 bits of `x` are not all 0, `t` is set to `1 << 5`, otherwise
         // `t` is set to 0.
-        t = ((x >= (1 << 32)) as usize) << 5;
+        t = ((x >= (T::ONE << 32)) as u32) << 5;
         // If `t` was set to `1 << 5`, then the upper 32 bits are shifted down for the
         // next step to process.
         x >>= t;
@@ -107,43 +110,58 @@ pub(crate) fn usize_leading_zeros_riscv(x: usize) -> usize {
         // leading zeros
         z -= t;
     }
-    #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
-    {
-        t = ((x >= (1 << 16)) as usize) << 4;
+    if T::BITS >= 32 {
+        t = ((x >= (T::ONE << 16)) as u32) << 4;
         x >>= t;
         z -= t;
     }
-    t = ((x >= (1 << 8)) as usize) << 3;
+    const { assert!(T::BITS >= 16) };
+    t = ((x >= (T::ONE << 8)) as u32) << 3;
     x >>= t;
     z -= t;
-    t = ((x >= (1 << 4)) as usize) << 2;
+    t = ((x >= (T::ONE << 4)) as u32) << 2;
     x >>= t;
     z -= t;
-    t = ((x >= (1 << 2)) as usize) << 1;
+    t = ((x >= (T::ONE << 2)) as u32) << 1;
     x >>= t;
     z -= t;
-    t = (x >= (1 << 1)) as usize;
+    t = (x >= (T::ONE << 1)) as u32;
     x >>= t;
     z -= t;
     // All bits except the LSB are guaranteed to be zero for this final bisection step.
     // If `x != 0` then `x == 1` and subtracts one potential zero from `z`.
-    z - x
+    z as usize - x.cast()
 }
 }
 
 intrinsics! {
     #[maybe_use_optimized_c_shim]
-    #[cfg(any(
-        target_pointer_width = "16",
-        target_pointer_width = "32",
-        target_pointer_width = "64"
-    ))]
-    /// Returns the number of leading binary zeros in `x`.
-    pub extern "C" fn __clzsi2(x: usize) -> usize {
+    /// Returns the number of leading binary zeros in `x`
+    pub extern "C" fn __clzsi2(x: u32) -> usize {
         if cfg!(any(target_arch = "riscv32", target_arch = "riscv64")) {
-            usize_leading_zeros_riscv(x)
+            leading_zeros_riscv(x)
         } else {
-            usize_leading_zeros_default(x)
+            leading_zeros_default(x)
+        }
+    }
+
+    #[maybe_use_optimized_c_shim]
+    /// Returns the number of leading binary zeros in `x`
+    pub extern "C" fn __clzdi2(x: u64) -> usize {
+        if cfg!(any(target_arch = "riscv32", target_arch = "riscv64")) {
+            leading_zeros_riscv(x)
+        } else {
+            leading_zeros_default(x)
+        }
+    }
+
+    /// Returns the number of leading binary zeros in `x`
+    pub extern "C" fn __clzti2(x: u128) -> usize {
+        let hi = (x >> 64) as u64;
+        if hi == 0 {
+            64 + __clzdi2(x as u64)
+        } else {
+            __clzdi2(hi)
         }
     }
 }

--- a/src/int/leading_zeros.rs
+++ b/src/int/leading_zeros.rs
@@ -135,7 +135,6 @@ pub(crate) fn leading_zeros_riscv<T: Int + CastInto<usize>>(x: T) -> usize {
 }
 
 intrinsics! {
-    #[maybe_use_optimized_c_shim]
     /// Returns the number of leading binary zeros in `x`
     pub extern "C" fn __clzsi2(x: u32) -> usize {
         if cfg!(any(target_arch = "riscv32", target_arch = "riscv64")) {
@@ -145,7 +144,6 @@ intrinsics! {
         }
     }
 
-    #[maybe_use_optimized_c_shim]
     /// Returns the number of leading binary zeros in `x`
     pub extern "C" fn __clzdi2(x: u64) -> usize {
         if cfg!(any(target_arch = "riscv32", target_arch = "riscv64")) {

--- a/src/int/mod.rs
+++ b/src/int/mod.rs
@@ -12,7 +12,6 @@ pub mod shift;
 pub mod udiv;
 
 pub use big::{i256, u256};
-pub use leading_zeros::__clzsi2;
 
 public_test_dep! {
 /// Minimal integer implementations needed on all integer types, including wide integers.

--- a/testcrate/tests/misc.rs
+++ b/testcrate/tests/misc.rs
@@ -65,31 +65,70 @@ fn fuzz_values() {
 
 #[test]
 fn leading_zeros() {
-    use compiler_builtins::int::__clzsi2;
-    use compiler_builtins::int::leading_zeros::{
-        usize_leading_zeros_default, usize_leading_zeros_riscv,
-    };
-    fuzz(N, |x: usize| {
-        let lz = x.leading_zeros() as usize;
-        let lz0 = __clzsi2(x);
-        let lz1 = usize_leading_zeros_default(x);
-        let lz2 = usize_leading_zeros_riscv(x);
-        if lz0 != lz {
-            panic!("__clzsi2({}): std: {}, builtins: {}", x, lz, lz0);
-        }
-        if lz1 != lz {
-            panic!(
-                "usize_leading_zeros_default({}): std: {}, builtins: {}",
-                x, lz, lz1
-            );
-        }
-        if lz2 != lz {
-            panic!(
-                "usize_leading_zeros_riscv({}): std: {}, builtins: {}",
-                x, lz, lz2
-            );
-        }
-    })
+    use compiler_builtins::int::leading_zeros::{leading_zeros_default, leading_zeros_riscv};
+    {
+        use compiler_builtins::int::leading_zeros::__clzsi2;
+        fuzz(N, |x: u32| {
+            if x == 0 {
+                return; // undefined value for an intrinsic
+            }
+            let lz = x.leading_zeros() as usize;
+            let lz0 = __clzsi2(x);
+            let lz1 = leading_zeros_default(x);
+            let lz2 = leading_zeros_riscv(x);
+            if lz0 != lz {
+                panic!("__clzsi2({}): std: {}, builtins: {}", x, lz, lz0);
+            }
+            if lz1 != lz {
+                panic!(
+                    "leading_zeros_default({}): std: {}, builtins: {}",
+                    x, lz, lz1
+                );
+            }
+            if lz2 != lz {
+                panic!("leading_zeros_riscv({}): std: {}, builtins: {}", x, lz, lz2);
+            }
+        });
+    }
+
+    {
+        use compiler_builtins::int::leading_zeros::__clzdi2;
+        fuzz(N, |x: u64| {
+            if x == 0 {
+                return; // undefined value for an intrinsic
+            }
+            let lz = x.leading_zeros() as usize;
+            let lz0 = __clzdi2(x);
+            let lz1 = leading_zeros_default(x);
+            let lz2 = leading_zeros_riscv(x);
+            if lz0 != lz {
+                panic!("__clzdi2({}): std: {}, builtins: {}", x, lz, lz0);
+            }
+            if lz1 != lz {
+                panic!(
+                    "leading_zeros_default({}): std: {}, builtins: {}",
+                    x, lz, lz1
+                );
+            }
+            if lz2 != lz {
+                panic!("leading_zeros_riscv({}): std: {}, builtins: {}", x, lz, lz2);
+            }
+        });
+    }
+
+    {
+        use compiler_builtins::int::leading_zeros::__clzti2;
+        fuzz(N, |x: u128| {
+            if x == 0 {
+                return; // undefined value for an intrinsic
+            }
+            let lz = x.leading_zeros() as usize;
+            let lz0 = __clzti2(x);
+            if lz0 != lz {
+                panic!("__clzti2({}): std: {}, builtins: {}", x, lz, lz0);
+            }
+        });
+    }
 }
 
 #[test]


### PR DESCRIPTION
This one was a bit interesting to figure out.

Firstly, the existing implementation was wrong, as it was working with whatever native word is, whereas `__clzsi2` should be 32-bit specifically (SI is 32-bit exactly). compiler-rt implementation is always 32-bit. Interestingly, existing CI tests didn't catch this because testcrate only tests against compiler-rt when compiled with `--no-default-features -F c` (because testcrate defaults `mangled-names`). When tested in this way, testcreate surely enough failed `__clzsi2` test on 64 bit target.

Even more interestingly, the compiler-rt implementation is also wrong! It is 32-bit implementation but it uses int type for its argument, so on 16-bit platform it couldn't get 32-bit value. I guess compiler-rt is not used much for 16 bit?

Now, libgcc implementation is the correct one. It always uses 16 bit types for HI functions, 32 bit types for SI, 64 bit for DI and 128 bit for TI. But it has its own twist: it only implements two functions out of all possible - one for native word size and one for double that. So on 16 bit it would be HI and SI, on 32 bit SI/DI and on 64 bit DI/TI. Which is why buggy existing implementation didn't caused any dramas: it would never be called as the compilers know it shouldn't even exist (indeed, even trying hard to call it via `__builtin_clz(uint32_t)` results in something akin to `_clzdi2(x as u64) - 32`).

So I did the same thing as with bswap - simply relegate work to the LLVM and let it spit out proper builtin implementation. i686 and x86-64 versions look great using `bsr`. Riscv64... cannot say if it became better or worse than it was; its a different algorithm, though both are branchless and logarithmic in complexity. One would need to benchmark it like crazy to decide which is better :)

I like new version better because of two things:
1) it could get better "for free" as llvm improves (definitely more eyes on llvm builtins than on compiler-builtins repo).
2) it could do much better if allowed (e.g. when there is a native cpu instruction to do it; Riscv64gc+Zbb functions const of two instructions).

With this implementation tests are not quite as useful; they can only work as a documentation of sorts since they check the same implementation against itself. Well, they also can check against compiler-rt so there's that.