### PR TITLE
ci: Use a mirror for musl

### DIFF
--- a/ci/update-musl.sh
+++ b/ci/update-musl.sh
@@ -3,7 +3,7 @@
 
 set -eux
 
-url=git://git.musl-libc.org/musl
+url=https://github.com/kraj/musl.git
 ref=c47ad25ea3b484e10326f933e927c0bc8cded3da
 dst=crates/musl-math-sys/musl
 


### PR DESCRIPTION
We pretty often get at least one job failed because of failure to pull the musl git repo. Switch this to the unofficial mirror [1] which should be more reliable.

Link: https://github.com/kraj/musl [1]