### PR TITLE
Add `release-plz` for automatic releases.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Install Rust (rustup)
+        run: rustup update nightly --no-self-update && rustup default nightly
+      - name: Publish `libm` as part of builtins, rather than its own crate
+        run: rm libm/Cargo.toml
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,0 +1,3 @@
+[workspace]
+changelog_update = false
+semver_check = false

--- a/crates/panic-handler/Cargo.toml
+++ b/crates/panic-handler/Cargo.toml
@@ -3,5 +3,6 @@ name = "panic-handler"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2021"
+publish = false
 
 [dependencies]

--- a/testcrate/Cargo.toml
+++ b/testcrate/Cargo.toml
@@ -3,6 +3,7 @@ name = "testcrate"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2021"
+publish = false
 
 [lib]
 test = false


### PR DESCRIPTION
This is what `cc-rs` is using and should create a release PR whenever a change to `master` is made. If the branch is merged, it should publish the new version.

This will need the `CARGO_REGISTRY_TOKEN` github secret set, but I think omitting it for now might allow for a dry run.