### PR TITLE
Expose `erf{,c}{,f}` from `libm`

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -91,6 +91,11 @@ no_mangle! {
     fn fmod(x: f64, y: f64) -> f64;
     // `f32 % f32`
     fn fmodf(x: f32, y: f32) -> f32;
+
+    fn erf(x: f64) -> f64;
+    fn erff(x: f32) -> f32;
+    fn erfc(x: f64) -> f64;
+    fn erfcf(x: f32) -> f32;
 }
 
 // allow for windows (and other targets)


### PR DESCRIPTION
For https://github.com/rust-lang/rust/pull/136324