### PR TITLE
Use our libm on windows-gnu targets

### DIFF
--- a/compiler-builtins/src/math/mod.rs
+++ b/compiler-builtins/src/math/mod.rs
@@ -39,9 +39,13 @@ pub mod full_availability {
     }
 
     /* Weak linkage is unreliable on Windows and Apple, so we don't expose symbols that we know
-     * the system libc provides in order to avoid conflicts. */
+     * the system libc provides in order to avoid conflicts.
+     *
+     * Windows+GNU is an exception since we _do_ want to use our `fma` to avoid the inaccurate
+     * system implementation. see the issue: https://github.com/rust-lang/rust/issues/140515.
+     */
 
-    #[cfg(all(not(windows), not(target_vendor = "apple")))]
+    #[cfg(all(not(all(windows, target_env = "gnu")), not(target_vendor = "apple")))]
     libm_intrinsics! {
         /* f32 */
         fn cbrtf(n: f32) -> f32;


### PR DESCRIPTION
Add Windows-GNU to the group of targets that gets our version of basic libm symbols available through compiler-builtins. This is done to avoid bugs in the platform `fma`, see [1].

[1]: https://github.com/rust-lang/rust/issues/140515