### PR TITLE
Add minimal triagebot config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,21 @@
+## See <https://forge.rust-lang.org/triagebot/index.html> for documentation
+## of these features.
+
+# Warns when a PR contains merge commits
+# Documentation at: https://forge.rust-lang.org/triagebot/no-merge.html
+[no-merges]
+exclude_titles = ["Update from"]
+
+# Canonicalize issue numbers to avoid closing the wrong issue
+# when commits are included in subtrees, as well as warning links in commits.
+# Documentation at: https://forge.rust-lang.org/triagebot/issue-links.html
+[issue-links]
+check-commits = false
+
+# Prevents mentions in commits to avoid users being spammed
+# Documentation at: https://forge.rust-lang.org/triagebot/no-mentions.html
+[no-mentions]
+
+# Enable issue transfers within the org
+# Documentation at: https://forge.rust-lang.org/triagebot/transfer.html
+[transfer]


### PR DESCRIPTION
This PR adds a minimal `triagebot.toml` config to make contributions to this repository respect upstream rust-lang/rust conventions and avoid issues when syncing this subtree.

If you're interested in more triagebot feature, I highly recommand looking at [miri's `triagebot.toml` config](https://github.com/rust-lang/miri/blob/master/triagebot.toml).

Accompanying team PR: https://github.com/rust-lang/team/pull/1876

cf. https://github.com/rust-lang/rust/pull/142489#issuecomment-2972474814
cc @tgross35 