### PR TITLE
Upgrade dependencies to the latest version

### DIFF
--- a/builtins-test/Cargo.toml
+++ b/builtins-test/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT AND Apache-2.0 WITH LLVM-exception AND (MIT OR Apache-2.0)"
 # `xoshiro128**` is used for its quality, size, and speed at generating `u32` shift amounts.
 rand_xoshiro = "0.7"
 # To compare float builtins against
-rustc_apfloat = "0.2.2"
+rustc_apfloat = "0.2.3"
 # Really a dev dependency, but dev dependencies can't be optional
 iai-callgrind = { version = "0.14.1", optional = true }
 

--- a/crates/libm-macros/Cargo.toml
+++ b/crates/libm-macros/Cargo.toml
@@ -12,7 +12,7 @@ proc-macro = true
 heck = "0.5.0"
 proc-macro2 = "1.0.95"
 quote = "1.0.40"
-syn = { version = "2.0.101", features = ["full", "extra-traits", "visit-mut"] }
+syn = { version = "2.0.104", features = ["full", "extra-traits", "visit-mut"] }
 
 [lints.rust]
 # Values used during testing

--- a/crates/musl-math-sys/Cargo.toml
+++ b/crates/musl-math-sys/Cargo.toml
@@ -11,4 +11,4 @@ license = "MIT OR Apache-2.0"
 libm = { path = "../../libm" }
 
 [build-dependencies]
-cc = "1.2.25"
+cc = "1.2.29"

--- a/libm-test/Cargo.toml
+++ b/libm-test/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = "1.0.98"
 # This is not directly used but is required so we can enable `gmp-mpfr-sys/force-cross`.
 gmp-mpfr-sys = { version = "1.6.5", optional = true, default-features = false }
 iai-callgrind = { version = "0.14.1", optional = true }
-indicatif = { version = "0.17.11", default-features = false }
+indicatif = { version = "0.18.0", default-features = false }
 libm = { path = "../libm", features = ["unstable-public-internals"] }
 libm-macros = { path = "../crates/libm-macros" }
 musl-math-sys = { path = "../crates/musl-math-sys", optional = true }


### PR DESCRIPTION
This picks up a fix in `rustc_apfloat` [1] that resolves a problem with `fma`.

[1]: https://github.com/rust-lang/rustc_apfloat/releases/tag/rustc_apfloat-v0.2.3%2Bllvm-462a31f5a5ab