### PR TITLE
Apply fixes to `build.rs` files

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,9 @@ mod configure;
 use configure::{configure_f16_f128, Target};
 
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=configure.rs");
+
     let target = Target::from_env();
     let cwd = env::current_dir().unwrap();
 
@@ -46,7 +48,7 @@ fn main() {
     // These targets have hardware unaligned access support.
     println!("cargo::rustc-check-cfg=cfg(feature, values(\"mem-unaligned\"))");
     if target.arch.contains("x86_64")
-        || target.arch.contains("i686")
+        || target.arch.contains("x86")
         || target.arch.contains("aarch64")
         || target.arch.contains("bpf")
     {

--- a/configure.rs
+++ b/configure.rs
@@ -2,6 +2,7 @@
 
 use std::env;
 
+#[derive(Debug)]
 #[allow(dead_code)]
 pub struct Target {
     pub triple: String,
@@ -39,6 +40,11 @@ impl Target {
                 .map(ToOwned::to_owned)
                 .collect(),
         }
+    }
+
+    #[allow(dead_code)]
+    pub fn has_feature(&self, feature: &str) -> bool {
+        self.features.iter().any(|f| f == feature)
     }
 }
 

--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -14,6 +14,8 @@ mod builtins_configure {
 }
 
 fn main() {
+    println!("cargo::rerun-if-changed=../configure.rs");
+
     let target = builtins_configure::Target::from_env();
     let mut features = HashSet::new();
 
@@ -27,7 +29,7 @@ fn main() {
         || (target.os == "windows" && target.env == "gnu")
         // FIXME(llvm): There is an ABI incompatibility between GCC and Clang on 32-bit x86.
         // See <https://github.com/llvm/llvm-project/issues/77401>.
-        || target.arch == "i686"
+        || target.arch == "x86"
         // 32-bit PowerPC and 64-bit LE gets code generated that Qemu cannot handle. See
         // <https://github.com/rust-lang/compiler-builtins/pull/606#issuecomment-2105635926>.
         || target.arch == "powerpc"
@@ -41,7 +43,7 @@ fn main() {
         features.insert(Feature::NoSysF16F128Convert);
     }
 
-    if target.arch == "i586" || target.arch == "i686" {
+    if target.arch == "x86" {
         // 32-bit x86 does not have `__fixunstfti`/`__fixtfti` but does have everything else
         features.insert(Feature::NoSysF128IntConvert);
         // FIXME: 32-bit x86 has a bug in `f128 -> f16` system libraries
@@ -55,7 +57,7 @@ fn main() {
         || target.arch == "powerpc"
         || target.arch == "powerpc64"
         || target.arch == "powerpc64le"
-        || target.arch == "i586"
+        || (target.arch == "x86" && !target.has_feature("sse"))
         || target.os == "windows"
         // Linking says "error: function signature mismatch: __extendhfsf2" and seems to
         // think the signature is either `(i32) -> f32` or `(f32) -> f32`. See
@@ -72,11 +74,11 @@ fn main() {
             Feature::NoSysF128 => ("no-sys-f128", "using apfloat fallback for f128"),
             Feature::NoSysF128IntConvert => (
                 "no-sys-f128-int-convert",
-                "using apfloat fallback for f128 to int conversions",
+                "using apfloat fallback for f128 <-> int conversions",
             ),
             Feature::NoSysF16F128Convert => (
                 "no-sys-f16-f128-convert",
-                "skipping using apfloat fallback for f16 <-> f128 conversions",
+                "using apfloat fallback for f16 <-> f128 conversions",
             ),
             Feature::NoSysF16 => ("no-sys-f16", "using apfloat fallback for f16"),
         };


### PR DESCRIPTION
Make the following changes:

- Add `rerun-if-changed` to the new `configure.rs`, it seems this was causing incorrect caching.
- Change from matching `i686` to `x86`. The target triple starts with `i686` so that is what we were checking before, but the architecture is `x86`. This change should have been made when we added `struct Target`, update it now instead.