### PR TITLE
Replace `super::super` with `crate::support` where possible

### DIFF
--- a/ci/ci-util.py
+++ b/ci/ci-util.py
@@ -261,7 +261,9 @@ class Context:
         if error_on_many_tests and total_to_test > MANY_EXTENSIVE_THRESHOLD:
             eprint(
                 f"More than {MANY_EXTENSIVE_THRESHOLD} tests would be run; add"
-                f" `{ALLOW_MANY_EXTENSIVE_DIRECTIVE}` to the PR body if this is intentional"
+                f" `{ALLOW_MANY_EXTENSIVE_DIRECTIVE}` to the PR body if this is"
+                " intentional. If this is refactoring that happens to touch a lot of"
+                f" files, `{SKIP_EXTENSIVE_DIRECTIVE}` can be used instead."
             )
             exit(1)
 

--- a/libm/src/math/generic/ceil.rs
+++ b/libm/src/math/generic/ceil.rs
@@ -7,8 +7,7 @@
 //! performance seems to be better (based on icount) and it does not seem to experience rounding
 //! errors on i386.
 
-use super::super::support::{FpResult, Status};
-use super::super::{Float, Int, IntTy, MinInt};
+use crate::support::{Float, FpResult, Int, IntTy, MinInt, Status};
 
 #[inline]
 pub fn ceil<F: Float>(x: F) -> F {

--- a/libm/src/math/generic/copysign.rs
+++ b/libm/src/math/generic/copysign.rs
@@ -1,4 +1,4 @@
-use super::super::Float;
+use crate::support::Float;
 
 /// Copy the sign of `y` to `x`.
 #[inline]

--- a/libm/src/math/generic/fabs.rs
+++ b/libm/src/math/generic/fabs.rs
@@ -1,4 +1,4 @@
-use super::super::Float;
+use crate::support::Float;
 
 /// Absolute value.
 #[inline]

--- a/libm/src/math/generic/fdim.rs
+++ b/libm/src/math/generic/fdim.rs
@@ -1,4 +1,4 @@
-use super::super::Float;
+use crate::support::Float;
 
 #[inline]
 pub fn fdim<F: Float>(x: F, y: F) -> F {

--- a/libm/src/math/generic/floor.rs
+++ b/libm/src/math/generic/floor.rs
@@ -7,8 +7,7 @@
 //! performance seems to be better (based on icount) and it does not seem to experience rounding
 //! errors on i386.
 
-use super::super::support::{FpResult, Status};
-use super::super::{Float, Int, IntTy, MinInt};
+use crate::support::{Float, FpResult, Int, IntTy, MinInt, Status};
 
 #[inline]
 pub fn floor<F: Float>(x: F) -> F {

--- a/libm/src/math/generic/fmax.rs
+++ b/libm/src/math/generic/fmax.rs
@@ -14,7 +14,7 @@
 //!
 //! [link]: https://grouper.ieee.org/groups/msc/ANSI_IEEE-Std-754-2019/background/minNum_maxNum_Removal_Demotion_v3.pdf
 
-use super::super::Float;
+use crate::support::Float;
 
 #[inline]
 pub fn fmax<F: Float>(x: F, y: F) -> F {

--- a/libm/src/math/generic/fmaximum.rs
+++ b/libm/src/math/generic/fmaximum.rs
@@ -9,7 +9,7 @@
 //!
 //! Excluded from our implementation is sNaN handling.
 
-use super::super::Float;
+use crate::support::Float;
 
 #[inline]
 pub fn fmaximum<F: Float>(x: F, y: F) -> F {

--- a/libm/src/math/generic/fmaximum_num.rs
+++ b/libm/src/math/generic/fmaximum_num.rs
@@ -11,7 +11,7 @@
 //!
 //! Excluded from our implementation is sNaN handling.
 
-use super::super::Float;
+use crate::support::Float;
 
 #[inline]
 pub fn fmaximum_num<F: Float>(x: F, y: F) -> F {

--- a/libm/src/math/generic/fmin.rs
+++ b/libm/src/math/generic/fmin.rs
@@ -14,7 +14,7 @@
 //!
 //! [link]: https://grouper.ieee.org/groups/msc/ANSI_IEEE-Std-754-2019/background/minNum_maxNum_Removal_Demotion_v3.pdf
 
-use super::super::Float;
+use crate::support::Float;
 
 #[inline]
 pub fn fmin<F: Float>(x: F, y: F) -> F {

--- a/libm/src/math/generic/fminimum.rs
+++ b/libm/src/math/generic/fminimum.rs
@@ -9,7 +9,7 @@
 //!
 //! Excluded from our implementation is sNaN handling.
 
-use super::super::Float;
+use crate::support::Float;
 
 #[inline]
 pub fn fminimum<F: Float>(x: F, y: F) -> F {

--- a/libm/src/math/generic/fminimum_num.rs
+++ b/libm/src/math/generic/fminimum_num.rs
@@ -11,7 +11,7 @@
 //!
 //! Excluded from our implementation is sNaN handling.
 
-use super::super::Float;
+use crate::support::Float;
 
 #[inline]
 pub fn fminimum_num<F: Float>(x: F, y: F) -> F {

--- a/libm/src/math/generic/fmod.rs
+++ b/libm/src/math/generic/fmod.rs
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: MIT OR Apache-2.0 */
-use super::super::{CastFrom, Float, Int, MinInt};
+use crate::support::{CastFrom, Float, Int, MinInt};
 
 #[inline]
 pub fn fmod<F: Float>(x: F, y: F) -> F {

--- a/libm/src/math/generic/rint.rs
+++ b/libm/src/math/generic/rint.rs
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 /* origin: musl src/math/rint.c */
 
-use super::super::Float;
-use super::super::support::{FpResult, Round};
+use crate::support::{Float, FpResult, Round};
 
 /// IEEE 754-2019 `roundToIntegralExact`, which respects rounding mode and raises inexact if
 /// applicable.

--- a/libm/src/math/generic/round.rs
+++ b/libm/src/math/generic/round.rs
@@ -1,5 +1,5 @@
-use super::super::{Float, MinInt};
 use super::{copysign, trunc};
+use crate::support::{Float, MinInt};
 
 #[inline]
 pub fn round<F: Float>(x: F) -> F {

--- a/libm/src/math/generic/scalbn.rs
+++ b/libm/src/math/generic/scalbn.rs
@@ -1,4 +1,4 @@
-use super::super::{CastFrom, CastInto, Float, IntTy, MinInt};
+use crate::support::{CastFrom, CastInto, Float, IntTy, MinInt};
 
 /// Scale the exponent.
 ///

--- a/libm/src/math/generic/sqrt.rs
+++ b/libm/src/math/generic/sqrt.rs
@@ -41,8 +41,9 @@
 //! Goldschmidt has the advantage over Newton-Raphson that `sqrt(x)` and `1/sqrt(x)` are
 //! computed at the same time, i.e. there is no need to calculate `1/sqrt(x)` and invert it.
 
-use super::super::support::{FpResult, IntTy, Round, Status, cold_path};
-use super::super::{CastFrom, CastInto, DInt, Float, HInt, Int, MinInt};
+use crate::support::{
+    CastFrom, CastInto, DInt, Float, FpResult, HInt, Int, IntTy, MinInt, Round, Status, cold_path,
+};
 
 #[inline]
 pub fn sqrt<F>(x: F) -> F

--- a/libm/src/math/generic/trunc.rs
+++ b/libm/src/math/generic/trunc.rs
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: MIT
  * origin: musl src/math/trunc.c */
 
-use super::super::support::{FpResult, Status};
-use super::super::{Float, Int, IntTy, MinInt};
+use crate::support::{Float, FpResult, Int, IntTy, MinInt, Status};
 
 #[inline]
 pub fn trunc<F: Float>(x: F) -> F {


### PR DESCRIPTION
Since `crate::support` now works in both `compiler-builtins` and `libm`, we can get rid of some of these unusual paths.

ci: skip-extensive