### PR TITLE
Update for new warn-by-default clippy lints

### DIFF
--- a/libm/src/math/mod.rs
+++ b/libm/src/math/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::approx_constant)] // many false positives
+
 macro_rules! force_eval {
     ($e:expr) => {
         unsafe { ::core::ptr::read_volatile(&$e) }

--- a/libm/src/math/support/mod.rs
+++ b/libm/src/math/support/mod.rs
@@ -11,7 +11,8 @@ mod int_traits;
 
 #[allow(unused_imports)]
 pub use big::{i256, u256};
-#[allow(unused_imports)]
+// Clippy seems to have a false positive
+#[allow(unused_imports, clippy::single_component_path_imports)]
 pub(crate) use cfg_if;
 pub use env::{FpResult, Round, Status};
 #[allow(unused_imports)]


### PR DESCRIPTION
Remove an import that is actually unused, and silence the approximate constant lint because it isn't always correct here.