### PR TITLE
Replace some uses of `sign` with `sig`

### DIFF
--- a/src/float/extend.rs
+++ b/src/float/extend.rs
@@ -15,22 +15,22 @@ where
     let src_zero = F::Int::ZERO;
     let src_one = F::Int::ONE;
     let src_bits = F::BITS;
-    let src_sign_bits = F::SIG_BITS;
+    let src_sig_bits = F::SIG_BITS;
     let src_exp_bias = F::EXP_BIAS;
     let src_min_normal = F::IMPLICIT_BIT;
     let src_infinity = F::EXP_MASK;
-    let src_sign_mask = F::SIGN_MASK as F::Int;
+    let src_sign_mask = F::SIGN_MASK;
     let src_abs_mask = src_sign_mask - src_one;
     let src_qnan = F::SIG_MASK;
     let src_nan_code = src_qnan - src_one;
 
     let dst_bits = R::BITS;
-    let dst_sign_bits = R::SIG_BITS;
+    let dst_sig_bits = R::SIG_BITS;
     let dst_inf_exp = R::EXP_SAT;
     let dst_exp_bias = R::EXP_BIAS;
     let dst_min_normal = R::IMPLICIT_BIT;
 
-    let sign_bits_delta = dst_sign_bits - src_sign_bits;
+    let sig_bits_delta = dst_sig_bits - src_sig_bits;
     let exp_bias_delta = dst_exp_bias - src_exp_bias;
     let a_abs = a.to_bits() & src_abs_mask;
     let mut abs_result = R::Int::ZERO;
@@ -41,8 +41,8 @@ where
         // exponent into the proper position and rebiasing the exponent.
         let abs_dst: R::Int = a_abs.cast();
         let bias_dst: R::Int = exp_bias_delta.cast();
-        abs_result = abs_dst.wrapping_shl(sign_bits_delta);
-        abs_result += bias_dst.wrapping_shl(dst_sign_bits);
+        abs_result = abs_dst.wrapping_shl(sig_bits_delta);
+        abs_result += bias_dst.wrapping_shl(dst_sig_bits);
     } else if a_abs >= src_infinity {
         // a is NaN or infinity.
         // Conjure the result by beginning with infinity, then setting the qNaN
@@ -51,9 +51,9 @@ where
         let qnan_dst: R::Int = (a_abs & src_qnan).cast();
         let nan_code_dst: R::Int = (a_abs & src_nan_code).cast();
         let inf_exp_dst: R::Int = dst_inf_exp.cast();
-        abs_result = inf_exp_dst.wrapping_shl(dst_sign_bits);
-        abs_result |= qnan_dst.wrapping_shl(sign_bits_delta);
-        abs_result |= nan_code_dst.wrapping_shl(sign_bits_delta);
+        abs_result = inf_exp_dst.wrapping_shl(dst_sig_bits);
+        abs_result |= qnan_dst.wrapping_shl(sig_bits_delta);
+        abs_result |= nan_code_dst.wrapping_shl(sig_bits_delta);
     } else if a_abs != src_zero {
         // a is denormal.
         // Renormalize the significand and clear the leading bit, then insert
@@ -61,8 +61,8 @@ where
         let scale = a_abs.leading_zeros() - src_min_normal.leading_zeros();
         let abs_dst: R::Int = a_abs.cast();
         let bias_dst: R::Int = (exp_bias_delta - scale + 1).cast();
-        abs_result = abs_dst.wrapping_shl(sign_bits_delta + scale);
-        abs_result = (abs_result ^ dst_min_normal) | (bias_dst.wrapping_shl(dst_sign_bits));
+        abs_result = abs_dst.wrapping_shl(sig_bits_delta + scale);
+        abs_result = (abs_result ^ dst_min_normal) | (bias_dst.wrapping_shl(dst_sig_bits));
     }
 
     let sign_result: R::Int = (a.to_bits() & src_sign_mask).cast();

--- a/src/float/trunc.rs
+++ b/src/float/trunc.rs
@@ -17,7 +17,7 @@ where
     let src_exp_bias = F::EXP_BIAS;
 
     let src_min_normal = F::IMPLICIT_BIT;
-    let src_significand_mask = F::SIG_MASK;
+    let src_sig_mask = F::SIG_MASK;
     let src_infinity = F::EXP_MASK;
     let src_sign_mask = F::SIGN_MASK;
     let src_abs_mask = src_sign_mask - src_one;
@@ -40,7 +40,7 @@ where
     let dst_qnan = R::Int::ONE << (R::SIG_BITS - 1);
     let dst_nan_code = dst_qnan - dst_one;
 
-    let sign_bits_delta = F::SIG_BITS - R::SIG_BITS;
+    let sig_bits_delta = F::SIG_BITS - R::SIG_BITS;
     // Break a into a sign and representation of the absolute value.
     let a_abs = a.to_bits() & src_abs_mask;
     let sign = a.to_bits() & src_sign_mask;
@@ -50,7 +50,7 @@ where
         // The exponent of a is within the range of normal numbers in the
         // destination format.  We can convert by simply right-shifting with
         // rounding and adjusting the exponent.
-        abs_result = (a_abs >> sign_bits_delta).cast();
+        abs_result = (a_abs >> sig_bits_delta).cast();
         // Cast before shifting to prevent overflow.
         let bias_diff: R::Int = src_exp_bias.wrapping_sub(dst_exp_bias).cast();
         let tmp = bias_diff << R::SIG_BITS;
@@ -85,7 +85,7 @@ where
         let a_exp: u32 = (a_abs >> F::SIG_BITS).cast();
         let shift = src_exp_bias - dst_exp_bias - a_exp + 1;
 
-        let significand = (a.to_bits() & src_significand_mask) | src_min_normal;
+        let significand = (a.to_bits() & src_sig_mask) | src_min_normal;
 
         // Right shift by the denormalization amount with sticky.
         if shift > F::SIG_BITS {


### PR DESCRIPTION
It seems like "sign" was used as a shortened version of "significand", but that is easy to confuse with "sign". Update these to use "sig" like most other places.