### PR TITLE
symcheck: Ignore symbols in `.debug_gdb_scripts`

### DIFF
--- a/crates/symbol-check/src/main.rs
+++ b/crates/symbol-check/src/main.rs
@@ -215,6 +215,11 @@ fn verify_no_duplicates(archive: &Archive) {
             return;
         }
 
+        // GDB pretty printing symbols may show up more than once but are weak.
+        if sym.section == ".debug_gdb_scripts" && sym.is_weak {
+            return;
+        }
+
         // Windows has symbols for literal numeric constants, string literals, and MinGW pseudo-
         // relocations. These are allowed to have repeated definitions.
         let win_allowed_dup_pfx = ["__real@", "__xmm@", "??_C@_", ".refptr"];


### PR DESCRIPTION
Since [1], our object files may now contain a GDB script section. These
symbols wind up with multiple instances in the archive but are weak, so
we can safely ignore them in our duplicates check.

This resolves the current CI failures.

[1]: https://github.com/rust-lang/rust/pull/143679