### PR TITLE
Revert "Bump cc dependency"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ test = false
 core = { version = "1.0.0", optional = true, package = 'rustc-std-workspace-core' }
 
 [build-dependencies]
-cc = { optional = true, version = "1.1" }
+cc = { optional = true, version = "1.0" }
 
 [dev-dependencies]
 panic-handler = { path = 'crates/panic-handler' }


### PR DESCRIPTION
Reverts rust-lang/compiler-builtins#690

I am going to do this so we can continue to update builtins without forcing a `cc` bump in `library/Cargo.lock`, which has been problematic (see https://github.com/rust-lang/rust/pull/130720). Further, I'm not sure this was actually needed since the builtins we ship uses that locked version of `cc` anyway.

cc @arttet