### PR TITLE
Fix ABI for `f16` builtins on Intel Apple targets

### DIFF
--- a/src/float/extend.rs
+++ b/src/float/extend.rs
@@ -86,6 +86,7 @@ intrinsics! {
 intrinsics! {
     #[avr_skip]
     #[aapcs_on_arm]
+    #[apple_f16_arg_abi]
     #[arm_aeabi_alias = __aeabi_h2f]
     #[cfg(f16_enabled)]
     pub extern "C" fn __extendhfsf2(a: f16) -> f32 {
@@ -94,6 +95,7 @@ intrinsics! {
 
     #[avr_skip]
     #[aapcs_on_arm]
+    #[apple_f16_arg_abi]
     #[cfg(f16_enabled)]
     pub extern "C" fn __gnu_h2f_ieee(a: f16) -> f32 {
         extend(a)

--- a/src/float/trunc.rs
+++ b/src/float/trunc.rs
@@ -134,6 +134,7 @@ intrinsics! {
 intrinsics! {
     #[avr_skip]
     #[aapcs_on_arm]
+    #[apple_f16_ret_abi]
     #[arm_aeabi_alias = __aeabi_f2h]
     #[cfg(f16_enabled)]
     pub extern "C" fn __truncsfhf2(a: f32) -> f16 {
@@ -142,6 +143,7 @@ intrinsics! {
 
     #[avr_skip]
     #[aapcs_on_arm]
+    #[apple_f16_ret_abi]
     #[cfg(f16_enabled)]
     pub extern "C" fn __gnu_f2h_ieee(a: f32) -> f16 {
         trunc(a)
@@ -149,6 +151,7 @@ intrinsics! {
 
     #[avr_skip]
     #[aapcs_on_arm]
+    #[apple_f16_ret_abi]
     #[arm_aeabi_alias = __aeabi_d2h]
     #[cfg(f16_enabled)]
     pub extern "C" fn __truncdfhf2(a: f64) -> f16 {


### PR DESCRIPTION
For builtins on x86 (32-bit and 64-bit) Apple platforms, `f16` is passed and returned like a `u16` unless the builtin involves `f128`. This PR adds two `#[win64_128bit_abi_hack]`-like attributes (`#[apple_f16_arg_abi]` and `#[apple_f16_ret_abi]`) to the `intrinsics` macro to handle this. This should fix the CI failure that's blocking rust-lang/rust#128349.