### PR TITLE
Fix a bug in `abs_diff`

### DIFF
--- a/src/int/mod.rs
+++ b/src/int/mod.rs
@@ -240,11 +240,7 @@ macro_rules! int_impl {
             }
 
             fn abs_diff(self, other: Self) -> Self {
-                if self < other {
-                    other.wrapping_sub(self)
-                } else {
-                    self.wrapping_sub(other)
-                }
+                self.abs_diff(other)
             }
 
             int_impl_common!($uty);
@@ -277,7 +273,7 @@ macro_rules! int_impl {
             }
 
             fn abs_diff(self, other: Self) -> $uty {
-                self.wrapping_sub(other).wrapping_abs() as $uty
+                self.abs_diff(other)
             }
 
             int_impl_common!($ity);


### PR DESCRIPTION
These implementations of `abs_diff` were added in c2ff1b3119 ("Completely overhaul fuzz testing"), but the signed implementation is wrong when |x| + |y| exceeds the integer's limits (e.g. `(-128).abs_diff(1)` should be 128 but currently these return 127.

Resolve this by just using `std`'s implementation since that is stable now. This isn't used anywhere critical, we probably just weren't hitting the edge case.