### PR TITLE
Disable `f16` for LoongArch64

### DIFF
--- a/configure.rs
+++ b/configure.rs
@@ -64,7 +64,7 @@ pub fn configure_f16_f128(target: &Target) {
         "arm64ec" => (false, false),
         // `f16` crashes <https://github.com/llvm/llvm-project/issues/50374>
         "s390x" => (false, true),
-        // `f16` test failures
+        // FIXME(llvm): `f16` test failures fixed by <https://github.com/llvm/llvm-project/pull/107791>
         "loongarch64" => (false, true),
         // `f128` crashes <https://github.com/llvm/llvm-project/issues/96432>
         "mips64" | "mips64r6" => (true, false),

--- a/configure.rs
+++ b/configure.rs
@@ -64,6 +64,8 @@ pub fn configure_f16_f128(target: &Target) {
         "arm64ec" => (false, false),
         // `f16` crashes <https://github.com/llvm/llvm-project/issues/50374>
         "s390x" => (false, true),
+        // `f16` test failures
+        "loongarch64" => (false, true),
         // `f128` crashes <https://github.com/llvm/llvm-project/issues/96432>
         "mips64" | "mips64r6" => (true, false),
         // `f128` crashes <https://github.com/llvm/llvm-project/issues/101545>


### PR DESCRIPTION
Disable `f161` for LoongArch64 due to incorrect code generation on LLVM 19, which causes failures in `testcrate/tests/conv.rs`. This workaround will remain in place until llvm/llvm-project#109093 is merged or we upgrade to LLVM 20.
