### PR TITLE
Update `no-merges` PR title

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -4,7 +4,7 @@
 # Warns when a PR contains merge commits
 # Documentation at: https://forge.rust-lang.org/triagebot/no-merge.html
 [no-merges]
-exclude_titles = ["Update from"]
+exclude_titles = ["Rustc pull update"]
 
 # Canonicalize issue numbers to avoid closing the wrong issue
 # when commits are included in subtrees, as well as warning links in commits.


### PR DESCRIPTION
To match the new CI created PRs: https://github.com/rust-lang/compiler-builtins/pull/974.