### PR TITLE
Remove unneeded `--manifest-path` from CI scripts

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -23,7 +23,7 @@ fi
 if [ "${NO_STD:-}" = "1" ]; then
     echo "nothing to do for no_std"
 else
-    run="cargo test --manifest-path testcrate/Cargo.toml --no-fail-fast --target $target"
+    run="cargo test --no-fail-fast --target $target"
     $run
     $run --release
     $run --features c
@@ -38,8 +38,7 @@ fi
 
 if [ "${TEST_VERBATIM:-}" = "1" ]; then
     verb_path=$(cmd.exe //C echo \\\\?\\%cd%\\testcrate\\target2)
-    cargo build --manifest-path testcrate/Cargo.toml \
-        --target "$target" --target-dir "$verb_path" --features c
+    cargo build --target "$target" --target-dir "$verb_path" --features c
 fi
 
 declare -a rlib_paths


### PR DESCRIPTION
Since 942ab9fc37 ("Move `examples/intrinsics.rs` to its own crate"), `testcrate` is a default workspace member so there is no need to specify it explicitly when testing or building. Use this to clean up CI scripts.