### PR TITLE
Remove a mention of `force-soft-float` in `build.rs`

### DIFF
--- a/compiler-builtins/build.rs
+++ b/compiler-builtins/build.rs
@@ -101,9 +101,7 @@ fn configure_libm(target: &Target) {
     println!("cargo:rustc-cfg=intrinsics_enabled");
 
     // The arch module may contain assembly.
-    if cfg!(feature = "no-asm") {
-        println!("cargo:rustc-cfg=feature=\"force-soft-floats\"");
-    } else {
+    if !cfg!(feature = "no-asm") {
         println!("cargo:rustc-cfg=arch_enabled");
     }
 


### PR DESCRIPTION
`libm` no longer uses this directly in `cfg`, it is only for setting other configuration in the `libm` `build.rs`. Clean up this configuration in `compiler-builtins` since it is unused.