### PR TITLE
remove win64_128bit_abi_hack

### DIFF
--- a/src/float/conv.rs
+++ b/src/float/conv.rs
@@ -403,7 +403,6 @@ intrinsics! {
         float_to_unsigned_int(f)
     }
 
-    #[win64_128bit_abi_hack]
     pub extern "C" fn __fixunssfti(f: f32) -> u128 {
         float_to_unsigned_int(f)
     }
@@ -418,7 +417,6 @@ intrinsics! {
         float_to_unsigned_int(f)
     }
 
-    #[win64_128bit_abi_hack]
     pub extern "C" fn __fixunsdfti(f: f64) -> u128 {
         float_to_unsigned_int(f)
     }
@@ -454,7 +452,6 @@ intrinsics! {
         float_to_signed_int(f)
     }
 
-    #[win64_128bit_abi_hack]
     pub extern "C" fn __fixsfti(f: f32) -> i128 {
         float_to_signed_int(f)
     }
@@ -469,7 +466,6 @@ intrinsics! {
         float_to_signed_int(f)
     }
 
-    #[win64_128bit_abi_hack]
     pub extern "C" fn __fixdfti(f: f64) -> i128 {
         float_to_signed_int(f)
     }

--- a/src/int/sdiv.rs
+++ b/src/int/sdiv.rs
@@ -165,5 +165,5 @@ sdivmod!(
     i128,
     maybe_use_optimized_c_shim
 );
-sdiv!(__udivti3, __divti3, u128, i128, win64_128bit_abi_hack);
-smod!(__umodti3, __modti3, u128, i128, win64_128bit_abi_hack);
+sdiv!(__udivti3, __divti3, u128, i128,);
+smod!(__umodti3, __modti3, u128, i128,);

--- a/src/int/udiv.rs
+++ b/src/int/udiv.rs
@@ -58,7 +58,6 @@ intrinsics! {
     // the existence of `u128_div_rem` to get 32-bit SPARC to compile, see `u128_divide_sparc` docs.
 
     #[avr_skip]
-    #[win64_128bit_abi_hack]
     /// Returns `n / d`
     pub extern "C" fn __udivti3(n: u128, d: u128) -> u128 {
         #[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))] {
@@ -70,7 +69,6 @@ intrinsics! {
     }
 
     #[avr_skip]
-    #[win64_128bit_abi_hack]
     /// Returns `n % d`
     pub extern "C" fn __umodti3(n: u128, d: u128) -> u128 {
         #[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))] {
@@ -84,7 +82,6 @@ intrinsics! {
     }
 
     #[avr_skip]
-    #[win64_128bit_abi_hack]
     /// Returns `n / d` and sets `*rem = n % d`
     pub extern "C" fn __udivmodti4(n: u128, d: u128, rem: Option<&mut u128>) -> u128 {
         #[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))] {


### PR DESCRIPTION
For msvc and GNU targets, that hack is no longer needed -- rustc by itself now returns i128/u128 via xmm0 on these targets. That got implemented in https://github.com/rust-lang/rust/pull/134290.

For the x86_64-unknown-uefi target, the situation still seems a bit unclear, but using a `repr(simd)` is definitely wrong for that target as SIMD is not available. So I can't imagine that this PR would make anything any worse...

Fixes https://github.com/rust-lang/compiler-builtins/issues/758