### PR TITLE
ci: add support for loongarch64-unknown-linux-gnu

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,9 @@ jobs:
         - target: i686-unknown-linux-gnu
           os: ubuntu-latest
           rust: nightly
+        - target: loongarch64-unknown-linux-gnu
+          os: ubuntu-latest
+          rust: nightly
         # MIPS targets disabled since they are dropped to tier 3.
         # See https://github.com/rust-lang/compiler-team/issues/648
         #- target: mips-unknown-linux-gnu

--- a/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
@@ -1,0 +1,13 @@
+ARG IMAGE=ubuntu:24.04
+FROM $IMAGE
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc libc6-dev qemu-user-static ca-certificates \
+    gcc-14-loongarch64-linux-gnu libc6-dev-loong64-cross
+
+ENV CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER=loongarch64-linux-gnu-gcc-14 \
+    CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_RUNNER=qemu-loongarch64-static \
+    CC_loongarch64_unknown_linux_gnu=loongarch64-linux-gnu-gcc-14 \
+    QEMU_LD_PREFIX=/usr/loongarch64-linux-gnu \
+    RUST_TEST_THREADS=1


### PR DESCRIPTION
On top of #722 and #724