### PR TITLE
Add remaining `libm` crates to the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,20 +4,18 @@ members = [
     "builtins-test",
     "compiler-builtins",
     "crates/libm-macros",
+    "crates/musl-math-sys",
+    "crates/util",
     "libm",
-    # FIXME(libm): disabled until tests work in CI
-    # "libm-test",
-    # "crates/musl-math-sys",
-    # "crates/util",
+    "libm-test",
 ]
 
 default-members = [
     "builtins-test",
     "compiler-builtins",
     "crates/libm-macros",
-    # FIXME(libm): disabled until tests work in CI
-    # "crates/libm-test"
     "libm",
+    "libm-test",
 ]
 
 exclude = [

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -58,14 +58,14 @@ update_rlib_paths() {
 update_rlib_paths
 rm -f "${rlib_paths[@]}"
 
-cargo build --target "$target"
-cargo build --target "$target" --release
-cargo build --target "$target" --features c
-cargo build --target "$target" --release --features c
-cargo build --target "$target" --features no-asm
-cargo build --target "$target" --release --features no-asm
-cargo build --target "$target" --features no-f16-f128
-cargo build --target "$target" --release --features no-f16-f128
+cargo build -p compiler_builtins --target "$target"
+cargo build -p compiler_builtins --target "$target" --release
+cargo build -p compiler_builtins --target "$target" --features c
+cargo build -p compiler_builtins --target "$target" --release --features c
+cargo build -p compiler_builtins --target "$target" --features no-asm
+cargo build -p compiler_builtins --target "$target" --release --features no-asm
+cargo build -p compiler_builtins --target "$target" --features no-f16-f128
+cargo build -p compiler_builtins --target "$target" --release --features no-f16-f128
 
 PREFIX=${target//unknown-/}-
 case "$target" in

--- a/libm-test/tests/check_coverage.rs
+++ b/libm-test/tests/check_coverage.rs
@@ -19,7 +19,7 @@ macro_rules! callback {
 
 #[test]
 fn test_for_each_function_all_included() {
-    let all_functions: HashSet<_> = include_str!("../../../etc/function-list.txt")
+    let all_functions: HashSet<_> = include_str!("../../etc/function-list.txt")
         .lines()
         .filter(|line| !line.starts_with("#"))
         .collect();
@@ -52,7 +52,7 @@ fn ensure_list_updated() {
     }
 
     let res = Command::new("python3")
-        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../etc/update-api-list.py"))
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("../etc/update-api-list.py"))
         .arg("--check")
         .status()
         .unwrap();


### PR DESCRIPTION
These are still not yet covered in CI since we always name explicit packages there, but all crates are now part of the workspace.