### PR TITLE
Re-enable memset tests on powerpc64(le)

### DIFF
--- a/testcrate/tests/mem.rs
+++ b/testcrate/tests/mem.rs
@@ -230,8 +230,6 @@ fn memmove_backward_aligned() {
     }
 }
 
-// PowerPC tests are failing: https://github.com/rust-lang/rust/issues/99853
-#[cfg(not(target_arch = "powerpc64"))]
 #[test]
 fn memset_backward_misaligned_nonaligned_start() {
     let mut arr = gen_arr::<32>();
@@ -244,8 +242,6 @@ fn memset_backward_misaligned_nonaligned_start() {
     }
 }
 
-// PowerPC tests are failing: https://github.com/rust-lang/rust/issues/99853
-#[cfg(not(target_arch = "powerpc64"))]
 #[test]
 fn memset_backward_misaligned_aligned_start() {
     let mut arr = gen_arr::<32>();
@@ -258,8 +254,6 @@ fn memset_backward_misaligned_aligned_start() {
     }
 }
 
-// PowerPC tests are failing: https://github.com/rust-lang/rust/issues/99853
-#[cfg(not(target_arch = "powerpc64"))]
 #[test]
 fn memset_backward_aligned() {
     let mut arr = gen_arr::<32>();


### PR DESCRIPTION
Originally disabled in https://github.com/rust-lang/compiler-builtins/pull/481, these tests pass fine for me on powerpc64le-unknown-linux-gnu with LLVM 20.1 and `rustc 1.87.0-nightly (4d30011f6 2025-03-15)`.

Fixes: https://github.com/rust-lang/rust/issues/99853

cc @RalfJung @Amanieu @apiraino

Full test run (successful): https://gist.github.com/Gelbpunkt/b178b3838b32154e877799e2b6395546