### PR TITLE
copy_misaligned_words: avoid out-of-bounds accesses

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,6 +160,21 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Install Rust (rustup)
+      run: rustup update nightly --no-self-update && rustup default nightly
+      shell: bash
+    - run: rustup component add miri
+    - run: cargo miri setup
+    - uses: Swatinem/rust-cache@v2
+    - run: ./ci/miri.sh
+
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
@@ -190,6 +205,7 @@ jobs:
       - test
       - rustfmt
       - clippy
+      - miri
     runs-on: ubuntu-latest
     # GitHub branch protection is exceedingly silly and treats "jobs skipped because a dependency
     # failed" as success. So we have to do some contortions to ensure the job fails if any of its

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ex
+
+# We need Tree Borrows as some of our raw pointer patterns are not
+# compatible with Stacked Borrows.
+export MIRIFLAGS="-Zmiri-tree-borrows"
+
+# One target that sets `mem-unaligned` and one that does not,
+# and a big-endian target.
+TARGETS=(x86_64-unknown-linux-gnu
+    armv7-unknown-linux-gnueabihf
+    s390x-unknown-linux-gnu)
+for TARGET in "${TARGETS[@]}"; do
+    # Only run the `mem` tests to avoid this taking too long.
+    cargo miri test --manifest-path testcrate/Cargo.toml --features no-asm --target $TARGET -- mem
+done

--- a/compiler-builtins/src/mem/impls.rs
+++ b/compiler-builtins/src/mem/impls.rs
@@ -155,10 +155,11 @@ pub unsafe fn copy_forward(mut dest: *mut u8, mut src: *const u8, mut n: usize) 
         while dest_usize.wrapping_add(1) < dest_end {
             src_aligned = src_aligned.wrapping_add(1);
             let cur_word = *src_aligned;
-            #[cfg(target_endian = "little")]
-            let reassembled = prev_word >> shift | cur_word << (WORD_SIZE * 8 - shift);
-            #[cfg(target_endian = "big")]
-            let reassembled = prev_word << shift | cur_word >> (WORD_SIZE * 8 - shift);
+            let reassembled = if cfg!(target_endian = "little") {
+                prev_word >> shift | cur_word << (WORD_SIZE * 8 - shift)
+            } else {
+                prev_word << shift | cur_word >> (WORD_SIZE * 8 - shift)
+            };
             prev_word = cur_word;
 
             *dest_usize = reassembled;
@@ -169,10 +170,11 @@ pub unsafe fn copy_forward(mut dest: *mut u8, mut src: *const u8, mut n: usize) 
         // it is partially out-of-bounds.
         src_aligned = src_aligned.wrapping_add(1);
         let cur_word = load_aligned_partial(src_aligned, offset);
-        #[cfg(target_endian = "little")]
-        let reassembled = prev_word >> shift | cur_word << (WORD_SIZE * 8 - shift);
-        #[cfg(target_endian = "big")]
-        let reassembled = prev_word << shift | cur_word >> (WORD_SIZE * 8 - shift);
+        let reassembled = if cfg!(target_endian = "little") {
+            prev_word >> shift | cur_word << (WORD_SIZE * 8 - shift)
+        } else {
+            prev_word << shift | cur_word >> (WORD_SIZE * 8 - shift)
+        };
         // prev_word does not matter any more
 
         *dest_usize = reassembled;
@@ -268,10 +270,11 @@ pub unsafe fn copy_backward(dest: *mut u8, src: *const u8, mut n: usize) {
         while dest_start.wrapping_add(1) < dest_usize {
             src_aligned = src_aligned.wrapping_sub(1);
             let cur_word = *src_aligned;
-            #[cfg(target_endian = "little")]
-            let reassembled = prev_word << (WORD_SIZE * 8 - shift) | cur_word >> shift;
-            #[cfg(target_endian = "big")]
-            let reassembled = prev_word >> (WORD_SIZE * 8 - shift) | cur_word << shift;
+            let reassembled = if cfg!(target_endian = "little") {
+                prev_word << (WORD_SIZE * 8 - shift) | cur_word >> shift
+            } else {
+                prev_word >> (WORD_SIZE * 8 - shift) | cur_word << shift
+            };
             prev_word = cur_word;
 
             dest_usize = dest_usize.wrapping_sub(1);
@@ -282,10 +285,11 @@ pub unsafe fn copy_backward(dest: *mut u8, src: *const u8, mut n: usize) {
         // it is partially out-of-bounds.
         src_aligned = src_aligned.wrapping_sub(1);
         let cur_word = load_aligned_end_partial(src_aligned, WORD_SIZE - offset);
-        #[cfg(target_endian = "little")]
-        let reassembled = prev_word << (WORD_SIZE * 8 - shift) | cur_word >> shift;
-        #[cfg(target_endian = "big")]
-        let reassembled = prev_word >> (WORD_SIZE * 8 - shift) | cur_word << shift;
+        let reassembled = if cfg!(target_endian = "little") {
+            prev_word << (WORD_SIZE * 8 - shift) | cur_word >> shift
+        } else {
+            prev_word >> (WORD_SIZE * 8 - shift) | cur_word << shift
+        };
         // prev_word does not matter any more
 
         dest_usize = dest_usize.wrapping_sub(1);

--- a/testcrate/tests/mem.rs
+++ b/testcrate/tests/mem.rs
@@ -231,6 +231,23 @@ fn memmove_backward_aligned() {
 }
 
 #[test]
+fn memmove_misaligned_bounds() {
+    // The above test have the downside that the addresses surrounding the range-to-copy are all
+    // still in-bounds, so Miri would not actually complain about OOB accesses. So we also test with
+    // an array that has just the right size. We test a few times to avoid it being accidentally
+    // aligned.
+    for _ in 0..8 {
+        let mut arr1 = [0u8; 17];
+        let mut arr2 = [0u8; 17];
+        unsafe {
+            // Copy both ways so we hit both the forward and backward cases.
+            memmove(arr1.as_mut_ptr(), arr2.as_mut_ptr(), 17);
+            memmove(arr2.as_mut_ptr(), arr1.as_mut_ptr(), 17);
+        }
+    }
+}
+
+#[test]
 fn memset_backward_misaligned_nonaligned_start() {
     let mut arr = gen_arr::<32>();
     let mut reference = arr;

--- a/testcrate/tests/mem.rs
+++ b/testcrate/tests/mem.rs
@@ -128,11 +128,13 @@ fn memcmp_eq() {
 #[test]
 fn memcmp_ne() {
     let arr1 @ arr2 = gen_arr::<256>();
-    for i in 0..256 {
+    // Reduce iteration count in Miri as it is too slow otherwise.
+    let limit = if cfg!(miri) { 64 } else { 256 };
+    for i in 0..limit {
         let mut diff_arr = arr1;
         diff_arr.0[i] = 127;
         let expect = diff_arr.0[i].cmp(&arr2.0[i]);
-        for k in i + 1..256 {
+        for k in i + 1..limit {
             let result = unsafe { memcmp(diff_arr.0.as_ptr(), arr2.0.as_ptr(), k) };
             assert_eq!(expect, result.cmp(&0));
         }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/compiler-builtins/issues/559 for `memmove`/`memcpy`: load the underaligned prefix and suffix in `copy_*_misaligned_words` in up to 3 separate aligned loads (a 1-byte load, a 2-byte load, and for 64bit targets a 4-byte load), while only doing those loads that are actually inbounds. The hope is that the performance loss compared to a single aligned ptr-sized load is negligible.

I confirmed that this now passes Miri (the second of these already worked before this PR):
```
# target without mem-unaligned
MIRIFLAGS=-Zmiri-tree-borrows cargo miri test --features no-asm --target armv7-unknown-linux-gnueabihf -- align
# target with mem-unaligned
MIRIFLAGS=-Zmiri-tree-borrows cargo miri test --features no-asm --target x86_64-unknown-linux-gnu -- align
```
I added a new test since the existing test had some slack space around the memory being copied, making all accesses accidentally inbounds (but Miri was still helpful to confirm everything is aligned). This test found a bug in my code, fixed in the second commit. :D

This also add those above commands to CI so hopefully this crate still stay green for Miri. :)