### PR TITLE
Account for optimization levels other than numbers

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -121,7 +121,7 @@ fn configure_libm(target: &Target) {
     }
 
     println!("cargo:rustc-check-cfg=cfg(optimizations_enabled)");
-    if target.opt_level >= 2 {
+    if !matches!(target.opt_level.as_str(), "0" | "1") {
         println!("cargo:rustc-cfg=optimizations_enabled");
     }
 

--- a/configure.rs
+++ b/configure.rs
@@ -6,7 +6,7 @@ use std::env;
 #[allow(dead_code)]
 pub struct Target {
     pub triple: String,
-    pub opt_level: u8,
+    pub opt_level: String,
     pub cargo_features: Vec<String>,
     pub os: String,
     pub arch: String,
@@ -32,7 +32,7 @@ impl Target {
         Self {
             triple: env::var("TARGET").unwrap(),
             os: env::var("CARGO_CFG_TARGET_OS").unwrap(),
-            opt_level: env::var("OPT_LEVEL").unwrap().parse().unwrap(),
+            opt_level: env::var("OPT_LEVEL").unwrap(),
             cargo_features,
             arch: env::var("CARGO_CFG_TARGET_ARCH").unwrap(),
             vendor: env::var("CARGO_CFG_TARGET_VENDOR").unwrap(),


### PR DESCRIPTION
The build script currently panics with `opt-level=z` or `opt-level=s`. Account for this here.

This is the `compiler-builtins` version of [1]. This PR also includes the `libm` submodule update with [1], and a few other small changes.

Fixes: https://github.com/rust-lang/compiler-builtins/issues/742

[1]: https://github.com/rust-lang/libm/pull/417