### PR TITLE
Update LLVM downloads to 20.1-2025-02-13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 env:
   RUSTDOCFLAGS: -Dwarnings
   RUSTFLAGS: -Dwarnings
-  RUST_LLVM_VERSION: 19.1-2024-09-17
+  RUST_LLVM_VERSION: 20.1-2025-02-13
   RUST_COMPILER_RT_ROOT: ./compiler-rt
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ to test against, located in a directory called `compiler-rt`. This can be
 obtained with the following:
 
 ```sh
-curl -L -o rustc-llvm-19.1.tar.gz https://github.com/rust-lang/llvm-project/archive/rustc/19.1-2024-09-17.tar.gz
-tar xzf rustc-llvm-19.1.tar.gz --strip-components 1 llvm-project-rustc-19.1-2024-09-17/compiler-rt
+curl -L -o rustc-llvm-20.1.tar.gz https://github.com/rust-lang/llvm-project/archive/rustc/20.1-2025-02-13.tar.gz
+tar xzf rustc-llvm-20.1.tar.gz --strip-components 1 llvm-project-rustc-20.1-2025-02-13/compiler-rt
 ```
 
 Local targets may also be tested with `./ci/run.sh [target]`.


### PR DESCRIPTION
This matches the version used by rust-lang/rust.