### PR TITLE
Enable the changelog for `release-plz`

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,5 +1,4 @@
 [workspace]
-changelog_update = false
 semver_check = false
 
 # As part of the release process, we delete `libm/Cargo.toml`. Since


### PR DESCRIPTION
This crate isn't meant for direct use, but having an easy way to see what changed between versions would still be helpful when this crate is updated in rust-lang/rust.