### PR TITLE
configure: Use `CARGO_CFG_*_{F16,F128}` rather than invoking rustc

### DIFF
--- a/compiler-builtins/configure.rs
+++ b/compiler-builtins/configure.rs
@@ -1,6 +1,5 @@
 // Configuration that is shared between `compiler_builtins` and `builtins_test`.
 
-use std::process::{Command, Stdio};
 use std::{env, str};
 
 #[derive(Debug)]
@@ -35,26 +34,6 @@ impl Target {
             .map(|s| s.to_lowercase().replace("_", "-"))
             .collect();
 
-        // Query rustc for options that Cargo does not provide env for. The bootstrap hack is used
-        // to get consistent output regardless of channel (`f16`/`f128` config options are hidden
-        // on stable otherwise).
-        let mut cmd = Command::new(env::var("RUSTC").unwrap());
-        cmd.args(["--print=cfg", "--target", &triple])
-            .env("RUSTC_BOOTSTRAP", "1")
-            .stderr(Stdio::inherit());
-        let out = cmd
-            .output()
-            .unwrap_or_else(|e| panic!("failed to run `{cmd:?}`: {e}"));
-        let rustc_cfg = str::from_utf8(&out.stdout).unwrap();
-
-        // If we couldn't query `rustc` (e.g. a custom JSON target was used), make the safe
-        // choice and leave `f16` and `f128` disabled.
-        let rustc_output_ok = out.status.success();
-        let reliable_f128 =
-            rustc_output_ok && rustc_cfg.lines().any(|l| l == "target_has_reliable_f128");
-        let reliable_f16 =
-            rustc_output_ok && rustc_cfg.lines().any(|l| l == "target_has_reliable_f16");
-
         Self {
             triple,
             triple_split,
@@ -74,8 +53,10 @@ impl Target {
                 .split(",")
                 .map(ToOwned::to_owned)
                 .collect(),
-            reliable_f128,
-            reliable_f16,
+            // Note that these are unstable options, so only show up with the nightly compiler or
+            // with `RUSTC_BOOTSTRAP=1` (which is required to use the types anyway).
+            reliable_f128: env::var_os("CARGO_CFG_TARGET_HAS_RELIABLE_F128").is_some(),
+            reliable_f16: env::var_os("CARGO_CFG_TARGET_HAS_RELIABLE_F16").is_some(),
         }
     }
 


### PR DESCRIPTION
Currently we run `rustc` from the `RUSTC` environment variable to figure out whether or not to enable `f16` and `f128`, based on the `target_has_reliable_{f16,f128}` config. However, this does not know about the codegen backend used, and the backend isn't trivial to check in a build script (usually the backend gets set via `RUSTFLAGS`).

It turns out we don't actually need to run `rustc` here: Cargo unconditionally emits all config from the relevant compiler as `CARGO_CFG_*` variables, regardless of whether or not they are known options. Switch to checking these to set config rather than invoking `rustc`.

As an added advantage, we don't need any special handling for target.json files.

Fixes: ed17b95715dd ("Use the compiler to determine whether or not to enable `f16` and `f128`")