### PR TITLE
Revert "Temporarily `use define_rust_probestack;`"

### DIFF
--- a/src/probestack.rs
+++ b/src/probestack.rs
@@ -120,10 +120,6 @@ macro_rules! define_rust_probestack {
     };
 }
 
-// FIXME(rust-lang/rust#126984): Remove allow once lint is fixed
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use define_rust_probestack;
-
 // Our goal here is to touch each page between %rsp+8 and %rsp+8-%rax,
 // ensuring that if any pages are unmapped we'll make a page fault.
 //


### PR DESCRIPTION
<https://github.com/rust-lang/rust/issues/126984> has been resolved. Remove the workaround that was introduced to suppress it.

This reverts commit 254edbcad4cfd6a8af32e3297c1037d7984c3c49.