### PR TITLE
Re-enable math module on i686-unknown-uefi

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,10 +44,16 @@ pub mod int;
 // Disable for any of the following:
 // - x86 without sse2 due to ABI issues
 //   - <https://github.com/rust-lang/rust/issues/114479>
+//   - but exclude UEFI since it is a soft-float target
+//     - <https://github.com/rust-lang/rust/issues/128533>
 // - All unix targets (linux, macos, freebsd, android, etc)
 // - wasm with known target_os
 #[cfg(not(any(
-    all(target_arch = "x86", not(target_feature = "sse2")),
+    all(
+        target_arch = "x86",
+        not(target_feature = "sse2"),
+        not(target_os = "uefi"),
+    ),
     unix,
     all(target_family = "wasm", not(target_os = "unknown"))
 )))]


### PR DESCRIPTION
In 9ba77d1583e6de5ab9cf7c9b82827ba8fcb9062f, this was disabled for x86 without sse2. It should be fine to re-enable it for UEFI, as explained at <https://github.com/rust-lang/rust/issues/128533#issuecomment-2408699671>.