### PR TITLE
Remove incorrect `sparcv9` match pattern from `configure_f16_f128`

### DIFF
--- a/configure.rs
+++ b/configure.rs
@@ -71,7 +71,7 @@ pub fn configure_f16_f128(target: &Target) {
         // `f128` crashes <https://github.com/llvm/llvm-project/issues/101545>
         "powerpc64" if &target.os == "aix" => (true, false),
         // `f128` crashes <https://github.com/llvm/llvm-project/issues/41838>
-        "sparc" | "sparcv9" => (true, false),
+        "sparc" => (true, false),
         // `f16` miscompiles <https://github.com/llvm/llvm-project/issues/96438>
         "wasm32" | "wasm64" => (false, true),
         // Most everything else works as of LLVM 19


### PR DESCRIPTION
`sparcv9-sun-solaris` (the only `sparcv9-` target) [uses the target architecture `sparc64`](https://github.com/rust-lang/rust/blob/b8c8287a229cd79604aa84c25e1235fc78cd5f2e/compiler/rustc_target/src/spec/targets/sparcv9_sun_solaris.rs#L27), so this pattern will never match anything. As `sparcv9-sun-solaris` is a 64-bit target, it is unaffected by the LLVM issue (https://github.com/llvm/llvm-project/issues/41838) so no replacement pattern needs to be added to replace `"sparcv9"`.