### PR TITLE
fix: Switch to resolver v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "3"
+resolver = "2"
 members = [
     "builtins-test",
     "compiler-builtins",


### PR DESCRIPTION
The published crates fail to build with an edition less than 2024 because they are packaged with `resolver = "3"`, which is a 2024-only option. Revert back to resolver v2 to drop this requirement.

Fixes: https://github.com/rust-lang/compiler-builtins/issues/883