### PR TITLE
[hexagon] Remove aliases w/o leading __

### DIFF
--- a/src/hexagon/dffma.s
+++ b/src/hexagon/dffma.s
@@ -3,8 +3,6 @@
         .type __hexagon_fmadf4,@function
  .global __hexagon_fmadf5
         .type __hexagon_fmadf5,@function
- .global fma
- .type fma,@function
  .global __qdsp_fmadf5 ; .set __qdsp_fmadf5, __hexagon_fmadf5
  .p2align 5
 __hexagon_fmadf4:

--- a/src/hexagon/dfminmax.s
+++ b/src/hexagon/dfminmax.s
@@ -1,17 +1,12 @@
  .text
  .global __hexagon_mindf3
  .global __hexagon_maxdf3
- .global fmin
- .type fmin,@function
- .global fmax
- .type fmax,@function
  .type __hexagon_mindf3,@function
  .type __hexagon_maxdf3,@function
  .global __qdsp_mindf3 ; .set __qdsp_mindf3, __hexagon_mindf3
  .global __qdsp_maxdf3 ; .set __qdsp_maxdf3, __hexagon_maxdf3
  .p2align 5
 __hexagon_mindf3:
-fmin:
  {
   p0 = dfclass(r1:0,#0x10)
   p1 = dfcmp.gt(r1:0,r3:2)
@@ -31,7 +26,6 @@ fmin:
 .size __hexagon_mindf3,.-__hexagon_mindf3
  .falign
 __hexagon_maxdf3:
-fmax:
  {
   p0 = dfclass(r1:0,#0x10)
   p1 = dfcmp.gt(r3:2,r1:0)

--- a/src/hexagon/fastmath2_dlib_asm.s
+++ b/src/hexagon/fastmath2_dlib_asm.s
@@ -1,7 +1,7 @@
         .text
-        .global fast2_dadd_asm
-        .type fast2_dadd_asm, @function
-fast2_dadd_asm:
+        .global __hexagon_fast2_dadd_asm
+        .type __hexagon_fast2_dadd_asm, @function
+__hexagon_fast2_dadd_asm:
         .falign
       {
         R7:6 = VABSDIFFH(R1:0, R3:2)
@@ -49,9 +49,9 @@ fast2_dadd_asm:
         jumpr r31
       }
         .text
-        .global fast2_dsub_asm
-        .type fast2_dsub_asm, @function
-fast2_dsub_asm:
+        .global __hexagon_fast2_dsub_asm
+        .type __hexagon_fast2_dsub_asm, @function
+__hexagon_fast2_dsub_asm:
         .falign
       {
         R7:6 = VABSDIFFH(R1:0, R3:2)
@@ -99,9 +99,9 @@ fast2_dsub_asm:
         jumpr r31
       }
         .text
-        .global fast2_dmpy_asm
-        .type fast2_dmpy_asm, @function
-fast2_dmpy_asm:
+        .global __hexagon_fast2_dmpy_asm
+        .type __hexagon_fast2_dmpy_asm, @function
+__hexagon_fast2_dmpy_asm:
         .falign
       {
         R13= lsr(R2, #16)
@@ -167,9 +167,9 @@ fast2_dmpy_asm:
         jumpr r31
       }
         .text
-        .global fast2_qd2f_asm
-        .type fast2_qd2f_asm, @function
-fast2_qd2f_asm:
+        .global __hexagon_fast2_qd2f_asm
+        .type __hexagon_fast2_qd2f_asm, @function
+__hexagon_fast2_qd2f_asm:
       .falign
      {
        R3 = abs(R1):sat
@@ -225,9 +225,9 @@ fast2_qd2f_asm:
        jumpr r31
      }
         .text
-        .global fast2_f2qd_asm
-        .type fast2_f2qd_asm, @function
-fast2_f2qd_asm:
+        .global __hexagon_fast2_f2qd_asm
+        .type __hexagon_fast2_f2qd_asm, @function
+__hexagon_fast2_f2qd_asm:
 
 
 

--- a/src/hexagon/fastmath2_ldlib_asm.s
+++ b/src/hexagon/fastmath2_ldlib_asm.s
@@ -1,7 +1,7 @@
         .text
-        .global fast2_ldadd_asm
-        .type fast2_ldadd_asm, @function
-fast2_ldadd_asm:
+        .global __hexagon_fast2ldadd_asm
+        .type __hexagon_fast2ldadd_asm, @function
+__hexagon_fast2ldadd_asm:
         .falign
       {
         R4 = memw(r29+#8)
@@ -54,9 +54,9 @@ fast2_ldadd_asm:
         jumpr r31
       }
         .text
-        .global fast2_ldsub_asm
-        .type fast2_ldsub_asm, @function
-fast2_ldsub_asm:
+        .global __hexagon_fast2ldsub_asm
+        .type __hexagon_fast2ldsub_asm, @function
+__hexagon_fast2ldsub_asm:
         .falign
       {
         R4 = memw(r29+#8)
@@ -109,9 +109,9 @@ fast2_ldsub_asm:
         jumpr r31
       }
         .text
-        .global fast2_ldmpy_asm
-        .type fast2_ldmpy_asm, @function
-fast2_ldmpy_asm:
+        .global __hexagon_fast2ldmpy_asm
+        .type __hexagon_fast2ldmpy_asm, @function
+__hexagon_fast2ldmpy_asm:
         .falign
       {
         R15:14 = memd(r29+#0)


### PR DESCRIPTION
These hexagon builtins incorrectly created aliases in the global namespace which can (and in at least one case, did) conflict with symbols defined by other programs.

This should address the issue reported as https://github.com/rust-lang/rust/issues/129823:

	   Compiling compiler_builtins v0.1.123
	   Compiling core v0.0.0 (/home/ben/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core)
	   Compiling rustc-std-workspace-core v1.99.0 (/home/ben/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/rustc-std-workspace-core)
	   Compiling byteorder v1.5.0
	   Compiling zerocopy v0.7.34
	error: symbol 'fma' is already defined

	error: could not compile `compiler_builtins` (lib) due to 1 previous error

Also: some of the symbols defined were not just aliases, so those are now qualified with `__hexagon_`.  The compiler does not yet emit calls to these particular ones, but if/when it does, it can use the new names.