### PR TITLE
docs: fix typo in Cargo.toml

### DIFF
--- a/compiler-builtins/Cargo.toml
+++ b/compiler-builtins/Cargo.toml
@@ -35,7 +35,7 @@ default = ["compiler-builtins"]
 c = ["dep:cc"]
 
 # Workaround for the Cranelift codegen backend. Disables any implementations
-# which use inline assembly and fall back to pure Rust versions (if avalible).
+# which use inline assembly and fall back to pure Rust versions (if available).
 no-asm = []
 
 # Workaround for codegen backends which haven't yet implemented `f16` and


### PR DESCRIPTION
Initially introduced in 63ccaf11f08fb5d0b39cc33884c5a1a63f547ace