### PR TITLE
mem: Use `core::ffi::c_int`

### DIFF
--- a/compiler-builtins/src/mem/mod.rs
+++ b/compiler-builtins/src/mem/mod.rs
@@ -3,13 +3,6 @@
 // FIXME(e2024): this eventually needs to be removed.
 #![allow(unsafe_op_in_unsafe_fn)]
 
-#[allow(warnings)]
-#[cfg(target_pointer_width = "16")]
-type c_int = i16;
-#[allow(warnings)]
-#[cfg(not(target_pointer_width = "16"))]
-type c_int = i32;
-
 // memcpy/memmove/memset have optimized implementations on some architectures
 #[cfg_attr(
     all(not(feature = "no-asm"), target_arch = "x86_64"),
@@ -38,7 +31,7 @@ intrinsics! {
     }
 
     #[mem_builtin]
-    pub unsafe extern "C" fn memset(s: *mut u8, c: crate::mem::c_int, n: usize) -> *mut u8 {
+    pub unsafe extern "C" fn memset(s: *mut u8, c: core::ffi::c_int, n: usize) -> *mut u8 {
         impls::set_bytes(s, c as u8, n);
         s
     }


### PR DESCRIPTION
This alias was added in 9897bfb8a ("Fix memset arguments for MSP430 target"), which predates `core::ffi`. Now that it exists we can just use `core::ffi::c_int`.