### PR TITLE
Add a test config for __gnu_h2f_ieee and __gnu_f2h_ieee

### DIFF
--- a/testcrate/Cargo.toml
+++ b/testcrate/Cargo.toml
@@ -44,8 +44,9 @@ no-sys-f128 = ["no-sys-f128-int-convert", "no-sys-f16-f128-convert"]
 no-sys-f128-int-convert = []
 no-sys-f16-f128-convert = []
 no-sys-f16-f64-convert = []
+no-sys-f16-gnu-convert = []
 # Skip tests that rely on f16 symbols being available on the system
-no-sys-f16 = ["no-sys-f16-f64-convert"]
+no-sys-f16 = ["no-sys-f16-f64-convert", "no-sys-f16-gnu-convert"]
 
 # Enable report generation without bringing in more dependencies by default
 benchmarking-reports = ["criterion/plotters", "criterion/html_reports"]

--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -12,6 +12,7 @@ enum Feature {
     NoSysF16,
     NoSysF16F64Convert,
     NoSysF16F128Convert,
+    NoSysF16GnuConvert,
 }
 
 impl Feature {
@@ -19,9 +20,15 @@ impl Feature {
         match self {
             Self::NoSysF128 => [Self::NoSysF128IntConvert, Self::NoSysF16F128Convert].as_slice(),
             Self::NoSysF128IntConvert => [].as_slice(),
-            Self::NoSysF16 => [Self::NoSysF16F64Convert, Self::NoSysF16F128Convert].as_slice(),
+            Self::NoSysF16 => [
+                Self::NoSysF16F64Convert,
+                Self::NoSysF16F128Convert,
+                Feature::NoSysF16GnuConvert,
+            ]
+            .as_slice(),
             Self::NoSysF16F64Convert => [].as_slice(),
             Self::NoSysF16F128Convert => [].as_slice(),
+            Self::NoSysF16GnuConvert => [].as_slice(),
         }
     }
 }
@@ -84,6 +91,11 @@ fn main() {
         features.insert(Feature::NoSysF16F64Convert);
     }
 
+    // These platforms do not have `__gnu_f2h_ieee` or `__gnu_h2f_ieee`.
+    if false {
+        features.insert(Feature::NoSysF16GnuConvert);
+    }
+
     // Add implied features. Collection is required for borrows.
     features.extend(
         features
@@ -107,6 +119,10 @@ fn main() {
             Feature::NoSysF16F128Convert => (
                 "no-sys-f16-f128-convert",
                 "using apfloat fallback for f16 <-> f128 conversions",
+            ),
+            Feature::NoSysF16GnuConvert => (
+                "no-sys-f16-gnu-convert",
+                "using apfloat fallback for __gnu f16",
             ),
             Feature::NoSysF16 => ("no-sys-f16", "using apfloat fallback for f16"),
         };

--- a/testcrate/tests/conv.rs
+++ b/testcrate/tests/conv.rs
@@ -310,7 +310,7 @@ mod extend {
     f_to_f! {
         extend,
         f16 => f32, Half => Single, __extendhfsf2, not(feature = "no-sys-f16");
-        f16 => f32, Half => Single, __gnu_h2f_ieee, not(feature = "no-sys-f16");
+        f16 => f32, Half => Single, __gnu_h2f_ieee, not(feature = "no-sys-f16-gnu-convert");
         f16 => f64, Half => Double, __extendhfdf2, not(feature = "no-sys-f16-f64-convert");
         f16 => f128, Half => Quad, __extendhftf2, not(feature = "no-sys-f16-f128-convert");
         f32 => f128, Single => Quad, __extendsftf2, not(feature = "no-sys-f128");
@@ -340,7 +340,7 @@ mod trunc {
     f_to_f! {
         trunc,
         f32 => f16, Single => Half, __truncsfhf2, not(feature = "no-sys-f16");
-        f32 => f16, Single => Half, __gnu_f2h_ieee, not(feature = "no-sys-f16");
+        f32 => f16, Single => Half, __gnu_f2h_ieee, not(feature = "no-sys-f16-gnu-convert");
         f64 => f16, Double => Half, __truncdfhf2, not(feature = "no-sys-f16-f64-convert");
         f128 => f16, Quad => Half, __trunctfhf2, not(feature = "no-sys-f16-f128-convert");
         f128 => f32, Quad => Single, __trunctfsf2, not(feature = "no-sys-f128");


### PR DESCRIPTION
Some targets do not provide these symbols since they always use __extendhfsf and __truncsfhf. Add a configuration option for this.