### PR TITLE
Resolve `unnecessary_transmutes` lints

### DIFF
--- a/builtins-test/tests/misc.rs
+++ b/builtins-test/tests/misc.rs
@@ -77,16 +77,13 @@ fn leading_zeros() {
             let lz1 = leading_zeros_default(x);
             let lz2 = leading_zeros_riscv(x);
             if lz0 != lz {
-                panic!("__clzsi2({}): std: {}, builtins: {}", x, lz, lz0);
+                panic!("__clzsi2({x}): std: {lz}, builtins: {lz0}");
             }
             if lz1 != lz {
-                panic!(
-                    "leading_zeros_default({}): std: {}, builtins: {}",
-                    x, lz, lz1
-                );
+                panic!("leading_zeros_default({x}): std: {lz}, builtins: {lz1}");
             }
             if lz2 != lz {
-                panic!("leading_zeros_riscv({}): std: {}, builtins: {}", x, lz, lz2);
+                panic!("leading_zeros_riscv({x}): std: {lz}, builtins: {lz2}");
             }
         });
     }
@@ -102,16 +99,13 @@ fn leading_zeros() {
             let lz1 = leading_zeros_default(x);
             let lz2 = leading_zeros_riscv(x);
             if lz0 != lz {
-                panic!("__clzdi2({}): std: {}, builtins: {}", x, lz, lz0);
+                panic!("__clzdi2({x}): std: {lz}, builtins: {lz0}");
             }
             if lz1 != lz {
-                panic!(
-                    "leading_zeros_default({}): std: {}, builtins: {}",
-                    x, lz, lz1
-                );
+                panic!("leading_zeros_default({x}): std: {lz}, builtins: {lz1}");
             }
             if lz2 != lz {
-                panic!("leading_zeros_riscv({}): std: {}, builtins: {}", x, lz, lz2);
+                panic!("leading_zeros_riscv({x}): std: {lz}, builtins: {lz2}");
             }
         });
     }
@@ -125,7 +119,7 @@ fn leading_zeros() {
             let lz = x.leading_zeros() as usize;
             let lz0 = __clzti2(x);
             if lz0 != lz {
-                panic!("__clzti2({}): std: {}, builtins: {}", x, lz, lz0);
+                panic!("__clzti2({x}): std: {lz}, builtins: {lz0}");
             }
         });
     }
@@ -142,10 +136,10 @@ fn trailing_zeros() {
         let tz0 = __ctzsi2(x);
         let tz1 = trailing_zeros(x);
         if tz0 != tz {
-            panic!("__ctzsi2({}): std: {}, builtins: {}", x, tz, tz0);
+            panic!("__ctzsi2({x}): std: {tz}, builtins: {tz0}");
         }
         if tz1 != tz {
-            panic!("trailing_zeros({}): std: {}, builtins: {}", x, tz, tz1);
+            panic!("trailing_zeros({x}): std: {tz}, builtins: {tz1}");
         }
     });
     fuzz(N, |x: u64| {
@@ -156,10 +150,10 @@ fn trailing_zeros() {
         let tz0 = __ctzdi2(x);
         let tz1 = trailing_zeros(x);
         if tz0 != tz {
-            panic!("__ctzdi2({}): std: {}, builtins: {}", x, tz, tz0);
+            panic!("__ctzdi2({x}): std: {tz}, builtins: {tz0}");
         }
         if tz1 != tz {
-            panic!("trailing_zeros({}): std: {}, builtins: {}", x, tz, tz1);
+            panic!("trailing_zeros({x}): std: {tz}, builtins: {tz1}");
         }
     });
     fuzz(N, |x: u128| {
@@ -169,7 +163,7 @@ fn trailing_zeros() {
         let tz = x.trailing_zeros() as usize;
         let tz0 = __ctzti2(x);
         if tz0 != tz {
-            panic!("__ctzti2({}): std: {}, builtins: {}", x, tz, tz0);
+            panic!("__ctzti2({x}): std: {tz}, builtins: {tz0}");
         }
     });
 }

--- a/builtins-test/tests/mul.rs
+++ b/builtins-test/tests/mul.rs
@@ -18,8 +18,8 @@ mod int_mul {
                         let mul1: $i = $fn(x, y);
                         if mul0 != mul1 {
                             panic!(
-                                "{}({}, {}): std: {}, builtins: {}",
-                                stringify!($fn), x, y, mul0, mul1
+                                "{func}({x}, {y}): std: {mul0}, builtins: {mul1}",
+                                func = stringify!($fn),
                             );
                         }
                     });
@@ -52,8 +52,8 @@ mod int_overflowing_mul {
                         let o1 = o1 != 0;
                         if mul0 != mul1 || o0 != o1 {
                             panic!(
-                                "{}({}, {}): std: ({}, {}), builtins: ({}, {})",
-                                stringify!($fn), x, y, mul0, o0, mul1, o1
+                                "{func}({x}, {y}): std: ({mul0}, {o0}), builtins: ({mul1}, {o1})",
+                                func = stringify!($fn),
                             );
                         }
                     });
@@ -77,20 +77,14 @@ mod int_overflowing_mul {
             let (mul0, o0) = x.overflowing_mul(y);
             let mul1 = __rust_u128_mulo(x, y, &mut o1);
             if mul0 != mul1 || i32::from(o0) != o1 {
-                panic!(
-                    "__rust_u128_mulo({}, {}): std: ({}, {}), builtins: ({}, {})",
-                    x, y, mul0, o0, mul1, o1
-                );
+                panic!("__rust_u128_mulo({x}, {y}): std: ({mul0}, {o0}), builtins: ({mul1}, {o1})",);
             }
             let x = x as i128;
             let y = y as i128;
             let (mul0, o0) = x.overflowing_mul(y);
             let mul1 = __rust_i128_mulo(x, y, &mut o1);
             if mul0 != mul1 || i32::from(o0) != o1 {
-                panic!(
-                    "__rust_i128_mulo({}, {}): std: ({}, {}), builtins: ({}, {})",
-                    x, y, mul0, o0, mul1, o1
-                );
+                panic!("__rust_i128_mulo({x}, {y}): std: ({mul0}, {o0}), builtins: ({mul1}, {o1})",);
             }
         });
     }
@@ -109,8 +103,8 @@ macro_rules! float_mul {
                     let mul1: $f = $fn(x, y);
                     if !Float::eq_repr(mul0, mul1) {
                         panic!(
-                            "{}({:?}, {:?}): std: {:?}, builtins: {:?}",
-                            stringify!($fn), x, y, mul0, mul1
+                            "{func}({x:?}, {y:?}): std: {mul0:?}, builtins: {mul1:?}",
+                            func = stringify!($fn),
                         );
                     }
                 });

--- a/compiler-builtins/build.rs
+++ b/compiler-builtins/build.rs
@@ -137,7 +137,7 @@ fn aarch64_symbol(ordering: Ordering) -> &'static str {
         Ordering::Acquire => "acq",
         Ordering::Release => "rel",
         Ordering::AcqRel => "acq_rel",
-        _ => panic!("unknown symbol for {:?}", ordering),
+        _ => panic!("unknown symbol for {ordering:?}"),
     }
 }
 
@@ -229,7 +229,7 @@ fn configure_check_cfg() {
 
         for op_size in op_sizes {
             for ordering in ["relax", "acq", "rel", "acq_rel"] {
-                aarch_atomic.push(format!("__aarch64_{}{}_{}", aarch_op, op_size, ordering));
+                aarch_atomic.push(format!("__aarch64_{aarch_op}{op_size}_{ordering}"));
             }
         }
     }
@@ -239,10 +239,7 @@ fn configure_check_cfg() {
         .copied()
         .chain(aarch_atomic.iter().map(|s| s.as_str()))
     {
-        println!(
-            "cargo::rustc-check-cfg=cfg({}, values(\"optimized-c\"))",
-            fn_name
-        );
+        println!("cargo::rustc-check-cfg=cfg({fn_name}, values(\"optimized-c\"))",);
     }
 
     // Rustc is unaware of sparc target features, but this does show up from

--- a/compiler-builtins/src/mem/impls.rs
+++ b/compiler-builtins/src/mem/impls.rs
@@ -38,7 +38,7 @@ unsafe fn read_usize_unaligned(x: *const usize) -> usize {
     // Do not use `core::ptr::read_unaligned` here, since it calls `copy_nonoverlapping` which
     // is translated to memcpy in LLVM.
     let x_read = (x as *const [u8; core::mem::size_of::<usize>()]).read();
-    core::mem::transmute(x_read)
+    usize::from_ne_bytes(x_read)
 }
 
 /// Loads a `T`-sized chunk from `src` into `dst` at offset `offset`, if that does not exceed

--- a/libm/src/math/pow.rs
+++ b/libm/src/math/pow.rs
@@ -452,11 +452,7 @@ mod tests {
             } else {
                 pow(base, exponent) == expected
             },
-            "{} ** {} was {} instead of {}",
-            base,
-            exponent,
-            res,
-            expected
+            "{base} ** {exponent} was {res} instead of {expected}",
         );
     }
 
@@ -486,10 +482,7 @@ mod tests {
                     } else {
                         exp == res
                     },
-                    "test for {} was {} instead of {}",
-                    val,
-                    res,
-                    exp
+                    "test for {val} was {res} instead of {exp}",
                 );
             })
         });

--- a/libm/src/math/support/float_traits.rs
+++ b/libm/src/math/support/float_traits.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints)] // FIXME(msrv) we shouldn't need this
+
 use core::{fmt, mem, ops};
 
 use super::int_traits::{CastFrom, Int, MinInt};
@@ -344,24 +346,28 @@ float_impl!(
 /* FIXME(msrv): vendor some things that are not const stable at our MSRV */
 
 /// `f32::from_bits`
+#[allow(unnecessary_transmutes)] // lint appears in newer versions of Rust
 pub const fn f32_from_bits(bits: u32) -> f32 {
     // SAFETY: POD cast with no preconditions
     unsafe { mem::transmute::<u32, f32>(bits) }
 }
 
 /// `f32::to_bits`
+#[allow(unnecessary_transmutes)] // lint appears in newer versions of Rust
 pub const fn f32_to_bits(x: f32) -> u32 {
     // SAFETY: POD cast with no preconditions
     unsafe { mem::transmute::<f32, u32>(x) }
 }
 
 /// `f64::from_bits`
+#[allow(unnecessary_transmutes)] // lint appears in newer versions of Rust
 pub const fn f64_from_bits(bits: u64) -> f64 {
     // SAFETY: POD cast with no preconditions
     unsafe { mem::transmute::<u64, f64>(bits) }
 }
 
 /// `f64::to_bits`
+#[allow(unnecessary_transmutes)] // lint appears in newer versions of Rust
 pub const fn f64_to_bits(x: f64) -> u64 {
     // SAFETY: POD cast with no preconditions
     unsafe { mem::transmute::<f64, u64>(x) }


### PR DESCRIPTION
These appeared in a later nightly. In compiler-builtins we can apply the suggestion, but in `libm` we need to ignore them since `fx::from_bits` is not `const` at the MSRV.

`clippy::uninlined_format_args` also seems to have gotten stricter, so fix those here.