### PR TITLE
Allow a new lint failure in nightly

### DIFF
--- a/libm/src/math/support/float_traits.rs
+++ b/libm/src/math/support/float_traits.rs
@@ -363,6 +363,7 @@ pub const fn f32_from_bits(bits: u32) -> f32 {
 }
 
 /// `f32::to_bits`
+#[allow(dead_code)] // workaround for false positive RUST-144060
 #[allow(unnecessary_transmutes)] // lint appears in newer versions of Rust
 pub const fn f32_to_bits(x: f32) -> u32 {
     // SAFETY: POD cast with no preconditions
@@ -377,6 +378,7 @@ pub const fn f64_from_bits(bits: u64) -> f64 {
 }
 
 /// `f64::to_bits`
+#[allow(dead_code)] // workaround for false positive RUST-144060
 #[allow(unnecessary_transmutes)] // lint appears in newer versions of Rust
 pub const fn f64_to_bits(x: f64) -> u64 {
     // SAFETY: POD cast with no preconditions


### PR DESCRIPTION
```text
warning: function `f32_to_bits` is never used
   --> libm/src/math/support/float_traits.rs:367:14
    |
367 | pub const fn f32_to_bits(x: f32) -> u32 {
    |              ^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: function `f64_to_bits` is never used
   --> libm/src/math/support/float_traits.rs:381:14
    |
381 | pub const fn f64_to_bits(x: f64) -> u64 {
    |              ^^^^^^^^^^^

warning: `libm` (lib) generated 2 warnings
```

This is a false positive, see RUST-144060.