### PR TITLE
Rename the `public-test-deps` feature to `unstable-public-internals`

### DIFF
--- a/builtins-test/Cargo.toml
+++ b/builtins-test/Cargo.toml
@@ -19,7 +19,7 @@ iai-callgrind = { version = "0.14.0", optional = true }
 [dependencies.compiler_builtins]
 path = "../compiler-builtins"
 default-features = false
-features = ["public-test-deps"]
+features = ["unstable-public-internals"]
 
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false, features = ["cargo_bench_support"] }

--- a/compiler-builtins/Cargo.toml
+++ b/compiler-builtins/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/rust-lang/compiler-builtins"
 documentation = "https://docs.rs/compiler_builtins"
 edition = "2021"
 description = "Compiler intrinsics used by the Rust compiler."
-links = 'compiler-rt'
+links = "compiler-rt"
 
 [lib]
 bench = false
@@ -19,20 +19,20 @@ test = false
 [dependencies]
 # For more information on this dependency see
 # https://github.com/rust-lang/rust/tree/master/library/rustc-std-workspace-core
-core = { version = "1.0.0", optional = true, package = 'rustc-std-workspace-core' }
+core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 
 [build-dependencies]
 cc = { optional = true, version = "1.0" }
 
 [dev-dependencies]
-panic-handler = { path = '../crates/panic-handler' }
+panic-handler = { path = "../crates/panic-handler" }
 
 [features]
 default = ["compiler-builtins"]
 
 # Enable compilation of C code in compiler-rt, filling in some more optimized
 # implementations and also filling in unimplemented intrinsics
-c = ["cc"]
+c = ["dep:cc"]
 
 # Workaround for the Cranelift codegen backend. Disables any implementations
 # which use inline assembly and fall back to pure Rust versions (if avalible).
@@ -53,11 +53,11 @@ mem = []
 mangled-names = []
 
 # Only used in the compiler's build system
-rustc-dep-of-std = ['compiler-builtins', 'core']
+rustc-dep-of-std = ["compiler-builtins", "dep:core"]
 
 # This makes certain traits and function specializations public that
 # are not normally public but are required by the `builtins-test`
-public-test-deps = []
+unstable-public-internals = []
 
 [lints.rust]
 # The cygwin config can be dropped after our benchmark toolchain is bumped

--- a/compiler-builtins/src/float/mod.rs
+++ b/compiler-builtins/src/float/mod.rs
@@ -9,7 +9,7 @@ pub mod sub;
 pub(crate) mod traits;
 pub mod trunc;
 
-#[cfg(not(feature = "public-test-deps"))]
+#[cfg(not(feature = "unstable-public-internals"))]
 pub(crate) use traits::{Float, HalfRep};
-#[cfg(feature = "public-test-deps")]
+#[cfg(feature = "unstable-public-internals")]
 pub use traits::{Float, HalfRep};

--- a/compiler-builtins/src/int/leading_zeros.rs
+++ b/compiler-builtins/src/int/leading_zeros.rs
@@ -3,9 +3,9 @@
 // adding a zero check at the beginning, but `__clzsi2` has a precondition that `x != 0`.
 // Compilers will insert the check for zero in cases where it is needed.
 
-#[cfg(feature = "public-test-deps")]
+#[cfg(feature = "unstable-public-internals")]
 pub use implementation::{leading_zeros_default, leading_zeros_riscv};
-#[cfg(not(feature = "public-test-deps"))]
+#[cfg(not(feature = "unstable-public-internals"))]
 pub(crate) use implementation::{leading_zeros_default, leading_zeros_riscv};
 
 mod implementation {

--- a/compiler-builtins/src/int/mod.rs
+++ b/compiler-builtins/src/int/mod.rs
@@ -12,7 +12,7 @@ mod traits;
 pub mod udiv;
 
 pub use big::{i256, u256};
-#[cfg(not(feature = "public-test-deps"))]
+#[cfg(not(feature = "unstable-public-internals"))]
 pub(crate) use traits::{CastFrom, CastInto, DInt, HInt, Int, MinInt};
-#[cfg(feature = "public-test-deps")]
+#[cfg(feature = "unstable-public-internals")]
 pub use traits::{CastFrom, CastInto, DInt, HInt, Int, MinInt};

--- a/compiler-builtins/src/int/specialized_div_rem/mod.rs
+++ b/compiler-builtins/src/int/specialized_div_rem/mod.rs
@@ -56,9 +56,9 @@ mod delegate;
 
 // used on SPARC
 #[allow(unused_imports)]
-#[cfg(not(feature = "public-test-deps"))]
+#[cfg(not(feature = "unstable-public-internals"))]
 pub(crate) use self::delegate::u128_divide_sparc;
-#[cfg(feature = "public-test-deps")]
+#[cfg(feature = "unstable-public-internals")]
 pub use self::delegate::u128_divide_sparc;
 
 #[macro_use]

--- a/compiler-builtins/src/int/trailing_zeros.rs
+++ b/compiler-builtins/src/int/trailing_zeros.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "public-test-deps")]
+#[cfg(feature = "unstable-public-internals")]
 pub use implementation::trailing_zeros;
-#[cfg(not(feature = "public-test-deps"))]
+#[cfg(not(feature = "unstable-public-internals"))]
 pub(crate) use implementation::trailing_zeros;
 
 mod implementation {

--- a/compiler-builtins/src/int/udiv.rs
+++ b/compiler-builtins/src/int/udiv.rs
@@ -1,6 +1,6 @@
-#[cfg(not(feature = "public-test-deps"))]
+#[cfg(not(feature = "unstable-public-internals"))]
 pub(crate) use crate::int::specialized_div_rem::*;
-#[cfg(feature = "public-test-deps")]
+#[cfg(feature = "unstable-public-internals")]
 pub use crate::int::specialized_div_rem::*;
 
 intrinsics! {


### PR DESCRIPTION
`compiler-builtins` uses `public-test-deps`, `libm` uses `unstable-public-internals`. Consolidate these under the `libm` name.

Once compiler-builtins is no longer published, this feature can probably be dropped.

Also switch to `dep:` syntax for features that enable dependencies.