### PR TITLE
ci: Add native PowerPC64LE and s390x jobs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -119,6 +119,13 @@ jobs:
     - name: Print runner information
       run: uname -a
 
+    # ppc/s390x runners don't have HOME set
+    - name: Set $HOME
+      if: matrix.os == 'ubuntu-24.04-ppc64le' || matrix.os == 'ubuntu-24.04-s390x'
+      run: |
+        set -x
+        echo "HOME=$(realpath ~)" >> "$GITHUB_ENV"
+
     # Native runners don't have rustup by default
     - name: Install rustup
       if: matrix.os == 'ubuntu-24.04-ppc64le' || matrix.os == 'ubuntu-24.04-s390x'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -109,6 +109,8 @@ jobs:
       TEST_VERBATIM: ${{ matrix.test_verbatim }}
       MAY_SKIP_LIBM_CI: ${{ needs.calculate_vars.outputs.may_skip_libm_ci }}
     steps:
+    - name: Print $HOME
+      run: echo "${HOME:-not found}"
     - name: Print runner information
       run: uname -a
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -142,6 +142,7 @@ jobs:
         rustup default "$channel"
         rustup target add "${{ matrix.target }}"
     - uses: taiki-e/install-action@nextest
+      if: "!(matrix.os == 'ubuntu-24.04-ppc64le' || matrix.os == 'ubuntu-24.04-s390x')"
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ matrix.target }}
@@ -335,8 +336,8 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
-    - name: Install nightly `rustfmt`
-      run: rustup set profile minimal && rustup default nightly && rustup component add rustfmt
+    - name: Install stable `rustfmt`
+      run: rustup set profile minimal && rustup default stable && rustup component add rustfmt
     - run: cargo fmt -- --check
 
   extensive:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -336,8 +336,8 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
-    - name: Install stable `rustfmt`
-      run: rustup set profile minimal && rustup default stable && rustup component add rustfmt
+    - name: Install nightly `rustfmt`
+      run: rustup set profile minimal && rustup default nightly && rustup component add rustfmt
     - run: cargo fmt -- --check
 
   extensive:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -111,6 +111,12 @@ jobs:
     steps:
     - name: Print runner information
       run: uname -a
+
+    # Native runners don't have rustup by default
+    - name: Install rustup
+      if: matrix.os == 'ubuntu-24.04-ppc64le' || matrix.os == 'ubuntu-24.04-s390x'
+      run: sudo apt-get install -y rustup
+
     - uses: actions/checkout@v4
     - name: Install Rust (rustup)
       shell: bash

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -119,10 +119,10 @@ jobs:
     - name: Print runner information
       run: uname -a
 
-    # Native runners don't have rustup by default
+    # Native ppc and s390x runners don't have rustup by default
     - name: Install rustup
       if: matrix.os == 'ubuntu-24.04-ppc64le' || matrix.os == 'ubuntu-24.04-s390x'
-      run: sudo apt-get install -y rustup
+      run: sudo apt-get update && sudo apt-get install -y rustup
 
     - uses: actions/checkout@v4
     - name: Install Rust (rustup)
@@ -135,7 +135,7 @@ jobs:
         rustup default "$channel"
         rustup target add "${{ matrix.target }}"
 
-    # Our scripts use nextest if possible. This is skipped on  the native ppc
+    # Our scripts use nextest if possible. This is skipped on the native ppc
     # and s390x runners since install-action doesn't support them.
     - uses: taiki-e/install-action@nextest
       if: "!(matrix.os == 'ubuntu-24.04-ppc64le' || matrix.os == 'ubuntu-24.04-s390x')"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -119,12 +119,12 @@ jobs:
     - name: Print runner information
       run: uname -a
 
-    # ppc/s390x runners don't have HOME set
-    - name: Set $HOME
-      if: matrix.os == 'ubuntu-24.04-ppc64le' || matrix.os == 'ubuntu-24.04-s390x'
-      run: |
-        set -x
-        echo "HOME=$(realpath ~)" >> "$GITHUB_ENV"
+    # # ppc/s390x runners don't have HOME set
+    # - name: Set $HOME
+    #   if: matrix.os == 'ubuntu-24.04-ppc64le' || matrix.os == 'ubuntu-24.04-s390x'
+    #   run: |
+    #     set -x
+    #     echo "HOME=$(realpath ~)" >> "$GITHUB_ENV"
 
     # Native runners don't have rustup by default
     - name: Install rustup

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -110,7 +110,12 @@ jobs:
       MAY_SKIP_LIBM_CI: ${{ needs.calculate_vars.outputs.may_skip_libm_ci }}
     steps:
     - name: Print $HOME
-      run: echo "${HOME:-not found}"
+      shell: bash
+      run: |
+        set -x
+        echo "${HOME:-not found}"
+        pwd
+        printenv
     - name: Print runner information
       run: uname -a
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -119,13 +119,6 @@ jobs:
     - name: Print runner information
       run: uname -a
 
-    # # ppc/s390x runners don't have HOME set
-    # - name: Set $HOME
-    #   if: matrix.os == 'ubuntu-24.04-ppc64le' || matrix.os == 'ubuntu-24.04-s390x'
-    #   run: |
-    #     set -x
-    #     echo "HOME=$(realpath ~)" >> "$GITHUB_ENV"
-
     # Native runners don't have rustup by default
     - name: Install rustup
       if: matrix.os == 'ubuntu-24.04-ppc64le' || matrix.os == 'ubuntu-24.04-s390x'
@@ -141,8 +134,12 @@ jobs:
         rustup update "$channel" --no-self-update
         rustup default "$channel"
         rustup target add "${{ matrix.target }}"
+
+    # Our scripts use nextest if possible. This is skipped on  the native ppc
+    # and s390x runners since install-action doesn't support them.
     - uses: taiki-e/install-action@nextest
       if: "!(matrix.os == 'ubuntu-24.04-ppc64le' || matrix.os == 'ubuntu-24.04-s390x')"
+
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ matrix.target }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -70,8 +70,12 @@ jobs:
           os: ubuntu-24.04
         - target: powerpc64le-unknown-linux-gnu
           os: ubuntu-24.04
+        - target: powerpc64le-unknown-linux-gnu
+          os: ubuntu-24.04-ppc64le
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-24.04
+        - target: s390x-unknown-linux-gnu
+          os: ubuntu-24.04-s390x
         - target: thumbv6m-none-eabi
           os: ubuntu-24.04
         - target: thumbv7em-none-eabi


### PR DESCRIPTION
We now have access to native runners, so make use of them for these architectures. The existing ppc64le Docker job is kept for now.