### PR TITLE
avr: Skip No More!

### DIFF
--- a/compiler-builtins/src/float/add.rs
+++ b/compiler-builtins/src/float/add.rs
@@ -189,14 +189,12 @@ where
 }
 
 intrinsics! {
-    #[avr_skip]
     #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_fadd]
     pub extern "C" fn __addsf3(a: f32, b: f32) -> f32 {
         add(a, b)
     }
 
-    #[avr_skip]
     #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_dadd]
     pub extern "C" fn __adddf3(a: f64, b: f64) -> f64 {

--- a/compiler-builtins/src/float/cmp.rs
+++ b/compiler-builtins/src/float/cmp.rs
@@ -3,6 +3,14 @@
 use crate::float::Float;
 use crate::int::MinInt;
 
+// https://github.com/llvm/llvm-project/blob/1e6ba3cd2fe96be00b6ed6ba28b3d9f9271d784d/compiler-rt/lib/builtins/fp_compare_impl.inc#L22
+#[cfg(target_arch = "avr")]
+pub type CmpResult = i8;
+
+// https://github.com/llvm/llvm-project/blob/1e6ba3cd2fe96be00b6ed6ba28b3d9f9271d784d/compiler-rt/lib/builtins/fp_compare_impl.inc#L25
+#[cfg(not(target_arch = "avr"))]
+pub type CmpResult = i32;
+
 #[derive(Clone, Copy)]
 enum Result {
     Less,
@@ -12,7 +20,7 @@ enum Result {
 }
 
 impl Result {
-    fn to_le_abi(self) -> i32 {
+    fn to_le_abi(self) -> CmpResult {
         match self {
             Result::Less => -1,
             Result::Equal => 0,
@@ -21,7 +29,7 @@ impl Result {
         }
     }
 
-    fn to_ge_abi(self) -> i32 {
+    fn to_ge_abi(self) -> CmpResult {
         match self {
             Result::Less => -1,
             Result::Equal => 0,
@@ -99,120 +107,99 @@ fn unord<F: Float>(a: F, b: F) -> bool {
 }
 
 intrinsics! {
-    #[avr_skip]
-    pub extern "C" fn __lesf2(a: f32, b: f32) -> i32 {
+    pub extern "C" fn __lesf2(a: f32, b: f32) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_le_abi()
     }
 
-    #[avr_skip]
-    pub extern "C" fn __gesf2(a: f32, b: f32) -> i32 {
+    pub extern "C" fn __gesf2(a: f32, b: f32) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_ge_abi()
     }
 
-    #[avr_skip]
     #[arm_aeabi_alias = __aeabi_fcmpun]
-    pub extern "C" fn __unordsf2(a: f32, b: f32) -> i32 {
-        unord(a, b) as i32
+    pub extern "C" fn __unordsf2(a: f32, b: f32) -> crate::float::cmp::CmpResult {
+        unord(a, b) as crate::float::cmp::CmpResult
     }
 
-    #[avr_skip]
-    pub extern "C" fn __eqsf2(a: f32, b: f32) -> i32 {
+    pub extern "C" fn __eqsf2(a: f32, b: f32) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_le_abi()
     }
 
-    #[avr_skip]
-    pub extern "C" fn __ltsf2(a: f32, b: f32) -> i32 {
+    pub extern "C" fn __ltsf2(a: f32, b: f32) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_le_abi()
     }
 
-    #[avr_skip]
-    pub extern "C" fn __nesf2(a: f32, b: f32) -> i32 {
+    pub extern "C" fn __nesf2(a: f32, b: f32) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_le_abi()
     }
 
-    #[avr_skip]
-    pub extern "C" fn __gtsf2(a: f32, b: f32) -> i32 {
+    pub extern "C" fn __gtsf2(a: f32, b: f32) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_ge_abi()
     }
 
-    #[avr_skip]
-    pub extern "C" fn __ledf2(a: f64, b: f64) -> i32 {
+    pub extern "C" fn __ledf2(a: f64, b: f64) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_le_abi()
     }
 
-    #[avr_skip]
-    pub extern "C" fn __gedf2(a: f64, b: f64) -> i32 {
+    pub extern "C" fn __gedf2(a: f64, b: f64) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_ge_abi()
     }
 
-    #[avr_skip]
     #[arm_aeabi_alias = __aeabi_dcmpun]
-    pub extern "C" fn __unorddf2(a: f64, b: f64) -> i32 {
-        unord(a, b) as i32
+    pub extern "C" fn __unorddf2(a: f64, b: f64) -> crate::float::cmp::CmpResult {
+        unord(a, b) as crate::float::cmp::CmpResult
     }
 
-    #[avr_skip]
-    pub extern "C" fn __eqdf2(a: f64, b: f64) -> i32 {
+    pub extern "C" fn __eqdf2(a: f64, b: f64) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_le_abi()
     }
 
-    #[avr_skip]
-    pub extern "C" fn __ltdf2(a: f64, b: f64) -> i32 {
+    pub extern "C" fn __ltdf2(a: f64, b: f64) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_le_abi()
     }
 
-    #[avr_skip]
-    pub extern "C" fn __nedf2(a: f64, b: f64) -> i32 {
+    pub extern "C" fn __nedf2(a: f64, b: f64) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_le_abi()
     }
 
-    #[avr_skip]
-    pub extern "C" fn __gtdf2(a: f64, b: f64) -> i32 {
+    pub extern "C" fn __gtdf2(a: f64, b: f64) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_ge_abi()
     }
 }
 
 #[cfg(f128_enabled)]
 intrinsics! {
-    #[avr_skip]
     #[ppc_alias = __lekf2]
-    pub extern "C" fn __letf2(a: f128, b: f128) -> i32 {
+    pub extern "C" fn __letf2(a: f128, b: f128) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_le_abi()
     }
 
-    #[avr_skip]
     #[ppc_alias = __gekf2]
-    pub extern "C" fn __getf2(a: f128, b: f128) -> i32 {
+    pub extern "C" fn __getf2(a: f128, b: f128) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_ge_abi()
     }
 
-    #[avr_skip]
     #[ppc_alias = __unordkf2]
-    pub extern "C" fn __unordtf2(a: f128, b: f128) -> i32 {
-        unord(a, b) as i32
+    pub extern "C" fn __unordtf2(a: f128, b: f128) -> crate::float::cmp::CmpResult {
+        unord(a, b) as crate::float::cmp::CmpResult
     }
 
-    #[avr_skip]
     #[ppc_alias = __eqkf2]
-    pub extern "C" fn __eqtf2(a: f128, b: f128) -> i32 {
+    pub extern "C" fn __eqtf2(a: f128, b: f128) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_le_abi()
     }
 
-    #[avr_skip]
     #[ppc_alias = __ltkf2]
-    pub extern "C" fn __lttf2(a: f128, b: f128) -> i32 {
+    pub extern "C" fn __lttf2(a: f128, b: f128) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_le_abi()
     }
 
-    #[avr_skip]
     #[ppc_alias = __nekf2]
-    pub extern "C" fn __netf2(a: f128, b: f128) -> i32 {
+    pub extern "C" fn __netf2(a: f128, b: f128) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_le_abi()
     }
 
-    #[avr_skip]
     #[ppc_alias = __gtkf2]
-    pub extern "C" fn __gttf2(a: f128, b: f128) -> i32 {
+    pub extern "C" fn __gttf2(a: f128, b: f128) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_ge_abi()
     }
 }

--- a/compiler-builtins/src/float/div.rs
+++ b/compiler-builtins/src/float/div.rs
@@ -606,19 +606,16 @@ where
 }
 
 intrinsics! {
-    #[avr_skip]
     #[arm_aeabi_alias = __aeabi_fdiv]
     pub extern "C" fn __divsf3(a: f32, b: f32) -> f32 {
         div(a, b)
     }
 
-    #[avr_skip]
     #[arm_aeabi_alias = __aeabi_ddiv]
     pub extern "C" fn __divdf3(a: f64, b: f64) -> f64 {
         div(a, b)
     }
 
-    #[avr_skip]
     #[ppc_alias = __divkf3]
     #[cfg(f128_enabled)]
     pub extern "C" fn __divtf3(a: f128, b: f128) -> f128 {

--- a/compiler-builtins/src/float/extend.rs
+++ b/compiler-builtins/src/float/extend.rs
@@ -70,7 +70,6 @@ where
 }
 
 intrinsics! {
-    #[avr_skip]
     #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_f2d]
     pub extern "C" fn  __extendsfdf2(a: f32) -> f64 {
@@ -79,7 +78,6 @@ intrinsics! {
 }
 
 intrinsics! {
-    #[avr_skip]
     #[aapcs_on_arm]
     #[apple_f16_arg_abi]
     #[arm_aeabi_alias = __aeabi_h2f]
@@ -88,7 +86,6 @@ intrinsics! {
         extend(a)
     }
 
-    #[avr_skip]
     #[aapcs_on_arm]
     #[apple_f16_arg_abi]
     #[cfg(f16_enabled)]
@@ -96,7 +93,6 @@ intrinsics! {
         extend(a)
     }
 
-    #[avr_skip]
     #[aapcs_on_arm]
     #[apple_f16_arg_abi]
     #[cfg(f16_enabled)]
@@ -104,7 +100,6 @@ intrinsics! {
         extend(a)
     }
 
-    #[avr_skip]
     #[aapcs_on_arm]
     #[ppc_alias = __extendhfkf2]
     #[cfg(all(f16_enabled, f128_enabled))]
@@ -112,7 +107,6 @@ intrinsics! {
         extend(a)
     }
 
-    #[avr_skip]
     #[aapcs_on_arm]
     #[ppc_alias = __extendsfkf2]
     #[cfg(f128_enabled)]
@@ -120,7 +114,6 @@ intrinsics! {
         extend(a)
     }
 
-    #[avr_skip]
     #[aapcs_on_arm]
     #[ppc_alias = __extenddfkf2]
     #[cfg(f128_enabled)]

--- a/compiler-builtins/src/float/mul.rs
+++ b/compiler-builtins/src/float/mul.rs
@@ -180,14 +180,12 @@ where
 }
 
 intrinsics! {
-    #[avr_skip]
     #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_fmul]
     pub extern "C" fn __mulsf3(a: f32, b: f32) -> f32 {
         mul(a, b)
     }
 
-    #[avr_skip]
     #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_dmul]
     pub extern "C" fn __muldf3(a: f64, b: f64) -> f64 {

--- a/compiler-builtins/src/float/pow.rs
+++ b/compiler-builtins/src/float/pow.rs
@@ -26,17 +26,14 @@ fn pow<F: Float>(a: F, b: i32) -> F {
 }
 
 intrinsics! {
-    #[avr_skip]
     pub extern "C" fn __powisf2(a: f32, b: i32) -> f32 {
         pow(a, b)
     }
 
-    #[avr_skip]
     pub extern "C" fn __powidf2(a: f64, b: i32) -> f64 {
         pow(a, b)
     }
 
-    #[avr_skip]
     #[ppc_alias = __powikf2]
     #[cfg(f128_enabled)]
     // FIXME(f16_f128): MSVC cannot build these until `__divtf3` is available in nightly.

--- a/compiler-builtins/src/float/sub.rs
+++ b/compiler-builtins/src/float/sub.rs
@@ -1,13 +1,11 @@
 use crate::float::Float;
 
 intrinsics! {
-    #[avr_skip]
     #[arm_aeabi_alias = __aeabi_fsub]
     pub extern "C" fn __subsf3(a: f32, b: f32) -> f32 {
         crate::float::add::__addsf3(a, f32::from_bits(b.to_bits() ^ f32::SIGN_MASK))
     }
 
-    #[avr_skip]
     #[arm_aeabi_alias = __aeabi_dsub]
     pub extern "C" fn __subdf3(a: f64, b: f64) -> f64 {
         crate::float::add::__adddf3(a, f64::from_bits(b.to_bits() ^ f64::SIGN_MASK))

--- a/compiler-builtins/src/float/trunc.rs
+++ b/compiler-builtins/src/float/trunc.rs
@@ -115,7 +115,6 @@ where
 }
 
 intrinsics! {
-    #[avr_skip]
     #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_d2f]
     pub extern "C" fn __truncdfsf2(a: f64) -> f32 {
@@ -124,7 +123,6 @@ intrinsics! {
 }
 
 intrinsics! {
-    #[avr_skip]
     #[aapcs_on_arm]
     #[apple_f16_ret_abi]
     #[arm_aeabi_alias = __aeabi_f2h]
@@ -133,7 +131,6 @@ intrinsics! {
         trunc(a)
     }
 
-    #[avr_skip]
     #[aapcs_on_arm]
     #[apple_f16_ret_abi]
     #[cfg(f16_enabled)]
@@ -141,7 +138,6 @@ intrinsics! {
         trunc(a)
     }
 
-    #[avr_skip]
     #[aapcs_on_arm]
     #[apple_f16_ret_abi]
     #[arm_aeabi_alias = __aeabi_d2h]
@@ -150,7 +146,6 @@ intrinsics! {
         trunc(a)
     }
 
-    #[avr_skip]
     #[aapcs_on_arm]
     #[ppc_alias = __trunckfhf2]
     #[cfg(all(f16_enabled, f128_enabled))]
@@ -158,7 +153,6 @@ intrinsics! {
         trunc(a)
     }
 
-    #[avr_skip]
     #[aapcs_on_arm]
     #[ppc_alias = __trunckfsf2]
     #[cfg(f128_enabled)]
@@ -166,7 +160,6 @@ intrinsics! {
         trunc(a)
     }
 
-    #[avr_skip]
     #[aapcs_on_arm]
     #[ppc_alias = __trunckfdf2]
     #[cfg(f128_enabled)]

--- a/compiler-builtins/src/int/bswap.rs
+++ b/compiler-builtins/src/int/bswap.rs
@@ -1,20 +1,17 @@
 intrinsics! {
     #[maybe_use_optimized_c_shim]
-    #[avr_skip]
     /// Swaps bytes in 32-bit number
     pub extern "C" fn __bswapsi2(x: u32) -> u32 {
         x.swap_bytes()
     }
 
     #[maybe_use_optimized_c_shim]
-    #[avr_skip]
     /// Swaps bytes in 64-bit number
     pub extern "C" fn __bswapdi2(x: u64) -> u64 {
         x.swap_bytes()
     }
 
     #[maybe_use_optimized_c_shim]
-    #[avr_skip]
     /// Swaps bytes in 128-bit number
     pub extern "C" fn __bswapti2(x: u128) -> u128 {
         x.swap_bytes()

--- a/compiler-builtins/src/int/shift.rs
+++ b/compiler-builtins/src/int/shift.rs
@@ -69,56 +69,47 @@ impl Lshr for u64 {}
 impl Lshr for u128 {}
 
 intrinsics! {
-    #[avr_skip]
     #[maybe_use_optimized_c_shim]
     pub extern "C" fn __ashlsi3(a: u32, b: u32) -> u32 {
         a.ashl(b)
     }
 
-    #[avr_skip]
     #[maybe_use_optimized_c_shim]
     #[arm_aeabi_alias = __aeabi_llsl]
     pub extern "C" fn __ashldi3(a: u64, b: core::ffi::c_uint) -> u64 {
         a.ashl(b as u32)
     }
 
-    #[avr_skip]
     pub extern "C" fn __ashlti3(a: u128, b: u32) -> u128 {
         a.ashl(b)
     }
 
-    #[avr_skip]
     #[maybe_use_optimized_c_shim]
     pub extern "C" fn __ashrsi3(a: i32, b: u32) -> i32 {
         a.ashr(b)
     }
 
-    #[avr_skip]
     #[maybe_use_optimized_c_shim]
     #[arm_aeabi_alias = __aeabi_lasr]
     pub extern "C" fn __ashrdi3(a: i64, b: core::ffi::c_uint) -> i64 {
         a.ashr(b as u32)
     }
 
-    #[avr_skip]
     pub extern "C" fn __ashrti3(a: i128, b: u32) -> i128 {
         a.ashr(b)
     }
 
-    #[avr_skip]
     #[maybe_use_optimized_c_shim]
     pub extern "C" fn __lshrsi3(a: u32, b: u32) -> u32 {
         a.lshr(b)
     }
 
-    #[avr_skip]
     #[maybe_use_optimized_c_shim]
     #[arm_aeabi_alias = __aeabi_llsr]
     pub extern "C" fn __lshrdi3(a: u64, b: core::ffi::c_uint) -> u64 {
         a.lshr(b as u32)
     }
 
-    #[avr_skip]
     pub extern "C" fn __lshrti3(a: u128, b: u32) -> u128 {
         a.lshr(b)
     }

--- a/compiler-builtins/src/macros.rs
+++ b/compiler-builtins/src/macros.rs
@@ -445,35 +445,6 @@ macro_rules! intrinsics {
         intrinsics!($($rest)*);
     );
 
-    // For some intrinsics, AVR uses a custom calling convention¹ that does not
-    // match our definitions here. Ideally we would just use hand-written naked
-    // functions, but that's quite a lot of code to port² - so for the time
-    // being we are just ignoring the problematic functions, letting avr-gcc
-    // (which is required to compile to AVR anyway) link them from libgcc.
-    //
-    // ¹ https://gcc.gnu.org/wiki/avr-gcc (see "Exceptions to the Calling
-    //   Convention")
-    // ² https://github.com/gcc-mirror/gcc/blob/31048012db98f5ec9c2ba537bfd850374bdd771f/libgcc/config/avr/lib1funcs.S
-    (
-        #[avr_skip]
-        $(#[$($attr:tt)*])*
-        pub extern $abi:tt fn $name:ident( $($argname:ident:  $ty:ty),* ) $(-> $ret:ty)? {
-            $($body:tt)*
-        }
-
-        $($rest:tt)*
-    ) => (
-        #[cfg(not(target_arch = "avr"))]
-        intrinsics! {
-            $(#[$($attr)*])*
-            pub extern $abi fn $name( $($argname: $ty),* ) $(-> $ret)? {
-                $($body)*
-            }
-        }
-
-        intrinsics!($($rest)*);
-    );
-
     // This is the final catch-all rule. At this point we generate an
     // intrinsic with a conditional `#[no_mangle]` directive to avoid
     // interfering with duplicate symbols and whatnot during testing.

--- a/testcrate/tests/misc.rs
+++ b/testcrate/tests/misc.rs
@@ -175,7 +175,6 @@ fn trailing_zeros() {
 }
 
 #[test]
-#[cfg(not(target_arch = "avr"))]
 fn bswap() {
     use compiler_builtins::int::bswap::{__bswapdi2, __bswapsi2};
     fuzz(N, |x: u32| {


### PR DESCRIPTION
This pull request gets rid of all of the `#[avr_skip]`s introduced in the past.

> My ~heart~ uC skips, skips, skips, skips, skips, skips ~a beat~ an intrinsic

... Olly Murs, frustrated about having to pull someone's intrinsics when working on AVR firmwares (colorized).

Changes here are related to https://github.com/rust-lang/compiler-builtins/issues/711, but note that we continue _not_ to provide `__u?divmod[hq]i4` - it shouldn't be terribly difficult to implement those (I even have a work-in-progress branch in rustc that exposes the proper calling convention), it's just a different kind of change that will be done in another pull request.

In general, the changes boil down to:

- removing overzealous `#[avr_skip]` on intrinsics that don't actually have special convention (such as `__addsf3`),
- implementing proper support for the other intrinsics (such as `__unordsf2` or `__divmodsi4`).

I've tested new code via [avr-tester](https://github.com/Patryk27/avr-tester/pull/6) - in particular, there's a test that [uses randomized math operations](https://github.com/Patryk27/avr-tester/blob/89c1820b50da9e41d6a2e9cb2896192321a3b544/avr-tester/tests/acc/eval.rs#L1) and another one that [checks floating point math](https://github.com/Patryk27/avr-tester/blob/89c1820b50da9e41d6a2e9cb2896192321a3b544/avr-tester/tests/acc/fractal.rs#L1), and both pass using the implementations provided by compiler-builtins.

Related discussions:

- https://github.com/Rahix/avr-hal/discussions/641
- https://github.com/rust-lang/compiler-builtins/issues/711