### PR TITLE
Fix emscripten as `os` rather than `env`.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -55,7 +55,7 @@ fn main() {
     println!("cargo:rustc-cfg=feature=\"unstable\"");
 
     // Emscripten's runtime includes all the builtins
-    if target.env == "emscripten" {
+    if target.os == "emscripten" {
         return;
     }
 


### PR DESCRIPTION
b7af6078 ("Switch to a target structure...") is checking whether the target environment is emscripten, but it seems emscripten is the OS. Fix this, which should resolve the issue in
<https://github.com/rust-lang/rust/pull/128691#issuecomment-2269933428>.