### PR TITLE
Disable aarch64 assembly if `target_abi = "softfloat"`

### DIFF
--- a/libm/src/math/arch/mod.rs
+++ b/libm/src/math/arch/mod.rs
@@ -19,7 +19,8 @@ cfg_if! {
         pub use x86::{sqrt, sqrtf, fma, fmaf};
     } else if #[cfg(all(
         any(target_arch = "aarch64", target_arch = "arm64ec"),
-        target_feature = "neon"
+        target_feature = "neon",
+        not(target_abi = "softfloat"),
     ))] {
         mod aarch64;
 

--- a/libm/src/math/fma.rs
+++ b/libm/src/math/fma.rs
@@ -20,7 +20,7 @@ pub fn fmaf(x: f32, y: f32, z: f32) -> f32 {
     select_implementation! {
         name: fmaf,
         use_arch: any(
-            all(target_arch = "aarch64", target_feature = "neon"),
+            all(target_arch = "aarch64", target_feature = "neon", not(target_abi = "softfloat")),
             target_feature = "sse2",
         ),
         args: x, y, z,
@@ -37,7 +37,7 @@ pub fn fma(x: f64, y: f64, z: f64) -> f64 {
     select_implementation! {
         name: fma,
         use_arch: any(
-            all(target_arch = "aarch64", target_feature = "neon"),
+            all(target_arch = "aarch64", target_feature = "neon", not(target_abi = "softfloat")),
             target_feature = "sse2",
         ),
         args: x, y, z,

--- a/libm/src/math/rint.rs
+++ b/libm/src/math/rint.rs
@@ -19,7 +19,7 @@ pub fn rintf(x: f32) -> f32 {
     select_implementation! {
         name: rintf,
         use_arch: any(
-            all(target_arch = "aarch64", target_feature = "neon"),
+            all(target_arch = "aarch64", target_feature = "neon", not(target_abi = "softfloat")),
             all(target_arch = "wasm32", intrinsics_enabled),
         ),
         args: x,
@@ -34,7 +34,7 @@ pub fn rint(x: f64) -> f64 {
     select_implementation! {
         name: rint,
         use_arch: any(
-            all(target_arch = "aarch64", target_feature = "neon"),
+            all(target_arch = "aarch64", target_feature = "neon", not(target_abi = "softfloat")),
             all(target_arch = "wasm32", intrinsics_enabled),
         ),
         args: x,

--- a/libm/src/math/sqrt.rs
+++ b/libm/src/math/sqrt.rs
@@ -17,7 +17,7 @@ pub fn sqrtf(x: f32) -> f32 {
     select_implementation! {
         name: sqrtf,
         use_arch: any(
-            all(target_arch = "aarch64", target_feature = "neon"),
+            all(target_arch = "aarch64", target_feature = "neon", not(target_abi = "softfloat")),
             all(target_arch = "wasm32", intrinsics_enabled),
             target_feature = "sse2"
         ),
@@ -33,7 +33,7 @@ pub fn sqrt(x: f64) -> f64 {
     select_implementation! {
         name: sqrt,
         use_arch: any(
-            all(target_arch = "aarch64", target_feature = "neon"),
+            all(target_arch = "aarch64", target_feature = "neon", not(target_abi = "softfloat")),
             all(target_arch = "wasm32", intrinsics_enabled),
             target_feature = "sse2"
         ),


### PR DESCRIPTION
The target `aarch64-unknown-none-softfloat` still sets the `neon` target feature, so the assembly implementations are incorrectly being enabled. Update gates to differentiate the `softfloat` ABI.