### PR TITLE
Add a script for downloading compiler-rt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 env:
   RUSTDOCFLAGS: -Dwarnings
   RUSTFLAGS: -Dwarnings
-  RUST_LLVM_VERSION: 20.1-2025-02-13
   RUST_COMPILER_RT_ROOT: ./compiler-rt
 
 jobs:
@@ -129,12 +128,10 @@ jobs:
       uses: actions/cache@v4
       with:
         path: compiler-rt
-        key: ${{ runner.os }}-compiler-rt-${{ env.RUST_LLVM_VERSION }}
+        key: ${{ runner.os }}-compiler-rt-${{ hashFiles('ci/download-compiler-rt.sh') }}
     - name: Download compiler-rt reference sources
       if: steps.cache-compiler-rt.outputs.cache-hit != 'true'
-      run: |
-        curl -L -o code.tar.gz "https://github.com/rust-lang/llvm-project/archive/rustc/${RUST_LLVM_VERSION}.tar.gz"
-        tar xzf code.tar.gz --strip-components 1 llvm-project-rustc-${RUST_LLVM_VERSION}/compiler-rt
+      run: ./ci/download-compiler-rt.sh
       shell: bash
 
     # Non-linux tests just use our raw script

--- a/build.rs
+++ b/build.rs
@@ -619,7 +619,10 @@ mod c {
         let root = match env::var_os("RUST_COMPILER_RT_ROOT") {
             Some(s) => PathBuf::from(s),
             None => {
-                panic!("RUST_COMPILER_RT_ROOT is not set. You may need to download compiler-rt.")
+                panic!(
+                    "RUST_COMPILER_RT_ROOT is not set. You may need to run \
+                    `ci/download-compiler-rt.sh`."
+                );
             }
         };
         if !root.exists() {

--- a/ci/download-compiler-rt.sh
+++ b/ci/download-compiler-rt.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Download sources to build C versions of intrinsics. Once being run,
+# `RUST_COMPILER_RT_ROOT` must be set.
+
+set -eux
+
+rust_llvm_version=20.1-2025-02-13
+
+curl -L -o code.tar.gz "https://github.com/rust-lang/llvm-project/archive/rustc/${rust_llvm_version}.tar.gz"
+tar xzf code.tar.gz --strip-components 1 llvm-project-rustc-${rust_llvm_version}/compiler-rt


### PR DESCRIPTION
Rather than needing to copy the version and URL from the CI workflow, put this into a script that can be directly run locally.