### PR TITLE
libm-macros: Start tracking which functions are public

### DIFF
--- a/crates/libm-macros/src/lib.rs
+++ b/crates/libm-macros/src/lib.rs
@@ -12,7 +12,7 @@ use syn::visit_mut::VisitMut;
 use syn::{Ident, ItemEnum};
 
 const KNOWN_TYPES: &[&str] = &[
-    "FTy", "CFn", "CArgs", "CRet", "RustFn", "RustArgs", "RustRet",
+    "FTy", "CFn", "CArgs", "CRet", "RustFn", "RustArgs", "RustRet", "public",
 ];
 
 /// Populate an enum with a variant representing function. Names are in upper camel case.
@@ -80,6 +80,8 @@ pub fn base_name_enum(attributes: pm::TokenStream, tokens: pm::TokenStream) -> p
 ///         RustArgs: $RustArgs:ty,
 ///         // The Rust version's return type (e.g. `(f32, f32)`)
 ///         RustRet: $RustRet:ty,
+///         // True if this is part of `libm`'s public API
+///         public: $public:expr,
 ///         // Attributes for the current function, if any
 ///         attrs: [$($attr:meta),*],
 ///         // Extra tokens passed directly (if any)
@@ -329,6 +331,7 @@ fn expand(input: StructuredInput, fn_list: &[&MathOpInfo]) -> syn::Result<pm2::T
         let c_ret = &func.c_sig.returns;
         let rust_args = &func.rust_sig.args;
         let rust_ret = &func.rust_sig.returns;
+        let public = func.public;
 
         let mut ty_fields = Vec::new();
         for ty in &input.emit_types {
@@ -340,6 +343,7 @@ fn expand(input: StructuredInput, fn_list: &[&MathOpInfo]) -> syn::Result<pm2::T
                 "RustFn" => quote! { RustFn: fn( #(#rust_args),* ,) -> ( #(#rust_ret),* ), },
                 "RustArgs" => quote! { RustArgs: ( #(#rust_args),* ,), },
                 "RustRet" => quote! { RustRet: ( #(#rust_ret),* ), },
+                "public" => quote! { public: #public, },
                 _ => unreachable!("checked in validation"),
             };
             ty_fields.push(field);

--- a/crates/libm-macros/tests/basic.rs
+++ b/crates/libm-macros/tests/basic.rs
@@ -13,6 +13,7 @@ macro_rules! basic {
         RustFn: $RustFn:ty,
         RustArgs: $RustArgs:ty,
         RustRet: $RustRet:ty,
+        public: $public:expr,
         attrs: [$($attr:meta),*],
         extra: [$($extra_tt:tt)*],
         fn_extra: $fn_extra:expr,
@@ -25,6 +26,7 @@ macro_rules! basic {
             type RustFnTy = $RustFn;
             type RustArgsTy = $RustArgs;
             type RustRetTy = $RustRet;
+            const PUBLIC: bool = $public;
             const A: &[&str] = &[$($extra_tt)*];
             fn foo(a: f32) -> f32 {
                 $fn_extra(a)

--- a/libm-test/src/op.rs
+++ b/libm-test/src/op.rs
@@ -90,6 +90,9 @@ pub trait MathOp {
 
     /// The function in `libm` which can be called.
     const ROUTINE: Self::RustFn;
+
+    /// Whether or not the function is part of libm public API.
+    const PUBLIC: bool;
 }
 
 /// Access the associated `FTy` type from an op (helper to avoid ambiguous associated types).
@@ -107,7 +110,7 @@ pub type OpRustArgs<Op> = <Op as MathOp>::RustArgs;
 /// Access the associated `RustRet` type from an op (helper to avoid ambiguous associated types).
 pub type OpRustRet<Op> = <Op as MathOp>::RustRet;
 
-macro_rules! do_thing {
+macro_rules! create_op_modules {
     // Matcher for unary functions
     (
         fn_name: $fn_name:ident,
@@ -118,8 +121,8 @@ macro_rules! do_thing {
         RustFn: $RustFn:ty,
         RustArgs: $RustArgs:ty,
         RustRet: $RustRet:ty,
+        public: $public:expr,
         attrs: [$($attr:meta),*],
-
     ) => {
         paste::paste! {
             $(#[$attr])*
@@ -138,6 +141,7 @@ macro_rules! do_thing {
 
                     const IDENTIFIER: Identifier = Identifier::[< $fn_name:camel >];
                     const ROUTINE: Self::RustFn = libm::$fn_name;
+                    const PUBLIC: bool = $public;
                 }
             }
 
@@ -146,6 +150,6 @@ macro_rules! do_thing {
 }
 
 libm_macros::for_each_function! {
-    callback: do_thing,
+    callback: create_op_modules,
     emit_types: all,
 }


### PR DESCRIPTION
It would be nice to reuse some of the macro structure for internal functions, like `rem_pio2`. To facilitate this, add a `public` field and make it available in the macro's API.