### PR TITLE
use #[naked] as an unsafe attribute

### DIFF
--- a/compiler-builtins/src/aarch64.rs
+++ b/compiler-builtins/src/aarch64.rs
@@ -3,7 +3,7 @@
 use core::intrinsics;
 
 intrinsics! {
-    #[naked]
+    #[unsafe(naked)]
     #[cfg(all(target_os = "uefi", not(feature = "no-asm")))]
     pub unsafe extern "C" fn __chkstk() {
         core::arch::naked_asm!(

--- a/compiler-builtins/src/aarch64_linux.rs
+++ b/compiler-builtins/src/aarch64_linux.rs
@@ -131,7 +131,7 @@ macro_rules! compare_and_swap {
     ($ordering:ident, $bytes:tt, $name:ident) => {
         intrinsics! {
             #[maybe_use_optimized_c_shim]
-            #[naked]
+            #[unsafe(naked)]
             pub unsafe extern "C" fn $name (
                 expected: int_ty!($bytes), desired: int_ty!($bytes), ptr: *mut int_ty!($bytes)
             ) -> int_ty!($bytes) {
@@ -161,7 +161,7 @@ macro_rules! compare_and_swap_i128 {
     ($ordering:ident, $name:ident) => {
         intrinsics! {
             #[maybe_use_optimized_c_shim]
-            #[naked]
+            #[unsafe(naked)]
             pub unsafe extern "C" fn $name (
                 expected: i128, desired: i128, ptr: *mut i128
             ) -> i128 {
@@ -190,7 +190,7 @@ macro_rules! swap {
     ($ordering:ident, $bytes:tt, $name:ident) => {
         intrinsics! {
             #[maybe_use_optimized_c_shim]
-            #[naked]
+            #[unsafe(naked)]
             pub unsafe extern "C" fn $name (
                 left: int_ty!($bytes), right_ptr: *mut int_ty!($bytes)
             ) -> int_ty!($bytes) {
@@ -215,7 +215,7 @@ macro_rules! fetch_op {
     ($ordering:ident, $bytes:tt, $name:ident, $op:literal) => {
         intrinsics! {
             #[maybe_use_optimized_c_shim]
-            #[naked]
+            #[unsafe(naked)]
             pub unsafe extern "C" fn $name (
                 val: int_ty!($bytes), ptr: *mut int_ty!($bytes)
             ) -> int_ty!($bytes) {

--- a/compiler-builtins/src/arm.rs
+++ b/compiler-builtins/src/arm.rs
@@ -20,7 +20,7 @@ macro_rules! bl {
 intrinsics! {
     // NOTE This function and the ones below are implemented using assembly because they are using a
     // custom calling convention which can't be implemented using a normal Rust function.
-    #[naked]
+    #[unsafe(naked)]
     #[cfg(not(target_env = "msvc"))]
     pub unsafe extern "C" fn __aeabi_uidivmod() {
         core::arch::naked_asm!(
@@ -34,7 +34,7 @@ intrinsics! {
         );
     }
 
-    #[naked]
+    #[unsafe(naked)]
     pub unsafe extern "C" fn __aeabi_uldivmod() {
         core::arch::naked_asm!(
             "push {{r4, lr}}",
@@ -49,7 +49,7 @@ intrinsics! {
         );
     }
 
-    #[naked]
+    #[unsafe(naked)]
     pub unsafe extern "C" fn __aeabi_idivmod() {
         core::arch::naked_asm!(
             "push {{r0, r1, r4, lr}}",
@@ -61,7 +61,7 @@ intrinsics! {
         );
     }
 
-    #[naked]
+    #[unsafe(naked)]
     pub unsafe extern "C" fn __aeabi_ldivmod() {
         core::arch::naked_asm!(
             "push {{r4, lr}}",

--- a/compiler-builtins/src/macros.rs
+++ b/compiler-builtins/src/macros.rs
@@ -423,7 +423,7 @@ macro_rules! intrinsics {
     // Naked functions are special: we can't generate wrappers for them since
     // they use a custom calling convention.
     (
-        #[naked]
+        #[unsafe(naked)]
         $(#[$($attr:tt)*])*
         pub unsafe extern $abi:tt fn $name:ident( $($argname:ident:  $ty:ty),* ) $(-> $ret:ty)? {
             $($body:tt)*
@@ -433,7 +433,7 @@ macro_rules! intrinsics {
     ) => (
         // `#[naked]` definitions are referenced by other places, so we can't use `cfg` like the others
         pub mod $name {
-            #[naked]
+            #[unsafe(naked)]
             $(#[$($attr)*])*
             #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
             #[cfg_attr(not(any(all(windows, target_env = "gnu"), target_os = "cygwin")), linkage = "weak")]

--- a/compiler-builtins/src/x86.rs
+++ b/compiler-builtins/src/x86.rs
@@ -8,7 +8,7 @@ use core::intrinsics;
 // NOTE These functions are never mangled as they are not tested against compiler-rt
 
 intrinsics! {
-    #[naked]
+    #[unsafe(naked)]
     #[cfg(all(
         any(all(windows, target_env = "gnu"), target_os = "uefi"),
         not(feature = "no-asm")
@@ -20,7 +20,7 @@ intrinsics! {
         );
     }
 
-    #[naked]
+    #[unsafe(naked)]
     #[cfg(all(
         any(all(windows, target_env = "gnu"), target_os = "uefi"),
         not(feature = "no-asm")

--- a/compiler-builtins/src/x86_64.rs
+++ b/compiler-builtins/src/x86_64.rs
@@ -8,7 +8,7 @@ use core::intrinsics;
 // NOTE These functions are never mangled as they are not tested against compiler-rt
 
 intrinsics! {
-    #[naked]
+    #[unsafe(naked)]
     #[cfg(all(
         any(
             all(windows, target_env = "gnu"),


### PR DESCRIPTION
Per https://github.com/rust-lang/rust/pull/134213#issuecomment-2755984503, we want to make the `#[naked]` attribute an unsafe attribute.

Based on the CI failures here https://github.com/rust-lang/rust/pull/139753, I believe that `compiler-builtins` need to be updated first.