### PR TITLE
builtins-test: Remove `no_mangle` from `eh_personality`

### DIFF
--- a/builtins-test-intrinsics/src/main.rs
+++ b/builtins-test-intrinsics/src/main.rs
@@ -682,7 +682,6 @@ pub fn _Unwind_Resume() {}
 
 #[cfg(not(any(windows, target_os = "cygwin")))]
 #[lang = "eh_personality"]
-#[unsafe(no_mangle)]
 pub extern "C" fn eh_personality() {}
 
 #[cfg(any(all(windows, target_env = "gnu"), target_os = "cygwin"))]


### PR DESCRIPTION
Rustc now mangles these symbols on its own, so `no_mangle` is rejected as an error.