### PR TITLE
Enable `f16` for MIPS

### DIFF
--- a/configure.rs
+++ b/configure.rs
@@ -78,7 +78,6 @@ pub fn configure_f16_f128(target: &Target) {
         "csky" => false,
         "hexagon" => false,
         "loongarch64" => false,
-        "mips" | "mips64" | "mips32r6" | "mips64r6" => false,
         "powerpc" | "powerpc64" => false,
         "sparc" | "sparc64" => false,
         "wasm32" | "wasm64" => false,


### PR DESCRIPTION
It seems as if `f16` works on MIPS now according to my testing on Rust master with LLVM 20, and I was asked [here](https://github.com/rust-lang/rust/pull/137167#issuecomment-2669387820) to create PRs with my changes.

I only tested on the flavour of `mipsel-unknown-linux-gnu` hardware that happens to be available to me, so I can't say anything about other MIPS hardware, but from a casual skimming of the LLVM code ([1], [2]) it seems like `f16` should work on all MIPS hardware. So enable it for all MIPS hardware.

[1]: https://github.com/rust-lang/llvm-project/blob/rustc/20.1-2025-02-13/llvm/lib/Target/Mips/MipsISelLowering.h#L370
[2]: https://github.com/rust-lang/llvm-project/blob/rustc/20.1-2025-02-13/llvm/lib/CodeGen/TargetLoweringBase.cpp#L1367-L1388

r? @tgross35

Tracking issue for f16: https://github.com/rust-lang/rust/issues/116909