### PR TITLE
Disable `f16` on AArch64 without the `neon` feature

### DIFF
--- a/configure.rs
+++ b/configure.rs
@@ -71,6 +71,8 @@ pub fn configure_f16_f128(target: &Target) {
     let f16_enabled = match target.arch.as_str() {
         // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
         "arm64ec" => false,
+        // Crash in LLVM20 <https://github.com/llvm/llvm-project/issues/129394>
+        "aarch64" if !target.features.iter().any(|f| f == "neon") => false,
         // Selection failure <https://github.com/llvm/llvm-project/issues/50374>
         "s390x" => false,
         // Infinite recursion <https://github.com/llvm/llvm-project/issues/97981>


### PR DESCRIPTION
There is an LLVM regression that breaks some `f16`-related code when `fp-armv8` is disabled [1]. Since Rust ties that feature to `neon`, disable `f16` if `neon` is not available.

[1]: https://github.com/llvm/llvm-project/issues/129394