### PR TITLE
avr: Provide `abort()`

### DIFF
--- a/compiler-builtins/src/avr.rs
+++ b/compiler-builtins/src/avr.rs
@@ -1,0 +1,23 @@
+intrinsics! {
+    pub unsafe extern "C" fn abort() -> ! {
+        // On AVRs, an architecture that doesn't support traps, unreachable code
+        // paths get lowered into calls to `abort`:
+        //
+        // https://github.com/llvm/llvm-project/blob/cbe8f3ad7621e402b050e768f400ff0d19c3aedd/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp#L4462
+        //
+        // When control gets here, it means that either core::intrinsics::abort()
+        // was called or an undefined bebavior has occurred, so there's not that
+        // much we can do to recover - we can't `panic!()`, because for all we
+        // know the environment is gone now, so panicking might end up with us
+        // getting back to this very function.
+        //
+        // So let's do the next best thing, loop.
+        //
+        // Alternatively we could (try to) restart the program, but since
+        // undefined behavior is undefined, there's really no obligation for us
+        // to do anything here - for all we care, we could just set the chip on
+        // fire; but that'd be bad for the environment.
+
+        loop {}
+    }
+}

--- a/compiler-builtins/src/lib.rs
+++ b/compiler-builtins/src/lib.rs
@@ -63,6 +63,9 @@ pub mod aarch64_linux;
 ))]
 pub mod arm_linux;
 
+#[cfg(target_arch = "avr")]
+pub mod avr;
+
 #[cfg(target_arch = "hexagon")]
 pub mod hexagon;
 


### PR DESCRIPTION
On AVRs, an architecture that doesn't support traps, unreachable code paths get lowered into calls to an intrinsic called `abort`:

https://github.com/llvm/llvm-project/blob/cbe8f3ad7621e402b050e768f400ff0d19c3aedd/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp#L4462

avr-gcc doesn't provide this function, presumably because they deal with traps in some other way, so when LLVM decides _not_ to optimize those unreachable code paths out (spotted over https://github.com/Rahix/avr-hal/pull/651 and https://github.com/rust-lang/rust/issues/139737), currently the linker fails with `undefined reference`.

It doesn't have to, though, because we can provide a valid implementation of this intrinsic right here.

Note that while we could shove this responsibility to end users, same way we do with `#[panic_handler]`, traps don't really allow to recover in a generic way - `abort()` is called when an unexpected code path gets exercised, so for all we know the environment (especially the Rust's stdlib part of it) is gone by then, there's no point in calling `panic!()` or anything else.

At the same time, some people might want to provide their own recovery mechanism (doing whatever magic they want), so let's mark this intrinsic as weak, so that it can be overridden if someone wants to (in particular, a safe-ish way to implement it would be to use inline assembly to manually manipulate registers to blink a LED, for instance).

cc @tgross35 