### PR TITLE
try using `#[cfg(bootstrap)]` for `#[unsafe(naked)]`

### DIFF
--- a/compiler-builtins/Cargo.toml
+++ b/compiler-builtins/Cargo.toml
@@ -70,3 +70,6 @@ rustc-dep-of-std = ['compiler-builtins', 'core']
 # This makes certain traits and function specializations public that
 # are not normally public but are required by the `testcrate`
 public-test-deps = []
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bootstrap)'] }

--- a/compiler-builtins/src/macros.rs
+++ b/compiler-builtins/src/macros.rs
@@ -433,6 +433,17 @@ macro_rules! intrinsics {
     ) => (
         // `#[naked]` definitions are referenced by other places, so we can't use `cfg` like the others
         pub mod $name {
+            // FIXME: when bootstrap supports `#[unsafe(naked)]` this duplication can be removed
+            #[cfg(bootstrap)]
+            #[naked]
+            $(#[$($attr)*])*
+            #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
+            #[cfg_attr(not(any(all(windows, target_env = "gnu"), target_os = "cygwin")), linkage = "weak")]
+            pub unsafe extern $abi fn $name( $($argname: $ty),* ) $(-> $ret)? {
+                $($body)*
+            }
+
+            #[cfg(not(bootstrap))]
             #[unsafe(naked)]
             $(#[$($attr)*])*
             #[cfg_attr(not(feature = "mangled-names"), no_mangle)]


### PR DESCRIPTION
Based on [#t-compiler/help > Does &#96;#&#91;cfg(bootstrap)&#93;&#96; get set in dependencies?](https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/Does.20.60.23.5Bcfg.28bootstrap.29.5D.60.20get.20set.20in.20dependencies.3F) this should resolve the error we see in https://github.com/rust-lang/rust/pull/139934.

It's probably a good idea to validate that this will actually work, but I'm not sure how to do that.