### PR TITLE
Add a no-f64 version of `fmaf`

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -184,6 +184,8 @@ fi
 
 mflags=()
 
+nowiden_tests=$(grep -vE '^#' etc/has-nowiden-impl.txt | tr '\n' ' ')
+
 # We enumerate features manually.
 mflags+=(--no-default-features)
 
@@ -283,6 +285,7 @@ else
     # Test the same in release mode, which also increases coverage. Also ensure
     # the soft float routines are checked.
     "${cmd[@]}" "$profile_flag" release-checked
+    [ -n "${nowiden_tests:-}" ] && LIBM_F32_NO_WIDEN=1 "${cmd[@]}" "$profile_flag" release-checked -- $nowiden_tests
     "${cmd[@]}" "$profile_flag" release-checked --features force-soft-floats
     "${cmd[@]}" "$profile_flag" release-checked --features unstable-intrinsics
     "${cmd[@]}" "$profile_flag" release-checked --features unstable-intrinsics --benches

--- a/etc/has-nowiden-impl.txt
+++ b/etc/has-nowiden-impl.txt
@@ -1,0 +1,2 @@
+# Functions that have a different version based on f32_no_widen
+fmaf

--- a/libm/configure.rs
+++ b/libm/configure.rs
@@ -50,6 +50,7 @@ pub fn emit_libm_config(cfg: &Config) {
     emit_intrinsics_cfg();
     emit_arch_cfg();
     emit_optimization_cfg(cfg);
+    emit_widen_cfg(cfg);
     emit_cfg_shorthands(cfg);
     emit_cfg_env(cfg);
     emit_f16_f128_cfg(cfg);
@@ -93,6 +94,15 @@ fn emit_optimization_cfg(cfg: &Config) {
 
     if !matches!(cfg.opt_level.as_str(), "0" | "1") {
         println!("cargo:rustc-cfg=optimizations_enabled");
+    }
+}
+
+fn emit_widen_cfg(_cfg: &Config) {
+    println!("cargo:rustc-check-cfg=cfg(f32_no_widen)");
+    println!("cargo:rerun-if-env-changed=LIBM_F32_NO_WIDEN");
+
+    if env::var_os("LIBM_F32_NO_WIDEN").is_some() {
+        println!("cargo:rustc-cfg=f32_no_widen");
     }
 }
 

--- a/libm/src/math/fma_wide.rs
+++ b/libm/src/math/fma_wide.rs
@@ -23,7 +23,11 @@ pub fn fmaf(x: f32, y: f32, z: f32) -> f32 {
         args: x, y, z,
     }
 
-    fma_wide_round(x, y, z, Round::Nearest).val
+    if cfg!(f32_no_widen) {
+        super::fma::fma_round(x, y, z, Round::Nearest).val
+    } else {
+        fma_wide_round(x, y, z, Round::Nearest).val
+    }
 }
 
 /// Fma implementation when a hardware-backed larger float type is available. For `f32` and `f64`,


### PR DESCRIPTION
Recreated from https://github.com/rust-lang/libm/pull/500