### PR TITLE
Don't include `math` for `unix` and `wasi` targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,16 @@ mod macros;
 pub mod float;
 pub mod int;
 
-// Disabled on x86 without sse2 due to ABI issues
-// <https://github.com/rust-lang/rust/issues/114479>
-#[cfg(not(all(target_arch = "x86", not(target_feature = "sse2"))))]
+// Disable for any of the following:
+// - x86 without sse2 due to ABI issues
+//   - <https://github.com/rust-lang/rust/issues/114479>
+// - All unix targets (linux, macos, freebsd, android, etc)
+// - wasm with known target_os
+#[cfg(not(any(
+    all(target_arch = "x86", not(target_feature = "sse2")),
+    unix,
+    all(target_family = "wasm", not(target_os = "unknown"))
+)))]
 pub mod math;
 pub mod mem;
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -17,7 +17,7 @@ macro_rules! no_mangle {
     }
 }
 
-#[cfg(all(not(windows), not(target_vendor = "apple")))]
+#[cfg(not(windows))]
 no_mangle! {
     fn acos(x: f64) -> f64;
     fn asin(x: f64) -> f64;
@@ -92,6 +92,7 @@ no_mangle! {
     fn fmodf(x: f32, y: f32) -> f32;
 }
 
+// allow for windows (and other targets)
 intrinsics! {
     pub extern "C" fn lgamma_r(x: f64, s: &mut i32) -> f64 {
         let r = self::libm::lgamma_r(x);


### PR DESCRIPTION
This fixes such as (https://github.com/rust-lang/rust/issues/128386) where, our implementation is being used on systems where there is already `math` library and its more performant and accurate.

So with this change, linux will go back to the previous behavior and not include these functions, windows and apple were generally not affected.

Looking at the targets we have builtin now in rust, everything else is probably good to have the math symbols.

> A note on the above, the `hermit` os uses `libm` directly for itself, but I think its Ok to keep providing math in `compiler_builtin` for it, its technically the same implementation either from `compiler_builtin`  or `hermit-builtins`.