### PR TITLE
Add CI workflow for automatically performing subtree sync pulls

### DIFF
--- a/.github/workflows/rustc-pull.yml
+++ b/.github/workflows/rustc-pull.yml
@@ -1,0 +1,23 @@
+# Perform a subtree sync (pull) using the josh-sync tool once every few days (or on demand).
+name: rustc-pull
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run at 04:00 UTC every Monday and Thursday
+    - cron: '0 4 * * 1,4'
+
+jobs:
+  pull:
+    if: github.repository == 'rust-lang/compiler-builtins'
+    uses: rust-lang/josh-sync/.github/workflows/rustc-pull.yml@main
+    with:
+      # https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/compiler-builtins.20subtree.20sync.20automation/with/528482375
+      zulip-stream-id: 219381
+      zulip-topic: 'compiler-builtins subtree sync automation'
+      zulip-bot-email:  "compiler-builtins-ci-bot@rust-lang.zulipchat.com"
+      pr-base-branch: master
+      branch-name: rustc-pull
+    secrets:
+      zulip-api-token: ${{ secrets.ZULIP_API_TOKEN }}
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This CI workflow will run the https://github.com/rust-lang/josh-sync tool on Mondays and Thursdays. It will try to do a pull (sync stdarch changes from rust-lang/rust into this repository). When it runs, three things can happen:
- There are no rustc changes to be pulled, the bot does nothing.
- There are some new changes to be pulled. In that case, the bot will either open or update an existing PR titled "Rustc pull update" on this repository with the changes. After the PR is merged, we should ideally do the opposite sync (push) manually.
- The pull fails (usually because of a merge conflict), or the bot determines that a pull PR has been opened for more than a week without being merged. In that case, it will post a ping to https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/compiler-builtins.20subtree.20sync.20automation/with/528482375.
