### PR TITLE
Move builtins-test-intrinsics out of the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,7 @@
 [workspace]
 resolver = "3"
 members = [
-    # Note that builtins-test-intrinsics cannot be a default member because it
-    # needs the `mangled-names` feature disabled, while `builtins-test` needs
-    # it enabled.
     "builtins-test",
-    "builtins-test-intrinsics",
     "compiler-builtins",
     "crates/libm-macros",
     "libm",
@@ -22,6 +18,13 @@ default-members = [
     # FIXME(libm): disabled until tests work in CI
     # "crates/libm-test"
     "libm",
+]
+
+exclude = [
+    # `builtins-test-intrinsics` needs the feature `compiler-builtins` enabled
+    # and `mangled-names` disabled, which is the opposite of what is needed for
+    # other tests, so it makes sense to keep it out of the workspace.
+    "builtins-test-intrinsics",
 ]
 
 [profile.release]

--- a/builtins-test-intrinsics/Cargo.toml
+++ b/builtins-test-intrinsics/Cargo.toml
@@ -6,7 +6,13 @@ publish = false
 
 [dependencies]
 compiler_builtins = { path = "../compiler-builtins", features = ["compiler-builtins"]}
-panic-handler = { path = '../crates/panic-handler' }
+panic-handler = { path = "../crates/panic-handler" }
 
 [features]
 c = ["compiler_builtins/c"]
+
+[profile.release]
+panic = "abort"
+
+[profile.dev]
+panic = "abort"

--- a/builtins-test/Cargo.toml
+++ b/builtins-test/Cargo.toml
@@ -5,10 +5,6 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2024"
 publish = false
 
-[lib]
-test = false
-doctest = false
-
 [dependencies]
 # For fuzzing tests we want a deterministic seedable RNG. We also eliminate potential
 # problems with system RNGs on the variety of platforms this crate is tested on.

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -19,9 +19,11 @@ run() {
         echo "target is emulated"
     fi
 
-    # This directory needs to exist before calling docker, otherwise docker will create it but it
-    # will be owned by root
+    # Directories and files that do not yet exist need to be created before
+    # calling docker, otherwise docker will create them but they will be owned
+    # by root.
     mkdir -p target
+    cargo generate-lockfile --manifest-path builtins-test-intrinsics/Cargo.toml
 
     run_cmd="HOME=/tmp"
 
@@ -53,7 +55,8 @@ run() {
         # Use rustc provided by a docker image
         docker volume create compiler-builtins-cache
         build_args=(
-            "--build-arg" "IMAGE=${DOCKER_BASE_IMAGE:-rustlang/rust:nightly}"
+            "--build-arg"
+            "IMAGE=${DOCKER_BASE_IMAGE:-rustlang/rust:nightly}"
         )
         run_args=(-v "compiler-builtins-cache:/builtins-target")
         run_cmd="$run_cmd HOME=/tmp" "USING_CONTAINER_RUSTC=1"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -122,7 +122,9 @@ done
 rm -f "${rlib_paths[@]}"
 
 build_intrinsics_test() {
-    cargo build --target "$target" -v --package builtins-test-intrinsics "$@"
+    cargo build \
+        --target "$target" --verbose \
+        --manifest-path builtins-test-intrinsics/Cargo.toml "$@"
 }
 
 # Verify that we haven't dropped any intrinsics/symbols
@@ -133,10 +135,8 @@ build_intrinsics_test --features c --release
 
 # Verify that there are no undefined symbols to `panic` within our
 # implementations
-CARGO_PROFILE_DEV_LTO=true \
-    cargo build --target "$target" --package builtins-test-intrinsics
-CARGO_PROFILE_RELEASE_LTO=true \
-    cargo build --target "$target" --package builtins-test-intrinsics --release
+CARGO_PROFILE_DEV_LTO=true build_intrinsics_test
+CARGO_PROFILE_RELEASE_LTO=true build_intrinsics_test --release
 
 # Ensure no references to any symbols from core
 update_rlib_paths

--- a/compiler-builtins/Cargo.toml
+++ b/compiler-builtins/Cargo.toml
@@ -25,8 +25,9 @@ include = [
 links = 'compiler-rt'
 
 [lib]
-test = false
 bench = false
+doctest = false
+test = false
 
 [dependencies]
 # For more information on this dependency see


### PR DESCRIPTION
This crate doesn't need to be a default member since it requires the opposite settings from everything else. Exclude it from the workspace and run it only when explicitly requested.

This also makes `cargo t --no-default-features` work without additional qualifiers. `--no-default-features` still needs to be passed to ensure `#![compiler_builtins]` does not get set.

compiler-builtins needs doctests disabled in order for everything to work correctly, since this causes an error running rustdoc that is unrelated to features (our `compiler_builtins` is getting into the crate graph before that from the sysroot, but `#![compiler_builtins]` is not set).

We can also remove `test = false` and `doctest = false` in `builtins-test` since these no longer cause issues. This is unlikely to be used but it is better to not quietly skip if anything ever gets added by accident.