### PR TITLE
Fixed `__divtf3` having wrong cfg for f128

### DIFF
--- a/src/float/div.rs
+++ b/src/float/div.rs
@@ -620,7 +620,7 @@ intrinsics! {
 
     #[avr_skip]
     #[ppc_alias = __divkf3]
-    #[cfg(not(feature = "no-f16-f128"))]
+    #[cfg(f128_enabled)]
     pub extern "C" fn __divtf3(a: f128, b: f128) -> f128 {
         div(a, b)
     }


### PR DESCRIPTION
This caused target with `f128` automatically disabled (as opposed to disabled via `no-f16-f128`) to not compile and complain about `f128` being unstable