### PR TITLE
Revert "Disable `f16` on AArch64 without the `neon` feature"

### DIFF
--- a/compiler-builtins/configure.rs
+++ b/compiler-builtins/configure.rs
@@ -91,8 +91,6 @@ pub fn configure_f16_f128(target: &Target) {
     let f16_enabled = match target.arch.as_str() {
         // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
         "arm64ec" => false,
-        // Crash in LLVM20 <https://github.com/llvm/llvm-project/issues/129394>
-        "aarch64" if !target.features.iter().any(|f| f == "neon") => false,
         // Selection failure <https://github.com/llvm/llvm-project/issues/50374>
         "s390x" => false,
         // Infinite recursion <https://github.com/llvm/llvm-project/issues/97981>


### PR DESCRIPTION
The LLVM issue [1] was resolved and the fix was synced to rust-lang/rust in [2].

This reverts commit 5cf417a9e92bb48e4e55756a645826fd167b9f3a.

[1]: https://github.com/llvm/llvm-project/issues/129394
[2]: https://github.com/rust-lang/rust/pull/138695