### PR TITLE
Re-enable a few more tests on powerpc64(le)

### DIFF
--- a/testcrate/tests/cmp.rs
+++ b/testcrate/tests/cmp.rs
@@ -2,11 +2,8 @@
 #![allow(unreachable_code)]
 #![cfg_attr(f128_enabled, feature(f128))]
 
-#[cfg(not(target_arch = "powerpc64"))]
 use testcrate::*;
 
-// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
-#[cfg(not(target_arch = "powerpc64"))]
 mod float_comparisons {
     use super::*;
 

--- a/testcrate/tests/conv.rs
+++ b/testcrate/tests/conv.rs
@@ -141,8 +141,6 @@ mod i_to_f {
     }
 }
 
-// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
-#[cfg(not(target_arch = "powerpc64"))]
 mod f_to_i {
     use super::*;
 


### PR DESCRIPTION
Originally disabled in https://github.com/rust-lang/compiler-builtins/pull/437, these pass again for me on LLVM 20.1 and can safely be re-enabled. I suspect the same goes for libm, I will look into those next.

Fixes: https://github.com/rust-lang/rust/issues/88520

Pinging those active on the issue: @RalfJung @tgross35 @Amanieu 