### PR TITLE
Change compiler-builtins to edition 2024

### DIFF
--- a/builtins-test-intrinsics/Cargo.toml
+++ b/builtins-test-intrinsics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "builtins-test-intrinsics"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 license = "MIT OR Apache-2.0"
 

--- a/builtins-test-intrinsics/src/main.rs
+++ b/builtins-test-intrinsics/src/main.rs
@@ -15,9 +15,10 @@
 
 extern crate panic_handler;
 
+// SAFETY: no definitions, only used for linking
 #[cfg(all(not(thumb), not(windows), not(target_arch = "wasm32")))]
 #[link(name = "c")]
-extern "C" {}
+unsafe extern "C" {}
 
 // Every function in this module maps will be lowered to an intrinsic by LLVM, if the platform
 // doesn't have native support for the operation used in the function. ARM has a naming convention
@@ -663,10 +664,11 @@ pub fn _start() -> ! {
     loop {}
 }
 
+// SAFETY: no definitions, only used for linking
 #[cfg(windows)]
 #[link(name = "kernel32")]
 #[link(name = "msvcrt")]
-extern "C" {}
+unsafe extern "C" {}
 
 // ARM targets need these symbols
 #[unsafe(no_mangle)]

--- a/builtins-test/tests/aeabi_memclr.rs
+++ b/builtins-test/tests/aeabi_memclr.rs
@@ -24,7 +24,8 @@ macro_rules! panic {
     };
 }
 
-extern "C" {
+// SAFETY: defined in  compiler-builtins
+unsafe extern "aapcs" {
     fn __aeabi_memclr4(dest: *mut u8, n: usize);
     fn __aeabi_memset4(dest: *mut u8, n: usize, c: u32);
 }

--- a/builtins-test/tests/aeabi_memcpy.rs
+++ b/builtins-test/tests/aeabi_memcpy.rs
@@ -22,7 +22,8 @@ macro_rules! panic {
     };
 }
 
-extern "C" {
+// SAFETY: defined in  compiler-builtins
+unsafe extern "aapcs" {
     fn __aeabi_memcpy(dest: *mut u8, src: *const u8, n: usize);
     fn __aeabi_memcpy4(dest: *mut u8, src: *const u8, n: usize);
 }

--- a/builtins-test/tests/aeabi_memset.rs
+++ b/builtins-test/tests/aeabi_memset.rs
@@ -24,7 +24,8 @@ macro_rules! panic {
     };
 }
 
-extern "C" {
+// SAFETY: defined in  compiler-builtins
+unsafe extern "aapcs" {
     fn __aeabi_memset4(dest: *mut u8, n: usize, c: u32);
 }
 

--- a/compiler-builtins/Cargo.toml
+++ b/compiler-builtins/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 repository = "https://github.com/rust-lang/compiler-builtins"
 homepage = "https://github.com/rust-lang/compiler-builtins"
 documentation = "https://docs.rs/compiler_builtins"
-edition = "2021"
+edition = "2024"
 description = "Compiler intrinsics used by the Rust compiler."
 links = "compiler-rt"
 

--- a/compiler-builtins/src/arm.rs
+++ b/compiler-builtins/src/arm.rs
@@ -1,13 +1,16 @@
 #![cfg(not(feature = "no-asm"))]
 
 // Interfaces used by naked trampolines.
-extern "C" {
+// SAFETY: these are defined in compiler-builtins
+unsafe extern "C" {
     fn __udivmodsi4(a: u32, b: u32, rem: *mut u32) -> u32;
     fn __udivmoddi4(a: u64, b: u64, rem: *mut u64) -> u64;
     fn __divmoddi4(a: i64, b: i64, rem: *mut i64) -> i64;
 }
 
-extern "aapcs" {
+// SAFETY: these are defined in compiler-builtins
+// FIXME(extern_custom), this isn't always the correct ABI
+unsafe extern "aapcs" {
     // AAPCS is not always the correct ABI for these intrinsics, but we only use this to
     // forward another `__aeabi_` call so it doesn't matter.
     fn __aeabi_idiv(a: i32, b: i32) -> i32;

--- a/compiler-builtins/src/int/specialized_div_rem/mod.rs
+++ b/compiler-builtins/src/int/specialized_div_rem/mod.rs
@@ -125,10 +125,10 @@ impl_normalization_shift!(
 /// dependencies.
 #[inline]
 fn u64_by_u64_div_rem(duo: u64, div: u64) -> (u64, u64) {
-    if let Some(quo) = duo.checked_div(div) {
-        if let Some(rem) = duo.checked_rem(div) {
-            return (quo, rem);
-        }
+    if let Some(quo) = duo.checked_div(div)
+        && let Some(rem) = duo.checked_rem(div)
+    {
+        return (quo, rem);
     }
     zero_div_fn()
 }
@@ -227,10 +227,10 @@ impl_asymmetric!(
 #[inline]
 #[allow(dead_code)]
 fn u32_by_u32_div_rem(duo: u32, div: u32) -> (u32, u32) {
-    if let Some(quo) = duo.checked_div(div) {
-        if let Some(rem) = duo.checked_rem(div) {
-            return (quo, rem);
-        }
+    if let Some(quo) = duo.checked_div(div)
+        && let Some(rem) = duo.checked_rem(div)
+    {
+        return (quo, rem);
     }
     zero_div_fn()
 }

--- a/compiler-builtins/src/macros.rs
+++ b/compiler-builtins/src/macros.rs
@@ -132,7 +132,7 @@ macro_rules! intrinsics {
     ) => (
         #[cfg($name = "optimized-c")]
         pub $(unsafe $($empty)? )? extern $abi fn $name( $($argname: $ty),* ) $(-> $ret)? {
-            extern $abi {
+            unsafe extern $abi {
                 fn $name($($argname: $ty),*) $(-> $ret)?;
             }
             unsafe {
@@ -435,7 +435,7 @@ macro_rules! intrinsics {
         pub mod $name {
             #[unsafe(naked)]
             $(#[$($attr)*])*
-            #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
+            #[cfg_attr(not(feature = "mangled-names"), unsafe(no_mangle))]
             #[cfg_attr(not(any(all(windows, target_env = "gnu"), target_os = "cygwin")), linkage = "weak")]
             pub unsafe extern $abi fn $name( $($argname: $ty),* ) $(-> $ret)? {
                 $($body)*

--- a/compiler-builtins/src/probestack.rs
+++ b/compiler-builtins/src/probestack.rs
@@ -49,7 +49,9 @@
 // We only define stack probing for these architectures today.
 #![cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 
-extern "C" {
+// SAFETY: defined in this module.
+// FIXME(extern_custom): the ABI is not correct.
+unsafe extern "C" {
     pub fn __rust_probestack();
 }
 

--- a/crates/symbol-check/src/main.rs
+++ b/crates/symbol-check/src/main.rs
@@ -46,15 +46,16 @@ fn main() {
 /// Run `cargo build` with the provided additional arguments, collecting the list of created
 /// libraries.
 fn exec_cargo_with_args(args: &[&str]) -> Vec<PathBuf> {
-    let mut cmd = Command::new("cargo")
-        .arg("build")
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build")
         .arg("--message-format=json")
         .args(args)
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("failed to launch Cargo");
+        .stdout(Stdio::piped());
 
-    let stdout = cmd.stdout.take().unwrap();
+    println!("running: {cmd:?}");
+    let mut child = cmd.spawn().expect("failed to launch Cargo");
+
+    let stdout = child.stdout.take().unwrap();
     let reader = BufReader::new(stdout);
     let mut check_files = Vec::new();
 
@@ -84,7 +85,7 @@ fn exec_cargo_with_args(args: &[&str]) -> Vec<PathBuf> {
         }
     }
 
-    assert!(cmd.wait().expect("failed to wait on Cargo").success());
+    assert!(child.wait().expect("failed to wait on Cargo").success());
 
     assert!(!check_files.is_empty(), "no compiler_builtins rlibs found");
     println!("Collected the following rlibs to check: {check_files:#?}");


### PR DESCRIPTION
Do the same for `builtins-test-intrinsics`. Mostly this means updating
`extern` to `unsafe extern`, and fixing a few new Clippy lints.