### PR TITLE
ci: Skip testing libm in PRs if it did not change

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,6 +16,27 @@ env:
   BENCHMARK_RUSTC: nightly-2025-01-16 # Pin the toolchain for reproducable results
 
 jobs:
+  # Determine which tests should be run based on changed files.
+  calculate_vars:
+    name: Calculate workflow variables
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    outputs:
+      extensive_matrix: ${{ steps.script.outputs.extensive_matrix }}
+      may_skip_libm_ci: ${{ steps.script.outputs.may_skip_libm_ci }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 500
+      - name: Fetch pull request ref
+        run: git fetch origin "$GITHUB_REF:$GITHUB_REF"
+        if: github.event_name == 'pull_request'
+      - run: python3 ci/ci-util.py generate-matrix >> "$GITHUB_OUTPUT"
+        id: script
+
   test:
     name: Build and test
     timeout-minutes: 60
@@ -78,9 +99,11 @@ jobs:
           os: windows-2025
           channel: nightly-x86_64-gnu
     runs-on: ${{ matrix.os }}
+    needs: [calculate_vars]
     env:
       BUILD_ONLY: ${{ matrix.build_only }}
       TEST_VERBATIM: ${{ matrix.test_verbatim }}
+      MAY_SKIP_LIBM_CI: ${{ needs.calculate_vars.outputs.may_skip_libm_ci }}
     steps:
     - name: Print runner information
       run: uname -a
@@ -267,41 +290,21 @@ jobs:
       run: rustup set profile minimal && rustup default stable && rustup component add rustfmt
     - run: cargo fmt -- --check
 
-  # Determine which extensive tests should be run based on changed files.
-  calculate_extensive_matrix:
-    name: Calculate job matrix
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-    outputs:
-      matrix: ${{ steps.script.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 100
-      - name: Fetch pull request ref
-        run: git fetch origin "$GITHUB_REF:$GITHUB_REF"
-        if: github.event_name == 'pull_request'
-      - run: python3 ci/ci-util.py generate-matrix >> "$GITHUB_OUTPUT"
-        id: script
-
   extensive:
     name: Extensive tests for ${{ matrix.ty }}
     needs:
       # Wait on `clippy` so we have some confidence that the crate will build
       - clippy
-      - calculate_extensive_matrix
+      - calculate_vars
     runs-on: ubuntu-24.04
     timeout-minutes: 240 # 4 hours
     strategy:
       matrix:
-        # Use the output from `calculate_extensive_matrix` to calculate the matrix
+        # Use the output from `calculate_vars` to create the matrix
         # FIXME: it would be better to run all jobs (i.e. all types) but mark those that
         # didn't change as skipped, rather than completely excluding the job. However,
         # this is not currently possible https://github.com/actions/runner/issues/1985.
-        include: ${{ fromJSON(needs.calculate_extensive_matrix.outputs.matrix).matrix }}
+        include: ${{ fromJSON(needs.calculate_vars.outputs.extensive_matrix).extensive_matrix }}
     env:
       TO_TEST: ${{ matrix.to_test }}
     steps:

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -77,6 +77,7 @@ run() {
         -e CI \
         -e CARGO_TARGET_DIR=/builtins-target \
         -e CARGO_TERM_COLOR \
+        -e MAY_SKIP_LIBM_CI \
         -e RUSTFLAGS \
         -e RUST_BACKTRACE \
         -e RUST_COMPILER_RT_ROOT \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -174,6 +174,14 @@ done
 
 # Test libm
 
+# Make sure a simple build works
+cargo check -p libm --no-default-features --target "$target"
+
+if [ "${MAY_SKIP_LIBM_CI:-}" = "true" ]; then
+    echo "skipping libm PR CI"
+    exit
+fi
+
 mflags=()
 
 # We enumerate features manually.
@@ -225,9 +233,6 @@ esac
 case "$target" in
     *windows-gnu) mflags+=(--exclude libm-macros) ;;
 esac
-
-# Make sure a simple build works
-cargo check -p libm --no-default-features --target "$target"
 
 if [ "${BUILD_ONLY:-}" = "1" ]; then
     # If we are on targets that can't run tests, verify that we can build.


### PR DESCRIPTION
Many contributions to compiler-builtins don't have any need to touch libm, and could get by with the few minutes of CI for compiler-builtins rather than the ~30 minutes for libm. We already have some scripts that handle changed file detection, so expand its use to skip libm CI if it doesn't need to run.