### PR TITLE
WIP: Don't assume all NaNs being type-converted are quiet NaNs

### DIFF
--- a/compiler-builtins/src/float/trunc.rs
+++ b/compiler-builtins/src/float/trunc.rs
@@ -24,7 +24,7 @@ where
     let round_mask = (src_one << (F::SIG_BITS - R::SIG_BITS)) - src_one;
     let halfway = src_one << (F::SIG_BITS - R::SIG_BITS - 1);
     let src_qnan = src_one << (F::SIG_BITS - 1);
-    let src_nan_code = src_qnan - src_one;
+    let src_nan_code = (src_qnan << 1) - src_one;
 
     let dst_zero = R::Int::ZERO;
     let dst_one = R::Int::ONE;
@@ -38,7 +38,7 @@ where
     let overflow: F::Int = overflow_exponent << F::SIG_BITS;
 
     let dst_qnan = R::Int::ONE << (R::SIG_BITS - 1);
-    let dst_nan_code = dst_qnan - dst_one;
+    let dst_nan_code = (dst_qnan << 1) - dst_one;
 
     let sig_bits_delta = F::SIG_BITS - R::SIG_BITS;
     // Break a into a sign and representation of the absolute value.
@@ -71,7 +71,6 @@ where
         // Cast before shifting to prevent overflow.
         let dst_inf_exp: R::Int = dst_inf_exp.cast();
         abs_result = dst_inf_exp << R::SIG_BITS;
-        abs_result |= dst_qnan;
         abs_result |= dst_nan_code & ((a_abs & src_nan_code) >> (F::SIG_BITS - R::SIG_BITS)).cast();
     } else if a_abs >= overflow {
         // a overflows to infinity.


### PR DESCRIPTION
When truncating floating point types, we detect whether the original value was any kind of NaN, but reconstruct the destination value with the qNaN bit always set - meaning any signalling NaNs get lost. This patch explicitly includes the source qNaN bit as part of the data which is copied over.