### PR TITLE
Use `macos-latest` in CI for `aarch64-apple-darwin`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
           os: ubuntu-latest
           rust: nightly
         - target: x86_64-apple-darwin
-          os: macos-latest
+          os: macos-13
           rust: nightly
         - target: i686-pc-windows-msvc
           os: windows-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
         - target: aarch64-apple-darwin
-          os: macos-14
+          os: macos-latest
           rust: nightly
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-latest


### PR DESCRIPTION
Per [the GitHub actions docs](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories), `macos-latest` now refers to the M1-CPU-using `macos-14`. This PR changes the `aarch64-apple-darwin` CI to match the other CI targets, which all use the `-latest` OS versions.