### PR TITLE
Upgrade CI LLVM version to 19.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 env:
   RUSTDOCFLAGS: -Dwarnings
   RUSTFLAGS: -Dwarnings
-  RUST_LLVM_VERSION: 18.0-2024-02-13
+  RUST_LLVM_VERSION: 19.1-2024-09-17
   RUST_COMPILER_RT_ROOT: ./compiler-rt
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ to test against, located in a directory called `compiler-rt`. This can be
 obtained with the following:
 
 ```sh
-curl -L -o rustc-llvm-18.0.tar.gz https://github.com/rust-lang/llvm-project/archive/rustc/18.0-2024-02-13.tar.gz
-tar xzf rustc-llvm-18.0.tar.gz --strip-components 1 llvm-project-rustc-18.0-2024-02-13/compiler-rt
+curl -L -o rustc-llvm-19.1.tar.gz https://github.com/rust-lang/llvm-project/archive/rustc/19.1-2024-09-17.tar.gz
+tar xzf rustc-llvm-19.1.tar.gz --strip-components 1 llvm-project-rustc-19.1-2024-09-17/compiler-rt
 ```
 
 Local targets may also be tested with `./ci/run.sh [target]`.


### PR DESCRIPTION
19.1 is the latest stable release from 2024-09-17. This will match what is currently being used in rust-lang/rust.