### PR TITLE
Disable f128 for amdgpu

### DIFF
--- a/configure.rs
+++ b/configure.rs
@@ -79,7 +79,7 @@ pub fn configure_f16_f128(target: &Target) {
     };
 
     let f128_enabled = match target.arch.as_str() {
-        // Unsupported (libcall is not supported)
+        // Unsupported (libcall is not supported) <https://github.com/llvm/llvm-project/issues/121122>
         "amdgpu" => false,
         // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
         "arm64ec" => false,

--- a/configure.rs
+++ b/configure.rs
@@ -79,6 +79,8 @@ pub fn configure_f16_f128(target: &Target) {
     };
 
     let f128_enabled = match target.arch.as_str() {
+        // Unsupported (libcall is not supported)
+        "amdgpu" => false,
         // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
         "arm64ec" => false,
         // Selection failure <https://github.com/llvm/llvm-project/issues/96432>


### PR DESCRIPTION
`compiler_builtins` fails to compile to amdgpu if f128 is enabled. The reason seems to be that compiler_builtins uses libcalls in the implementation. I’m not really familiar with what libcalls are, but the LLVM amdgpu backend explicitly does not support them.

Error message:
```
LLVM ERROR: unsupported libcall legalization
```

(The amdgpu target is not yet supported in rustc, there is an open PR here: https://github.com/rust-lang/rust/pull/134740)