### PR TITLE
Revert "ci: Pin the nightly toolchain for i686-pc-windows-gnu"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,8 +99,7 @@ jobs:
           test_verbatim: 1
         - target: i686-pc-windows-gnu
           os: windows-latest
-          # FIXME: pinned due to https://github.com/rust-lang/rust/issues/136795
-          rust: nightly-2025-02-07-i686-gnu
+          rust: nightly-i686-gnu
         - target: x86_64-pc-windows-gnu
           os: windows-latest
           rust: nightly-x86_64-gnu


### PR DESCRIPTION
Since [1], the issue should be resolved so the workaround can be dropped.

This reverts commit 88e83b96ad09f3cf9e2d1b4543a7d43f9c5a77c0.

[1]: https://github.com/rust-lang/compiler-builtins/pull/759