### PR TITLE
Make all linker warnings errors in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ env:
   CARGO_TERM_VERBOSE: true
   LIBM_BUILD_VERBOSE: true
   RUSTDOCFLAGS: -Dwarnings
-  RUSTFLAGS: -Dwarnings
+  RUSTFLAGS: -Dwarnings -Dlinker_messages
   RUST_BACKTRACE: full
   BENCHMARK_RUSTC: nightly-2026-08-05 # Pin the toolchain for reproducable results
 


### PR DESCRIPTION
Give us a better chance of detecting any kind of link issues or user-visible warnings in advance.

Inspired by https://github.com/rust-lang/compiler-builtins/pull/665#issuecomment-2282830722