### PR TITLE
Remove instances of `allow(improper_ctypes)`

### DIFF
--- a/builtins-test/benches/float_conv.rs
+++ b/builtins-test/benches/float_conv.rs
@@ -1,4 +1,3 @@
-#![allow(improper_ctypes)]
 #![cfg_attr(f128_enabled, feature(f128))]
 
 use builtins_test::float_bench;

--- a/compiler-builtins/src/lib.rs
+++ b/compiler-builtins/src/lib.rs
@@ -18,10 +18,6 @@
 #![no_std]
 #![allow(unused_features)]
 #![allow(internal_features)]
-// We use `u128` in a whole bunch of places which we currently agree with the
-// compiler on ABIs and such, so we should be "good enough" for now and changes
-// to the `u128` ABI will be reflected here.
-#![allow(improper_ctypes, improper_ctypes_definitions)]
 // `mem::swap` cannot be used because it may generate references to memcpy in unoptimized code.
 #![allow(clippy::manual_swap)]
 // Support compiling on both stage0 and stage1 which may differ in supported stable features.


### PR DESCRIPTION
i128/u128 haven't flagged `improper_ctypes` for a while, and this just
made it to stable [1]. Remove the `allow`s as they are no longer needed.

[1]: https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#i128-and-u128-in-extern-c-functions