### PR TITLE
use `naked_asm!` in `#[naked]` functions

### DIFF
--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -6,7 +6,7 @@ intrinsics! {
     #[naked]
     #[cfg(all(target_os = "uefi", not(feature = "no-asm")))]
     pub unsafe extern "C" fn __chkstk() {
-        core::arch::asm!(
+        core::arch::naked_asm!(
             ".p2align 2",
             "lsl    x16, x15, #4",
             "mov    x17, sp",
@@ -16,7 +16,6 @@ intrinsics! {
             "ldr    xzr, [x17]",
             "b.gt   1b",
             "ret",
-            options(noreturn)
         );
     }
 }

--- a/src/aarch64_linux.rs
+++ b/src/aarch64_linux.rs
@@ -136,7 +136,7 @@ macro_rules! compare_and_swap {
                 expected: int_ty!($bytes), desired: int_ty!($bytes), ptr: *mut int_ty!($bytes)
             ) -> int_ty!($bytes) {
                 // We can't use `AtomicI8::compare_and_swap`; we *are* compare_and_swap.
-                unsafe { core::arch::asm! {
+                unsafe { core::arch::naked_asm! {
                     // UXT s(tmp0), s(0)
                     concat!(uxt!($bytes), " ", reg!($bytes, 16), ", ", reg!($bytes, 0)),
                     "0:",
@@ -150,7 +150,6 @@ macro_rules! compare_and_swap {
                     "cbnz   w17, 0b",
                     "1:",
                     "ret",
-                    options(noreturn)
                 } }
             }
         }
@@ -166,7 +165,7 @@ macro_rules! compare_and_swap_i128 {
             pub unsafe extern "C" fn $name (
                 expected: i128, desired: i128, ptr: *mut i128
             ) -> i128 {
-                unsafe { core::arch::asm! {
+                unsafe { core::arch::naked_asm! {
                     "mov    x16, x0",
                     "mov    x17, x1",
                     "0:",
@@ -180,7 +179,6 @@ macro_rules! compare_and_swap_i128 {
                     "cbnz   w15, 0b",
                     "1:",
                     "ret",
-                    options(noreturn)
                 } }
             }
         }
@@ -196,7 +194,7 @@ macro_rules! swap {
             pub unsafe extern "C" fn $name (
                 left: int_ty!($bytes), right_ptr: *mut int_ty!($bytes)
             ) -> int_ty!($bytes) {
-                unsafe { core::arch::asm! {
+                unsafe { core::arch::naked_asm! {
                     // mov    s(tmp0), s(0)
                     concat!("mov ", reg!($bytes, 16), ", ", reg!($bytes, 0)),
                     "0:",
@@ -206,7 +204,6 @@ macro_rules! swap {
                     concat!(stxr!($ordering, $bytes), " w17, ", reg!($bytes, 16), ", [x1]"),
                     "cbnz   w17, 0b",
                     "ret",
-                    options(noreturn)
                 } }
             }
         }
@@ -222,7 +219,7 @@ macro_rules! fetch_op {
             pub unsafe extern "C" fn $name (
                 val: int_ty!($bytes), ptr: *mut int_ty!($bytes)
             ) -> int_ty!($bytes) {
-                unsafe { core::arch::asm! {
+                unsafe { core::arch::naked_asm! {
                     // mov    s(tmp0), s(0)
                     concat!("mov ", reg!($bytes, 16), ", ", reg!($bytes, 0)),
                     "0:",
@@ -234,7 +231,6 @@ macro_rules! fetch_op {
                     concat!(stxr!($ordering, $bytes), " w15, ", reg!($bytes, 17), ", [x1]"),
                     "cbnz  w15, 0b",
                     "ret",
-                    options(noreturn)
                 } }
             }
         }

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -23,7 +23,7 @@ intrinsics! {
     #[naked]
     #[cfg(not(target_env = "msvc"))]
     pub unsafe extern "C" fn __aeabi_uidivmod() {
-        core::arch::asm!(
+        core::arch::naked_asm!(
             "push {{lr}}",
             "sub sp, sp, #4",
             "mov r2, sp",
@@ -31,13 +31,12 @@ intrinsics! {
             "ldr r1, [sp]",
             "add sp, sp, #4",
             "pop {{pc}}",
-            options(noreturn)
         );
     }
 
     #[naked]
     pub unsafe extern "C" fn __aeabi_uldivmod() {
-        core::arch::asm!(
+        core::arch::naked_asm!(
             "push {{r4, lr}}",
             "sub sp, sp, #16",
             "add r4, sp, #8",
@@ -47,26 +46,24 @@ intrinsics! {
             "ldr r3, [sp, #12]",
             "add sp, sp, #16",
             "pop {{r4, pc}}",
-            options(noreturn)
         );
     }
 
     #[naked]
     pub unsafe extern "C" fn __aeabi_idivmod() {
-        core::arch::asm!(
+        core::arch::naked_asm!(
             "push {{r0, r1, r4, lr}}",
             bl!("__aeabi_idiv"),
             "pop {{r1, r2}}",
             "muls r2, r2, r0",
             "subs r1, r1, r2",
             "pop {{r4, pc}}",
-            options(noreturn)
         );
     }
 
     #[naked]
     pub unsafe extern "C" fn __aeabi_ldivmod() {
-        core::arch::asm!(
+        core::arch::naked_asm!(
             "push {{r4, lr}}",
             "sub sp, sp, #16",
             "add r4, sp, #8",
@@ -76,7 +73,6 @@ intrinsics! {
             "ldr r3, [sp, #12]",
             "add sp, sp, #16",
             "pop {{r4, pc}}",
-            options(noreturn)
         );
     }
 

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -14,9 +14,9 @@ intrinsics! {
         not(feature = "no-asm")
     ))]
     pub unsafe extern "C" fn __chkstk() {
-        core::arch::asm!(
+        core::arch::naked_asm!(
             "jmp __alloca", // Jump to __alloca since fallthrough may be unreliable"
-            options(noreturn, att_syntax)
+            options(att_syntax)
         );
     }
 
@@ -27,7 +27,7 @@ intrinsics! {
     ))]
     pub unsafe extern "C" fn _alloca() {
         // __chkstk and _alloca are the same function
-        core::arch::asm!(
+        core::arch::naked_asm!(
             "push   %ecx",
             "cmp    $0x1000,%eax",
             "lea    8(%esp),%ecx", // esp before calling this routine -> ecx
@@ -47,7 +47,7 @@ intrinsics! {
             "push   (%eax)",        // push return address onto the stack
             "sub    %esp,%eax",     // restore the original value in eax
             "ret",
-            options(noreturn, att_syntax)
+            options(att_syntax)
         );
     }
 }

--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -14,7 +14,7 @@ intrinsics! {
         not(feature = "no-asm")
     ))]
     pub unsafe extern "C" fn ___chkstk_ms() {
-        core::arch::asm!(
+        core::arch::naked_asm!(
             "push   %rcx",
             "push   %rax",
             "cmp    $0x1000,%rax",
@@ -32,7 +32,7 @@ intrinsics! {
             "pop    %rax",
             "pop    %rcx",
             "ret",
-            options(noreturn, att_syntax)
+            options(att_syntax)
         );
     }
 }


### PR DESCRIPTION
Part of an effort to stabilize `#[naked]` functions https://github.com/rust-lang/rust/issues/90957

This PR uses `naked_asm!` instead of `asm!` in all `#[naked]` functions, and removes `options(noreturn)` which is implicit with `naked_asm!`

the PR introducing `naked_asm!` just got merged https://github.com/rust-lang/rust/pull/130146, so it'll likely take some time before this can get merged. Does `compiler-builtins` use the latest nightly, or is it a little behind?

cc @Amanieu 