### PR TITLE
Add integer to `f16` conversions

### DIFF
--- a/builtins-test/Cargo.toml
+++ b/builtins-test/Cargo.toml
@@ -35,9 +35,10 @@ no-asm = ["compiler_builtins/no-asm"]
 mem = ["compiler_builtins/mem"]
 mangled-names = ["compiler_builtins/mangled-names"]
 # Skip tests that rely on f128 symbols being available on the system
-no-sys-f128 = ["no-sys-f128-int-convert", "no-sys-f16-f128-convert"]
+no-sys-f128 = ["no-sys-f16-int-convert", "no-sys-f128-int-convert", "no-sys-f16-f128-convert"]
 # Some platforms have some f128 functions but everything except integer conversions
 no-sys-f128-int-convert = []
+no-sys-f16-int-convert = []
 no-sys-f16-f128-convert = []
 no-sys-f16-f64-convert = []
 # Skip tests that rely on f16 symbols being available on the system

--- a/builtins-test/build.rs
+++ b/builtins-test/build.rs
@@ -11,6 +11,7 @@ enum Feature {
     NoSysF128IntConvert,
     NoSysF16,
     NoSysF16F64Convert,
+    NoSysF16IntConvert,
     NoSysF16F128Convert,
 }
 
@@ -19,7 +20,13 @@ impl Feature {
         match self {
             Self::NoSysF128 => [Self::NoSysF128IntConvert, Self::NoSysF16F128Convert].as_slice(),
             Self::NoSysF128IntConvert => [].as_slice(),
-            Self::NoSysF16 => [Self::NoSysF16F64Convert, Self::NoSysF16F128Convert].as_slice(),
+            Self::NoSysF16 => [
+                Self::NoSysF16IntConvert,
+                Self::NoSysF16F64Convert,
+                Self::NoSysF16F128Convert,
+            ]
+            .as_slice(),
+            Self::NoSysF16IntConvert => [].as_slice(),
             Self::NoSysF16F64Convert => [].as_slice(),
             Self::NoSysF16F128Convert => [].as_slice(),
         }
@@ -80,9 +87,11 @@ fn main() {
         features.insert(Feature::NoSysF16);
     }
 
-    // These platforms are missing either `__extendhfdf2` or `__truncdfhf2`.
+    // These platforms are missing either `__extendhfdf2` or `__truncdfhf2` and int
+    // conversions.
     if target.vendor == "apple" || target.os == "windows" {
         features.insert(Feature::NoSysF16F64Convert);
+        features.insert(Feature::NoSysF16IntConvert);
     }
 
     // Add implied features. Collection is required for borrows.
@@ -100,6 +109,10 @@ fn main() {
             Feature::NoSysF128IntConvert => (
                 "no-sys-f128-int-convert",
                 "using apfloat fallback for f128 <-> int conversions",
+            ),
+            Feature::NoSysF16IntConvert => (
+                "no-sys-f16-int-convert",
+                "using apfloat fallback for f16 <-> int conversions",
             ),
             Feature::NoSysF16F64Convert => (
                 "no-sys-f16-f64-convert",

--- a/builtins-test/tests/conv.rs
+++ b/builtins-test/tests/conv.rs
@@ -40,6 +40,7 @@ mod i_to_f {
                         );
                         let f1: $f_ty = $fn(x);
 
+                        // cfg needed for f->i conversions
                         #[cfg($sys_available)] {
                             // This makes sure that the conversion produced the best rounding possible, and does
                             // this independent of `x as $into` rounding correctly.
@@ -60,9 +61,12 @@ mod i_to_f {
                                     && ((f0.to_bits() & 1) != 0))
                             {
                                 panic!(
-                                    "incorrect rounding by {}({}): {}, ({}, {}, {}), errors ({}, {}, {})",
+                                    "incorrect rounding by {}({}): {} ({:#x})\n\
+                                        f->i bracket: ({}, {}, {})\n\
+                                        errors: ({}, {}, {})",
                                     stringify!($fn),
                                     x,
+                                    f1,
                                     f1.to_bits(),
                                     y_minus_ulp,
                                     y,

--- a/builtins-test/tests/conv.rs
+++ b/builtins-test/tests/conv.rs
@@ -34,7 +34,7 @@ mod i_to_f {
                                     FloatTy::from_u128(x.try_into().unwrap()).value
                                 };
 
-                                <$f_ty>::from_bits(apf.to_bits())
+                                <$f_ty>::from_bits(apf.to_bits().try_into().unwrap())
                             },
                             x
                         );
@@ -94,6 +94,16 @@ mod i_to_f {
                 }
             )*
         };
+    }
+
+    #[cfg(f16_enabled)]
+    i_to_f! { f16, Half, not(feature = "no-sys-f16-int-convert"),
+        u32, __floatunsihf;
+        i32, __floatsihf;
+        u64, __floatundihf;
+        i64, __floatdihf;
+        u128, __floatuntihf;
+        i128, __floattihf;
     }
 
     i_to_f! { f32, Single, all(),

--- a/builtins-test/tests/conv.rs
+++ b/builtins-test/tests/conv.rs
@@ -96,6 +96,16 @@ mod i_to_f {
         };
     }
 
+    #[cfg(f16_enabled)]
+    i_to_f! { f16, Half, not(feature = "no-sys-f16-int-convert"),
+        u32, __floatunsihf;
+        i32, __floatsihf;
+        u64, __floatundihf;
+        i64, __floatdihf;
+        u128, __floatuntihf;
+        i128, __floattihf;
+    }
+
     i_to_f! { f32, Single, all(),
         u32, __floatunsisf;
         i32, __floatsisf;

--- a/builtins-test/tests/conv.rs
+++ b/builtins-test/tests/conv.rs
@@ -34,7 +34,7 @@ mod i_to_f {
                                     FloatTy::from_u128(x.try_into().unwrap()).value
                                 };
 
-                                <$f_ty>::from_bits(apf.to_bits())
+                                <$f_ty>::from_bits(apf.to_bits().try_into().unwrap())
                             },
                             x
                         );

--- a/compiler-builtins/README.md
+++ b/compiler-builtins/README.md
@@ -159,11 +159,17 @@ of being added to Rust.
 - [x] fixunstfdi.c
 - [x] fixunstfsi.c
 - [x] fixunstfti.c
+- [x] floatdihf.c (not yet in `compiler-rt` but emitted by LLVM)
 - [x] floatditf.c
+- [x] floatsihf.c (not yet in `compiler-rt` but emitted by LLVM)
 - [x] floatsitf.c
+- [x] floattihf.c (not yet in `compiler-rt` but emitted by LLVM)
 - [x] floattitf.c
+- [x] floatundihf.c (not yet in `compiler-rt` but emitted by LLVM)
 - [x] floatunditf.c
+- [x] floatunsihf.c (not yet in `compiler-rt` but emitted by LLVM)
 - [x] floatunsitf.c
+- [x] floatuntihf.c (not yet in `compiler-rt` but emitted by LLVM)
 - [x] floatuntitf.c
 - [x] multf3.c
 - [x] powitf2.c


### PR DESCRIPTION
These are not present in LLVM's `compiler-rt` but LLVM does emit them in some cases [1].

[1]: https://github.com/rust-lang/rust/issues/132614#issuecomment-2455910165