### PR TITLE
Update the `libm` submodule

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "compiler-builtins", compiler_builtins)]
+#![cfg_attr(all(target_family = "wasm"), feature(wasm_numeric_instr))]
 #![feature(abi_unadjusted)]
 #![feature(asm_experimental_arch)]
 #![feature(cfg_target_has_atomic)]
@@ -58,6 +59,20 @@ pub mod int;
     all(target_family = "wasm", not(target_os = "unknown"))
 )))]
 pub mod math;
+
+// `libm` expects its `support` module to be available in the crate root. This config can be
+// cleaned up once `libm` is made always available.
+#[cfg(not(any(
+    all(
+        target_arch = "x86",
+        not(target_feature = "sse2"),
+        not(target_os = "uefi"),
+    ),
+    unix,
+    all(target_family = "wasm", not(target_os = "unknown"))
+)))]
+use math::libm::support;
+
 pub mod mem;
 
 #[cfg(target_arch = "arm")]

--- a/src/math.rs
+++ b/src/math.rs
@@ -3,7 +3,7 @@
 #[allow(unused_imports)]
 #[allow(clippy::all)]
 #[path = "../libm/src/math/mod.rs"]
-mod libm;
+pub(crate) mod libm;
 
 #[allow(unused_macros)]
 macro_rules! no_mangle {


### PR DESCRIPTION
This requires privately reexporting `libm`'s `support` module at crate root, where it is expected for macros. Once `libm` is made always available, the reexport can be simplified.

This delta adds a lot of routines to `f16` and `f128`:

* ceil
* floor
* fma (f128 only)
* fmax
* fmin
* fmod
* ldexp
* rint
* round
* scalbn
* sqrt

Additionally, the following new API was added for all four float types:

* fmaximum
* fmaximum_num
* fminimum
* fminimum_num
* roundeven

There are also some significant performance improvements for `sqrt` and
`sqrtf`, as well as precision improvements for `cbrt` (both `f32` and
`f64` versions of this function are now always correctly rounded).