### PR TITLE
Require `target_has_atomic = "ptr"` for runtime feature detection

### DIFF
--- a/libm/src/math/arch/x86/detect.rs
+++ b/libm/src/math/arch/x86/detect.rs
@@ -1,13 +1,16 @@
+// Using runtime feature detection requires atomics. Currently there are no x86 targets
+// that support sse but not `AtomicPtr`.
+
 #[cfg(target_arch = "x86")]
 use core::arch::x86::{__cpuid, __cpuid_count, _xgetbv, CpuidResult};
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::{__cpuid, __cpuid_count, _xgetbv, CpuidResult};
 
-use crate::support::{Flags, get_or_init_flags_cache};
+use crate::support::feature_detect::{Flags, get_or_init_flags_cache, unique_masks};
 
 /// CPU features that get cached (doesn't correlate to anything on the CPU).
 pub mod cpu_flags {
-    use crate::support::unique_masks;
+    use super::unique_masks;
 
     unique_masks! {
         u32,

--- a/libm/src/math/arch/x86/fma.rs
+++ b/libm/src/math/arch/x86/fma.rs
@@ -4,7 +4,8 @@ use core::arch::asm;
 
 use super::super::super::generic;
 use super::detect::{cpu_flags, get_cpu_features};
-use crate::support::{Round, select_once};
+use crate::support::Round;
+use crate::support::feature_detect::select_once;
 
 pub fn fma(x: f64, y: f64, z: f64) -> f64 {
     select_once! {

--- a/libm/src/math/support/feature_detect.rs
+++ b/libm/src/math/support/feature_detect.rs
@@ -1,5 +1,9 @@
 //! Helpers for runtime target feature detection that are shared across architectures.
 
+// `AtomicU32` is preferred for a consistent size across targets.
+#[cfg(all(target_has_atomic = "ptr", not(target_has_atomic = "32")))]
+compile_error!("currently all targets that support `AtomicPtr` also support `AtomicU32`");
+
 use core::sync::atomic::{AtomicU32, Ordering};
 
 /// Given a list of identifiers, assign each one a unique sequential single-bit mask.
@@ -72,6 +76,7 @@ macro_rules! select_once {
     }}
 }
 
+#[allow(unused_imports)]
 pub(crate) use {select_once, unique_masks};
 
 use crate::support::cold_path;

--- a/libm/src/math/support/mod.rs
+++ b/libm/src/math/support/mod.rs
@@ -2,7 +2,9 @@
 pub mod macros;
 mod big;
 mod env;
-mod feature_detect;
+// Runtime feature detection requires atomics.
+#[cfg(target_has_atomic = "ptr")]
+pub(crate) mod feature_detect;
 mod float_traits;
 pub mod hex_float;
 mod int_traits;
@@ -10,8 +12,6 @@ mod int_traits;
 #[allow(unused_imports)]
 pub use big::{i256, u256};
 pub use env::{FpResult, Round, Status};
-#[allow(unused_imports)]
-pub(crate) use feature_detect::{Flags, get_or_init_flags_cache, select_once, unique_masks};
 #[allow(unused_imports)]
 pub use float_traits::{DFloat, Float, HFloat, IntTy};
 pub(crate) use float_traits::{f32_from_bits, f64_from_bits};


### PR DESCRIPTION
The `feature_detect` module is currently being built on all targets, but the use of `AtomicU32` causes a problem if atomics are not available (such as with `bpfel-unknown-none`). Gate this module behind `target_has_atomic = "ptr"`.

The below now completes successfully:

    cargo build -p compiler_builtins --target=bpfel-unknown-none -Z build-std=core

Fixes: https://github.com/rust-lang/compiler-builtins/issues/908