### PR TITLE
Float trait: shorten prefixes, rename EXP_MAX to EXP_SAT

### DIFF
--- a/examples/intrinsics.rs
+++ b/examples/intrinsics.rs
@@ -640,7 +640,7 @@ fn run() {
 fn something_with_a_dtor(f: &dyn Fn()) {
     struct A<'a>(&'a (dyn Fn() + 'a));
 
-    impl<'a> Drop for A<'a> {
+    impl Drop for A<'_> {
         fn drop(&mut self) {
             (self.0)();
         }

--- a/src/float/add.rs
+++ b/src/float/add.rs
@@ -14,7 +14,7 @@ where
 
     let bits = F::BITS.cast();
     let significand_bits = F::SIG_BITS;
-    let max_exponent = F::EXP_MAX;
+    let max_exponent = F::EXP_SAT;
 
     let implicit_bit = F::IMPLICIT_BIT;
     let significand_mask = F::SIG_MASK;

--- a/src/float/add.rs
+++ b/src/float/add.rs
@@ -13,14 +13,14 @@ where
     let zero = F::Int::ZERO;
 
     let bits = F::BITS.cast();
-    let significand_bits = F::SIGNIFICAND_BITS;
-    let max_exponent = F::EXPONENT_MAX;
+    let significand_bits = F::SIG_BITS;
+    let max_exponent = F::EXP_MAX;
 
     let implicit_bit = F::IMPLICIT_BIT;
-    let significand_mask = F::SIGNIFICAND_MASK;
+    let significand_mask = F::SIG_MASK;
     let sign_bit = F::SIGN_MASK as F::Int;
     let abs_mask = sign_bit - one;
-    let exponent_mask = F::EXPONENT_MASK;
+    let exponent_mask = F::EXP_MASK;
     let inf_rep = exponent_mask;
     let quiet_bit = implicit_bit >> 1;
     let qnan_rep = exponent_mask | quiet_bit;

--- a/src/float/add.rs
+++ b/src/float/add.rs
@@ -143,9 +143,9 @@ where
 
         // If the addition carried up, we need to right-shift the result and
         // adjust the exponent:
-        if a_significand & implicit_bit << 4 != MinInt::ZERO {
+        if a_significand & (implicit_bit << 4) != MinInt::ZERO {
             let sticky = F::Int::from_bool(a_significand & one != MinInt::ZERO);
-            a_significand = a_significand >> 1 | sticky;
+            a_significand = (a_significand >> 1) | sticky;
             a_exponent += 1;
         }
     }
@@ -161,7 +161,7 @@ where
         let shift = (1 - a_exponent).cast();
         let sticky =
             F::Int::from_bool((a_significand << bits.wrapping_sub(shift).cast()) != MinInt::ZERO);
-        a_significand = a_significand >> shift.cast() | sticky;
+        a_significand = (a_significand >> shift.cast()) | sticky;
         a_exponent = 0;
     }
 
@@ -170,7 +170,7 @@ where
     let round_guard_sticky: i32 = a_significand_i32 & 0x7;
 
     // Shift the significand into place, and mask off the implicit bit.
-    let mut result = a_significand >> 3 & significand_mask;
+    let mut result = (a_significand >> 3) & significand_mask;
 
     // Insert the exponent and sign.
     result |= a_exponent.cast() << significand_bits;

--- a/src/float/cmp.rs
+++ b/src/float/cmp.rs
@@ -38,7 +38,7 @@ fn cmp<F: Float>(a: F, b: F) -> Result {
 
     let sign_bit = F::SIGN_MASK as F::Int;
     let abs_mask = sign_bit - one;
-    let exponent_mask = F::EXPONENT_MASK;
+    let exponent_mask = F::EXP_MASK;
     let inf_rep = exponent_mask;
 
     let a_rep = a.to_bits();
@@ -87,7 +87,7 @@ fn unord<F: Float>(a: F, b: F) -> bool {
 
     let sign_bit = F::SIGN_MASK as F::Int;
     let abs_mask = sign_bit - one;
-    let exponent_mask = F::EXPONENT_MASK;
+    let exponent_mask = F::EXP_MASK;
     let inf_rep = exponent_mask;
 
     let a_rep = a.to_bits();

--- a/src/float/conv.rs
+++ b/src/float/conv.rs
@@ -42,7 +42,7 @@ mod int_to_float {
     fn m_adj<F: Float>(m_base: F::Int, dropped_bits: F::Int) -> F::Int {
         // Branchlessly extract a `1` if rounding up should happen, 0 otherwise
         // This accounts for rounding to even.
-        let adj = (dropped_bits - (dropped_bits >> (F::BITS - 1) & !m_base)) >> (F::BITS - 1);
+        let adj = (dropped_bits - ((dropped_bits >> (F::BITS - 1)) & !m_base)) >> (F::BITS - 1);
 
         // Add one when we need to round up. Break ties to even.
         m_base + adj
@@ -129,7 +129,7 @@ mod int_to_float {
         let m_base: u32 = (i_m >> shift_f_lt_i::<u64, f32>()) as u32;
         // The entire lower half of `i` will be truncated (masked portion), plus the
         // next `EXP_BITS` bits.
-        let adj = (i_m >> f32::EXP_BITS | i_m & 0xFFFF) as u32;
+        let adj = ((i_m >> f32::EXP_BITS) | i_m & 0xFFFF) as u32;
         let m = m_adj::<f32>(m_base, adj);
         let e = if i == 0 { 0 } else { exp::<u64, f32>(n) - 1 };
         repr::<f32>(e, m)
@@ -187,7 +187,7 @@ mod int_to_float {
         let m_base: u64 = (i_m >> shift_f_lt_i::<u128, f64>()) as u64;
         // The entire lower half of `i` will be truncated (masked portion), plus the
         // next `EXP_BITS` bits.
-        let adj = (i_m >> f64::EXP_BITS | i_m & 0xFFFF_FFFF) as u64;
+        let adj = ((i_m >> f64::EXP_BITS) | i_m & 0xFFFF_FFFF) as u64;
         let m = m_adj::<f64>(m_base, adj);
         let e = if i == 0 { 0 } else { exp::<u128, f64>(n) - 1 };
         repr::<f64>(e, m)
@@ -377,7 +377,7 @@ where
         };
 
         // Set the implicit 1-bit.
-        let m: I::UnsignedInt = I::UnsignedInt::ONE << (I::BITS - 1) | m_base;
+        let m: I::UnsignedInt = (I::UnsignedInt::ONE << (I::BITS - 1)) | m_base;
 
         // Shift based on the exponent and bias.
         let s: u32 = (foobar) - u32::cast_from(fbits >> F::SIG_BITS);

--- a/src/float/div.rs
+++ b/src/float/div.rs
@@ -105,16 +105,16 @@ where
     let hw = F::BITS / 2;
     let lo_mask = F::Int::MAX >> hw;
 
-    let significand_bits = F::SIGNIFICAND_BITS;
+    let significand_bits = F::SIG_BITS;
     // Saturated exponent, representing infinity
-    let exponent_sat: F::Int = F::EXPONENT_MAX.cast();
+    let exponent_sat: F::Int = F::EXP_MAX.cast();
 
-    let exponent_bias = F::EXPONENT_BIAS;
+    let exponent_bias = F::EXP_BIAS;
     let implicit_bit = F::IMPLICIT_BIT;
-    let significand_mask = F::SIGNIFICAND_MASK;
+    let significand_mask = F::SIG_MASK;
     let sign_bit = F::SIGN_MASK;
     let abs_mask = sign_bit - one;
-    let exponent_mask = F::EXPONENT_MASK;
+    let exponent_mask = F::EXP_MASK;
     let inf_rep = exponent_mask;
     let quiet_bit = implicit_bit >> 1;
     let qnan_rep = exponent_mask | quiet_bit;

--- a/src/float/div.rs
+++ b/src/float/div.rs
@@ -261,7 +261,7 @@ where
         let c_hw = c_hw::<F>();
 
         // Check that the top bit is set, i.e. value is within `[1, 2)`.
-        debug_assert!(b_uq1_hw & one_hw << (HalfRep::<F>::BITS - 1) > zero_hw);
+        debug_assert!(b_uq1_hw & (one_hw << (HalfRep::<F>::BITS - 1)) > zero_hw);
 
         // b >= 1, thus an upper bound for 3/4 + 1/sqrt(2) - b/2 is about 0.9572,
         // so x0 fits to UQ0.HW without wrapping.

--- a/src/float/div.rs
+++ b/src/float/div.rs
@@ -107,7 +107,7 @@ where
 
     let significand_bits = F::SIG_BITS;
     // Saturated exponent, representing infinity
-    let exponent_sat: F::Int = F::EXP_MAX.cast();
+    let exponent_sat: F::Int = F::EXP_SAT.cast();
 
     let exponent_bias = F::EXP_BIAS;
     let implicit_bit = F::IMPLICIT_BIT;

--- a/src/float/extend.rs
+++ b/src/float/extend.rs
@@ -26,7 +26,7 @@ where
 
     let dst_bits = R::BITS;
     let dst_sign_bits = R::SIG_BITS;
-    let dst_inf_exp = R::EXP_MAX;
+    let dst_inf_exp = R::EXP_SAT;
     let dst_exp_bias = R::EXP_BIAS;
     let dst_min_normal = R::IMPLICIT_BIT;
 

--- a/src/float/extend.rs
+++ b/src/float/extend.rs
@@ -15,19 +15,19 @@ where
     let src_zero = F::Int::ZERO;
     let src_one = F::Int::ONE;
     let src_bits = F::BITS;
-    let src_sign_bits = F::SIGNIFICAND_BITS;
-    let src_exp_bias = F::EXPONENT_BIAS;
+    let src_sign_bits = F::SIG_BITS;
+    let src_exp_bias = F::EXP_BIAS;
     let src_min_normal = F::IMPLICIT_BIT;
-    let src_infinity = F::EXPONENT_MASK;
+    let src_infinity = F::EXP_MASK;
     let src_sign_mask = F::SIGN_MASK as F::Int;
     let src_abs_mask = src_sign_mask - src_one;
-    let src_qnan = F::SIGNIFICAND_MASK;
+    let src_qnan = F::SIG_MASK;
     let src_nan_code = src_qnan - src_one;
 
     let dst_bits = R::BITS;
-    let dst_sign_bits = R::SIGNIFICAND_BITS;
-    let dst_inf_exp = R::EXPONENT_MAX;
-    let dst_exp_bias = R::EXPONENT_BIAS;
+    let dst_sign_bits = R::SIG_BITS;
+    let dst_inf_exp = R::EXP_MAX;
+    let dst_exp_bias = R::EXP_BIAS;
     let dst_min_normal = R::IMPLICIT_BIT;
 
     let sign_bits_delta = dst_sign_bits - src_sign_bits;

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -51,11 +51,14 @@ pub(crate) trait Float:
     /// The bitwidth of the exponent.
     const EXP_BITS: u32 = Self::BITS - Self::SIG_BITS - 1;
 
-    /// The saturated value of the exponent (infinite representation), in the rightmost postiion.
-    const EXP_MAX: u32 = (1 << Self::EXP_BITS) - 1;
+    /// The saturated (maximum bitpattern) value of the exponent, i.e. the infinite
+    /// representation.
+    ///
+    /// This is in the rightmost position, use `EXP_MASK` for the shifted value.
+    const EXP_SAT: u32 = (1 << Self::EXP_BITS) - 1;
 
     /// The exponent bias value.
-    const EXP_BIAS: u32 = Self::EXP_MAX >> 1;
+    const EXP_BIAS: u32 = Self::EXP_SAT >> 1;
 
     /// A mask for the sign bit.
     const SIGN_MASK: Self::Int;

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -42,32 +42,32 @@ pub(crate) trait Float:
     const ZERO: Self;
     const ONE: Self;
 
-    /// The bitwidth of the float type
+    /// The bitwidth of the float type.
     const BITS: u32;
 
-    /// The bitwidth of the significand
-    const SIGNIFICAND_BITS: u32;
+    /// The bitwidth of the significand.
+    const SIG_BITS: u32;
 
-    /// The bitwidth of the exponent
-    const EXPONENT_BITS: u32 = Self::BITS - Self::SIGNIFICAND_BITS - 1;
+    /// The bitwidth of the exponent.
+    const EXP_BITS: u32 = Self::BITS - Self::SIG_BITS - 1;
 
     /// The saturated value of the exponent (infinite representation), in the rightmost postiion.
-    const EXPONENT_MAX: u32 = (1 << Self::EXPONENT_BITS) - 1;
+    const EXP_MAX: u32 = (1 << Self::EXP_BITS) - 1;
 
-    /// The exponent bias value
-    const EXPONENT_BIAS: u32 = Self::EXPONENT_MAX >> 1;
+    /// The exponent bias value.
+    const EXP_BIAS: u32 = Self::EXP_MAX >> 1;
 
-    /// A mask for the sign bit
+    /// A mask for the sign bit.
     const SIGN_MASK: Self::Int;
 
-    /// A mask for the significand
-    const SIGNIFICAND_MASK: Self::Int;
+    /// A mask for the significand.
+    const SIG_MASK: Self::Int;
 
-    /// The implicit bit of the float format
+    /// The implicit bit of the float format.
     const IMPLICIT_BIT: Self::Int;
 
-    /// A mask for the exponent
-    const EXPONENT_MASK: Self::Int;
+    /// A mask for the exponent.
+    const EXP_MASK: Self::Int;
 
     /// Returns `self` transmuted to `Self::Int`
     fn to_bits(self) -> Self::Int;
@@ -122,12 +122,12 @@ macro_rules! float_impl {
             const ONE: Self = 1.0;
 
             const BITS: u32 = $bits;
-            const SIGNIFICAND_BITS: u32 = $significand_bits;
+            const SIG_BITS: u32 = $significand_bits;
 
             const SIGN_MASK: Self::Int = 1 << (Self::BITS - 1);
-            const SIGNIFICAND_MASK: Self::Int = (1 << Self::SIGNIFICAND_BITS) - 1;
-            const IMPLICIT_BIT: Self::Int = 1 << Self::SIGNIFICAND_BITS;
-            const EXPONENT_MASK: Self::Int = !(Self::SIGN_MASK | Self::SIGNIFICAND_MASK);
+            const SIG_MASK: Self::Int = (1 << Self::SIG_BITS) - 1;
+            const IMPLICIT_BIT: Self::Int = 1 << Self::SIG_BITS;
+            const EXP_MASK: Self::Int = !(Self::SIGN_MASK | Self::SIG_MASK);
 
             fn to_bits(self) -> Self::Int {
                 self.to_bits()
@@ -142,8 +142,7 @@ macro_rules! float_impl {
                     // necessary builtin (__unordtf2) to test whether `f128` is NaN.
                     // FIXME(f16_f128): Remove once the nightly toolchain has the __unordtf2 builtin
                     // x is NaN if all the bits of the exponent are set and the significand is non-0
-                    x.to_bits() & $ty::EXPONENT_MASK == $ty::EXPONENT_MASK
-                        && x.to_bits() & $ty::SIGNIFICAND_MASK != 0
+                    x.to_bits() & $ty::EXP_MASK == $ty::EXP_MASK && x.to_bits() & $ty::SIG_MASK != 0
                 }
                 #[cfg(not(feature = "mangled-names"))]
                 fn is_nan(x: $ty) -> bool {
@@ -159,10 +158,10 @@ macro_rules! float_impl {
                 self.is_sign_negative()
             }
             fn exp(self) -> Self::ExpInt {
-                ((self.to_bits() & Self::EXPONENT_MASK) >> Self::SIGNIFICAND_BITS) as Self::ExpInt
+                ((self.to_bits() & Self::EXP_MASK) >> Self::SIG_BITS) as Self::ExpInt
             }
             fn frac(self) -> Self::Int {
-                self.to_bits() & Self::SIGNIFICAND_MASK
+                self.to_bits() & Self::SIG_MASK
             }
             fn imp_frac(self) -> Self::Int {
                 self.frac() | Self::IMPLICIT_BIT
@@ -173,21 +172,19 @@ macro_rules! float_impl {
             fn from_parts(negative: bool, exponent: Self::Int, significand: Self::Int) -> Self {
                 Self::from_bits(
                     ((negative as Self::Int) << (Self::BITS - 1))
-                        | ((exponent << Self::SIGNIFICAND_BITS) & Self::EXPONENT_MASK)
-                        | (significand & Self::SIGNIFICAND_MASK),
+                        | ((exponent << Self::SIG_BITS) & Self::EXP_MASK)
+                        | (significand & Self::SIG_MASK),
                 )
             }
             fn normalize(significand: Self::Int) -> (i32, Self::Int) {
-                let shift = significand
-                    .leading_zeros()
-                    .wrapping_sub(Self::EXPONENT_BITS);
+                let shift = significand.leading_zeros().wrapping_sub(Self::EXP_BITS);
                 (
                     1i32.wrapping_sub(shift as i32),
                     significand << shift as Self::Int,
                 )
             }
             fn is_subnormal(self) -> bool {
-                (self.to_bits() & Self::EXPONENT_MASK) == Self::Int::ZERO
+                (self.to_bits() & Self::EXP_MASK) == Self::Int::ZERO
             }
         }
     };

--- a/src/float/mul.rs
+++ b/src/float/mul.rs
@@ -13,20 +13,20 @@ where
     let zero = F::Int::ZERO;
 
     let bits = F::BITS;
-    let significand_bits = F::SIGNIFICAND_BITS;
-    let max_exponent = F::EXPONENT_MAX;
+    let significand_bits = F::SIG_BITS;
+    let max_exponent = F::EXP_MAX;
 
-    let exponent_bias = F::EXPONENT_BIAS;
+    let exponent_bias = F::EXP_BIAS;
 
     let implicit_bit = F::IMPLICIT_BIT;
-    let significand_mask = F::SIGNIFICAND_MASK;
-    let sign_bit = F::SIGN_MASK as F::Int;
+    let significand_mask = F::SIG_MASK;
+    let sign_bit = F::SIGN_MASK;
     let abs_mask = sign_bit - one;
-    let exponent_mask = F::EXPONENT_MASK;
+    let exponent_mask = F::EXP_MASK;
     let inf_rep = exponent_mask;
     let quiet_bit = implicit_bit >> 1;
     let qnan_rep = exponent_mask | quiet_bit;
-    let exponent_bits = F::EXPONENT_BITS;
+    let exponent_bits = F::EXP_BITS;
 
     let a_rep = a.to_bits();
     let b_rep = b.to_bits();

--- a/src/float/mul.rs
+++ b/src/float/mul.rs
@@ -154,7 +154,7 @@ where
         // not all zero so that the result is correctly rounded below.
         let sticky = product_low << (bits - shift) != zero;
         product_low =
-            product_high << (bits - shift) | product_low >> shift | (sticky as u32).cast();
+            (product_high << (bits - shift)) | (product_low >> shift) | (sticky as u32).cast();
         product_high >>= shift;
     } else {
         // Result is normal before rounding; insert the exponent.

--- a/src/float/mul.rs
+++ b/src/float/mul.rs
@@ -14,7 +14,7 @@ where
 
     let bits = F::BITS;
     let significand_bits = F::SIG_BITS;
-    let max_exponent = F::EXP_MAX;
+    let max_exponent = F::EXP_SAT;
 
     let exponent_bias = F::EXP_BIAS;
 

--- a/src/float/trunc.rs
+++ b/src/float/trunc.rs
@@ -96,7 +96,7 @@ where
             } else {
                 src_zero
             };
-            let denormalized_significand: F::Int = significand >> shift | sticky;
+            let denormalized_significand: F::Int = (significand >> shift) | sticky;
             abs_result = (denormalized_significand >> (F::SIG_BITS - R::SIG_BITS)).cast();
             let round_bits = denormalized_significand & round_mask;
             // Round to nearest

--- a/src/float/trunc.rs
+++ b/src/float/trunc.rs
@@ -29,7 +29,7 @@ where
     let dst_zero = R::Int::ZERO;
     let dst_one = R::Int::ONE;
     let dst_bits = R::BITS;
-    let dst_inf_exp = R::EXP_MAX;
+    let dst_inf_exp = R::EXP_SAT;
     let dst_exp_bias = R::EXP_BIAS;
 
     let underflow_exponent: F::Int = (src_exp_bias + 1 - dst_exp_bias).cast();

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -111,7 +111,7 @@ where
         let mut x = T::from(c);
         let mut i = 1;
         while i < mem::size_of::<T>() {
-            x = x << 8 | T::from(c);
+            x = (x << 8) | T::from(c);
             i += 1;
         }
 

--- a/testcrate/src/lib.rs
+++ b/testcrate/src/lib.rs
@@ -178,18 +178,18 @@ fn fuzz_float_step<F: Float>(rng: &mut Xoshiro128StarStar, f: &mut F) {
     let sign = (rng32 & 1) != 0;
 
     // exponent fuzzing. Only 4 bits for the selector needed.
-    let ones = (F::Int::ONE << F::EXPONENT_BITS) - F::Int::ONE;
-    let r0 = (rng32 >> 1) % F::EXPONENT_BITS;
-    let r1 = (rng32 >> 5) % F::EXPONENT_BITS;
+    let ones = (F::Int::ONE << F::EXP_BITS) - F::Int::ONE;
+    let r0 = (rng32 >> 1) % F::EXP_BITS;
+    let r1 = (rng32 >> 5) % F::EXP_BITS;
     // custom rotate shift. Note that `F::Int` is unsigned, so we can shift right without smearing
     // the sign bit.
     let mask = if r1 == 0 {
         ones.wrapping_shr(r0)
     } else {
         let tmp = ones.wrapping_shr(r0);
-        (tmp.wrapping_shl(r1) | tmp.wrapping_shr(F::EXPONENT_BITS - r1)) & ones
+        (tmp.wrapping_shl(r1) | tmp.wrapping_shr(F::EXP_BITS - r1)) & ones
     };
-    let mut exp = (f.to_bits() & F::EXPONENT_MASK) >> F::SIGNIFICAND_BITS;
+    let mut exp = (f.to_bits() & F::EXP_MASK) >> F::SIG_BITS;
     match (rng32 >> 9) % 4 {
         0 => exp |= mask,
         1 => exp &= mask,
@@ -197,9 +197,9 @@ fn fuzz_float_step<F: Float>(rng: &mut Xoshiro128StarStar, f: &mut F) {
     }
 
     // significand fuzzing
-    let mut sig = f.to_bits() & F::SIGNIFICAND_MASK;
+    let mut sig = f.to_bits() & F::SIG_MASK;
     fuzz_step(rng, &mut sig);
-    sig &= F::SIGNIFICAND_MASK;
+    sig &= F::SIG_MASK;
 
     *f = F::from_parts(sign, exp, sig);
 }
@@ -209,22 +209,22 @@ macro_rules! float_edge_cases {
         for exponent in [
             F::Int::ZERO,
             F::Int::ONE,
-            F::Int::ONE << (F::EXPONENT_BITS / 2),
-            (F::Int::ONE << (F::EXPONENT_BITS - 1)) - F::Int::ONE,
-            F::Int::ONE << (F::EXPONENT_BITS - 1),
-            (F::Int::ONE << (F::EXPONENT_BITS - 1)) + F::Int::ONE,
-            (F::Int::ONE << F::EXPONENT_BITS) - F::Int::ONE,
+            F::Int::ONE << (F::EXP_BITS / 2),
+            (F::Int::ONE << (F::EXP_BITS - 1)) - F::Int::ONE,
+            F::Int::ONE << (F::EXP_BITS - 1),
+            (F::Int::ONE << (F::EXP_BITS - 1)) + F::Int::ONE,
+            (F::Int::ONE << F::EXP_BITS) - F::Int::ONE,
         ]
         .iter()
         {
             for significand in [
                 F::Int::ZERO,
                 F::Int::ONE,
-                F::Int::ONE << (F::SIGNIFICAND_BITS / 2),
-                (F::Int::ONE << (F::SIGNIFICAND_BITS - 1)) - F::Int::ONE,
-                F::Int::ONE << (F::SIGNIFICAND_BITS - 1),
-                (F::Int::ONE << (F::SIGNIFICAND_BITS - 1)) + F::Int::ONE,
-                (F::Int::ONE << F::SIGNIFICAND_BITS) - F::Int::ONE,
+                F::Int::ONE << (F::SIG_BITS / 2),
+                (F::Int::ONE << (F::SIG_BITS - 1)) - F::Int::ONE,
+                F::Int::ONE << (F::SIG_BITS - 1),
+                (F::Int::ONE << (F::SIG_BITS - 1)) + F::Int::ONE,
+                (F::Int::ONE << F::SIG_BITS) - F::Int::ONE,
             ]
             .iter()
             {

--- a/testcrate/tests/float_pow.rs
+++ b/testcrate/tests/float_pow.rs
@@ -19,8 +19,8 @@ macro_rules! pow {
                 use compiler_builtins::float::Float;
                 fuzz_float_2(N, |x: $f, y: $f| {
                     if !(Float::is_subnormal(x) || Float::is_subnormal(y) || x.is_nan()) {
-                        let n = y.to_bits() & !<$f as Float>::SIGNIFICAND_MASK;
-                        let n = (n as <$f as Float>::SignedInt) >> <$f as Float>::SIGNIFICAND_BITS;
+                        let n = y.to_bits() & !<$f as Float>::SIG_MASK;
+                        let n = (n as <$f as Float>::SignedInt) >> <$f as Float>::SIG_BITS;
                         let n = n as i32;
                         let tmp0: $f = x.powi(n);
                         let tmp1: $f = $fn(x, n);


### PR DESCRIPTION
Change `SIGNIFICAND_*` to `SIG_*` and `EXPONENT_*` to `EXP_*`. This makes things more consistent with `libm`, and terseness is convenient here since there isn't anything to confuse.

---

"Maximum" is technically correct here with regards to what the bitpattern can represent, but it is not the numeric maximum value of the exponent which has a relationship with the bias. So, replace the maximum terminology with "saturated" to indicate it only means the full bitpattern.

---

`clippy::precedence` now applies to bitwise `&` and `|`. Update with all of its suggestions, including a separate elided lifetime suggestion.