### PR TITLE
Simplify test crate build features

### DIFF
--- a/testcrate/benches/float_conv.rs
+++ b/testcrate/benches/float_conv.rs
@@ -665,7 +665,7 @@ pub fn float_conv() {
     conv_f64_i64(&mut criterion);
     conv_f64_i128(&mut criterion);
 
-    #[cfg(all(f128_enabled))]
+    #[cfg(f128_enabled)]
     // FIXME: ppc64le has a sporadic overflow panic in the crate functions
     // <https://github.com/rust-lang/compiler-builtins/issues/617#issuecomment-2125914639>
     #[cfg(not(all(target_arch = "powerpc64", target_endian = "little")))]


### PR DESCRIPTION
Since we have a handful of different float-related configuration in testcrate, track a list of which are implied by others rather than repeating the config.