### PR TITLE
Revert "ci: Pin the nightly toolchain for aarch64-unknown-linux-gnu"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,7 @@ jobs:
           rust: nightly
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-latest
-          # FIXME: pinned due to https://github.com/llvm/llvm-project/issues/127804
-          rust: nightly-2025-02-07
+          rust: nightly
         - target: aarch64-pc-windows-msvc
           os: windows-latest
           rust: nightly


### PR DESCRIPTION
The fix to this issue was synced in [1] so we should no longer need to keep aarch64 pinned.

This reverts commit b2bcfc838e2a4b72fa62b333e3eb91f250aa4539.

[1]: https://github.com/rust-lang/rust/pull/137661