### PR TITLE
Enable `__powitf2` on MSVC

### DIFF
--- a/builtins-test/tests/float_pow.rs
+++ b/builtins-test/tests/float_pow.rs
@@ -58,8 +58,6 @@ pow! {
 }
 
 #[cfg(f128_enabled)]
-// FIXME(f16_f128): MSVC cannot build these until `__divtf3` is available in nightly.
-#[cfg(not(target_env = "msvc"))]
 #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
 pow! {
     f128, 1e-36, __powitf2, not(feature = "no-sys-f128");

--- a/compiler-builtins/src/float/pow.rs
+++ b/compiler-builtins/src/float/pow.rs
@@ -32,8 +32,6 @@ intrinsics! {
 
     #[ppc_alias = __powikf2]
     #[cfg(f128_enabled)]
-    // FIXME(f16_f128): MSVC cannot build these until `__divtf3` is available in nightly.
-    #[cfg(not(target_env = "msvc"))]
     pub extern "C" fn __powitf2(a: f128, b: i32) -> f128 {
         pow(a, b)
     }


### PR DESCRIPTION
`__divtf3` is now available on nightly, so CI should pass.