### PR TITLE
Reimplement the generic fmod

### DIFF
--- a/libm/src/lib.rs
+++ b/libm/src/lib.rs
@@ -14,6 +14,7 @@
 #![allow(clippy::excessive_precision)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::int_plus_one)]
+#![allow(clippy::just_underscores_and_digits)]
 #![allow(clippy::many_single_char_names)]
 #![allow(clippy::mixed_case_hex_literals)]
 #![allow(clippy::needless_late_init)]

--- a/libm/src/math/support/int_traits.rs
+++ b/libm/src/math/support/int_traits.rs
@@ -40,6 +40,9 @@ pub trait Int:
     + PartialOrd
     + ops::AddAssign
     + ops::SubAssign
+    + ops::MulAssign
+    + ops::DivAssign
+    + ops::RemAssign
     + ops::BitAndAssign
     + ops::BitOrAssign
     + ops::BitXorAssign
@@ -51,6 +54,7 @@ pub trait Int:
     + ops::Sub<Output = Self>
     + ops::Mul<Output = Self>
     + ops::Div<Output = Self>
+    + ops::Rem<Output = Self>
     + ops::Shl<i32, Output = Self>
     + ops::Shl<u32, Output = Self>
     + ops::Shr<i32, Output = Self>


### PR DESCRIPTION
Redo of https://github.com/rust-lang/libm/pull/536 since the repository was moved.

Full reimplementation for fmod, that should be somewhat cleaner. This was showing a decent perf gain locally, but the major improvement will come later by implementing the reduction helper with something smarter, which does involve some tradeoffs and alternatives to consider.

While applying the feedback from the original PR, I used the opportunity to go over the code again.