### PR TITLE
Upgrade `iai-callgrind` to 0.15

### DIFF
--- a/builtins-test/Cargo.toml
+++ b/builtins-test/Cargo.toml
@@ -14,7 +14,7 @@ rand_xoshiro = "0.7"
 # To compare float builtins against
 rustc_apfloat = "0.2.3"
 # Really a dev dependency, but dev dependencies can't be optional
-iai-callgrind = { version = "0.14.1", optional = true }
+iai-callgrind = { version = "0.15.2", optional = true }
 
 [dependencies.compiler_builtins]
 path = "../builtins-shim"

--- a/ci/bench-icount.sh
+++ b/ci/bench-icount.sh
@@ -28,7 +28,7 @@ function run_icount_benchmarks() {
 
     iai_args=(
         "--home" "$(pwd)/$iai_home"
-        "--regression=ir=5.0"
+        "--callgrind-limits=ir=5.0"
         "--save-summary"
     )
 

--- a/libm-test/Cargo.toml
+++ b/libm-test/Cargo.toml
@@ -31,7 +31,7 @@ short-benchmarks = []
 anyhow = "1.0.98"
 # This is not directly used but is required so we can enable `gmp-mpfr-sys/force-cross`.
 gmp-mpfr-sys = { version = "1.6.5", optional = true, default-features = false }
-iai-callgrind = { version = "0.14.1", optional = true }
+iai-callgrind = { version = "0.15.2", optional = true }
 indicatif = { version = "0.18.0", default-features = false }
 libm = { path = "../libm", features = ["unstable-public-internals"] }
 libm-macros = { path = "../crates/libm-macros" }


### PR DESCRIPTION
Pick up the latest version of `iai-callgrind`, which includes some output
improvements.

Changelog: https://github.com/iai-callgrind/iai-callgrind/releases