### PR TITLE
Revert "Add a test config for __gnu_h2f_ieee and __gnu_f2h_ieee"

### DIFF
--- a/testcrate/Cargo.toml
+++ b/testcrate/Cargo.toml
@@ -44,9 +44,8 @@ no-sys-f128 = ["no-sys-f128-int-convert", "no-sys-f16-f128-convert"]
 no-sys-f128-int-convert = []
 no-sys-f16-f128-convert = []
 no-sys-f16-f64-convert = []
-no-sys-f16-gnu-convert = []
 # Skip tests that rely on f16 symbols being available on the system
-no-sys-f16 = ["no-sys-f16-f64-convert", "no-sys-f16-gnu-convert"]
+no-sys-f16 = ["no-sys-f16-f64-convert"]
 
 # Enable report generation without bringing in more dependencies by default
 benchmarking-reports = ["criterion/plotters", "criterion/html_reports"]

--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -12,7 +12,6 @@ enum Feature {
     NoSysF16,
     NoSysF16F64Convert,
     NoSysF16F128Convert,
-    NoSysF16GnuConvert,
 }
 
 impl Feature {
@@ -20,15 +19,9 @@ impl Feature {
         match self {
             Self::NoSysF128 => [Self::NoSysF128IntConvert, Self::NoSysF16F128Convert].as_slice(),
             Self::NoSysF128IntConvert => [].as_slice(),
-            Self::NoSysF16 => [
-                Self::NoSysF16F64Convert,
-                Self::NoSysF16F128Convert,
-                Feature::NoSysF16GnuConvert,
-            ]
-            .as_slice(),
+            Self::NoSysF16 => [Self::NoSysF16F64Convert, Self::NoSysF16F128Convert].as_slice(),
             Self::NoSysF16F64Convert => [].as_slice(),
             Self::NoSysF16F128Convert => [].as_slice(),
-            Self::NoSysF16GnuConvert => [].as_slice(),
         }
     }
 }
@@ -92,11 +85,6 @@ fn main() {
         features.insert(Feature::NoSysF16F64Convert);
     }
 
-    // These platforms do not have `__gnu_f2h_ieee` or `__gnu_h2f_ieee`.
-    if false {
-        features.insert(Feature::NoSysF16GnuConvert);
-    }
-
     // Add implied features. Collection is required for borrows.
     features.extend(
         features
@@ -120,10 +108,6 @@ fn main() {
             Feature::NoSysF16F128Convert => (
                 "no-sys-f16-f128-convert",
                 "using apfloat fallback for f16 <-> f128 conversions",
-            ),
-            Feature::NoSysF16GnuConvert => (
-                "no-sys-f16-gnu-convert",
-                "using apfloat fallback for __gnu f16",
             ),
             Feature::NoSysF16 => ("no-sys-f16", "using apfloat fallback for f16"),
         };

--- a/testcrate/tests/conv.rs
+++ b/testcrate/tests/conv.rs
@@ -314,7 +314,7 @@ mod extend {
     f_to_f! {
         extend,
         f16 => f32, Half => Single, __extendhfsf2, not(feature = "no-sys-f16");
-        f16 => f32, Half => Single, __gnu_h2f_ieee, not(feature = "no-sys-f16-gnu-convert");
+        f16 => f32, Half => Single, __gnu_h2f_ieee, not(feature = "no-sys-f16");
         f16 => f64, Half => Double, __extendhfdf2, not(feature = "no-sys-f16-f64-convert");
         f16 => f128, Half => Quad, __extendhftf2, not(feature = "no-sys-f16-f128-convert");
         f32 => f128, Single => Quad, __extendsftf2, not(feature = "no-sys-f128");
@@ -348,7 +348,7 @@ mod trunc {
     f_to_f! {
         trunc,
         f32 => f16, Single => Half, __truncsfhf2, not(feature = "no-sys-f16");
-        f32 => f16, Single => Half, __gnu_f2h_ieee, not(feature = "no-sys-f16-gnu-convert");
+        f32 => f16, Single => Half, __gnu_f2h_ieee, not(feature = "no-sys-f16");
         f64 => f16, Double => Half, __truncdfhf2, not(feature = "no-sys-f16-f64-convert");
         f128 => f16, Quad => Half, __trunctfhf2, not(feature = "no-sys-f16-f128-convert");
         f128 => f32, Quad => Single, __trunctfsf2, not(feature = "no-sys-f128");


### PR DESCRIPTION
This turned out to not be useful, so remove it.

This reverts commit b7b93103fb9293c0c502dc1ae34e2ad5c871bc39.