### PR TITLE
fix(int): avoid infinite recursion on left shift

### DIFF
--- a/src/int/big.rs
+++ b/src/int/big.rs
@@ -222,6 +222,10 @@ impl HInt for u128 {
     fn widen_mul(self, rhs: Self) -> Self::D {
         self.zero_widen_mul(rhs)
     }
+
+    fn widen_hi(self) -> Self::D {
+        self.widen() << <Self as MinInt>::BITS
+    }
 }
 
 impl HInt for i128 {
@@ -246,6 +250,10 @@ impl HInt for i128 {
 
     fn widen_mul(self, rhs: Self) -> Self::D {
         unimplemented!("signed i128 widening multiply is not used")
+    }
+
+    fn widen_hi(self) -> Self::D {
+        self.widen() << <Self as MinInt>::BITS
     }
 }
 

--- a/src/int/mod.rs
+++ b/src/int/mod.rs
@@ -319,9 +319,7 @@ pub(crate) trait HInt: Int {
     /// around problems with associated type bounds (such as `Int<Othersign: DInt>`) being unstable
     fn zero_widen(self) -> Self::D;
     /// Widens the integer to have double bit width and shifts the integer into the higher bits
-    fn widen_hi(self) -> Self::D {
-        self.widen() << <Self as MinInt>::BITS
-    }
+    fn widen_hi(self) -> Self::D;
     /// Widening multiplication with zero widening. This cannot overflow.
     fn zero_widen_mul(self, rhs: Self) -> Self::D;
     /// Widening multiplication. This cannot overflow.
@@ -363,6 +361,9 @@ macro_rules! impl_h_int {
                 }
                 fn widen_mul(self, rhs: Self) -> Self::D {
                     self.widen().wrapping_mul(rhs.widen())
+                }
+                fn widen_hi(self) -> Self::D {
+                    (self as $X) << <Self as MinInt>::BITS
                 }
             }
         )*


### PR DESCRIPTION
Please, see this discussion for the full
context: https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/.5Bwasm32.5D.20Infinite.20recursion.20.60compiler-builtins.60.20.60__multi3.60