### PR TITLE
Temporarily disable the test call to `rust_begin_unwind`

### DIFF
--- a/builtins-test-intrinsics/src/main.rs
+++ b/builtins-test-intrinsics/src/main.rs
@@ -626,13 +626,14 @@ fn run() {
 
     something_with_a_dtor(&|| assert_eq!(bb(1), 1));
 
-    extern "C" {
-        fn rust_begin_unwind(x: usize);
-    }
+    // FIXME(#802): This should be re-enabled once a workaround is found.
+    // extern "C" {
+    //     fn rust_begin_unwind(x: usize);
+    // }
 
-    unsafe {
-        rust_begin_unwind(0);
-    }
+    // unsafe {
+    //     rust_begin_unwind(0);
+    // }
 }
 
 fn something_with_a_dtor(f: &dyn Fn()) {


### PR DESCRIPTION
Since [1] this symbol is mangled, meaning it is not easy to call directly. A better fix will come in [2] but for now, just disable that portion of the test.

[1]: https://github.com/rust-lang/rust/pull/127173
[2]: https://github.com/rust-lang/compiler-builtins/pull/802