### PR TITLE
libm: Fix crate compilation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "musl"]
-	path = libm/crates/musl-math-sys/musl
+[submodule "crates/musl-math-sys/musl"]
+	path = crates/musl-math-sys/musl
 	url = https://git.musl-libc.org/git/musl
 	shallow = true

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -13,6 +13,6 @@ unstable-float = ["libm/unstable-float", "libm-test/unstable-float", "rug?/night
 [dependencies]
 libm = { path = "../../libm", default-features = false }
 libm-macros = { path = "../libm-macros" }
-libm-test = { path = "../libm-test", default-features = false }
+libm-test = { path = "../../libm-test", default-features = false }
 musl-math-sys = { path = "../musl-math-sys", optional = true }
 rug = { version = "1.27.0", optional = true, default-features = false, features = ["float", "std"] }

--- a/libm-test/Cargo.toml
+++ b/libm-test/Cargo.toml
@@ -32,9 +32,9 @@ anyhow = "1.0.97"
 gmp-mpfr-sys = { version = "1.6.4", optional = true, default-features = false }
 iai-callgrind = { version = "0.14.0", optional = true }
 indicatif = { version = "0.17.11", default-features = false }
-libm = { path = "../../libm", features = ["unstable-public-internals"] }
-libm-macros = { path = "../libm-macros" }
-musl-math-sys = { path = "../musl-math-sys", optional = true }
+libm = { path = "../libm", features = ["unstable-public-internals"] }
+libm-macros = { path = "../crates/libm-macros" }
+musl-math-sys = { path = "../crates/musl-math-sys", optional = true }
 paste = "1.0.15"
 rand = "0.9.0"
 rand_chacha = "0.9.0"

--- a/libm-test/build.rs
+++ b/libm-test/build.rs
@@ -1,9 +1,9 @@
-#[path = "../../libm/configure.rs"]
+#[path = "../libm/configure.rs"]
 mod configure;
 use configure::Config;
 
 fn main() {
-    println!("cargo:rerun-if-changed=../../libm/configure.rs");
+    println!("cargo:rerun-if-changed=../libm/configure.rs");
     let cfg = Config::from_env();
     configure::emit_test_config(&cfg);
 }

--- a/libm-test/src/op.rs
+++ b/libm-test/src/op.rs
@@ -16,12 +16,12 @@
 use std::fmt;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 
-pub use shared::{ALL_OPERATIONS, FloatTy, MathOpInfo, Ty};
+pub use shared::{FloatTy, MathOpInfo, Ty, ALL_OPERATIONS};
 
 use crate::{CheckOutput, Float, TupleCall};
 
 mod shared {
-    include!("../../libm-macros/src/shared.rs");
+    include!("../../crates/libm-macros/src/shared.rs");
 }
 
 /// An enum representing each possible symbol name (`sin`, `sinf`, `sinl`, etc).


### PR DESCRIPTION
Update paths and submodules to fix `libm-test` and `util` building so we will be able to add them to the workspace.