### PR TITLE
Compare against `CARGO_CFG_TARGET_FAMILY` in a multi-valued fashion

### DIFF
--- a/crates/musl-math-sys/build.rs
+++ b/crates/musl-math-sys/build.rs
@@ -46,7 +46,7 @@ fn main() {
     let cfg = Config::from_env();
 
     if cfg.target_env == "msvc"
-        || cfg.target_family == "wasm"
+        || cfg.target_families.iter().any(|f| f == "wasm")
         || cfg.target_features.iter().any(|f| f == "thumb-mode")
     {
         println!(
@@ -69,7 +69,7 @@ struct Config {
     musl_arch: String,
     target_arch: String,
     target_env: String,
-    target_family: String,
+    target_families: Vec<String>,
     target_os: String,
     target_string: String,
     target_vendor: String,
@@ -79,6 +79,9 @@ struct Config {
 impl Config {
     fn from_env() -> Self {
         let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+        let target_families = env::var("CARGO_CFG_TARGET_FAMILY")
+            .map(|feats| feats.split(',').map(ToOwned::to_owned).collect())
+            .unwrap_or_default();
         let target_features = env::var("CARGO_CFG_TARGET_FEATURE")
             .map(|feats| feats.split(',').map(ToOwned::to_owned).collect())
             .unwrap_or_default();
@@ -104,7 +107,7 @@ impl Config {
             musl_arch,
             target_arch,
             target_env: env::var("CARGO_CFG_TARGET_ENV").unwrap(),
-            target_family: env::var("CARGO_CFG_TARGET_FAMILY").unwrap(),
+            target_families,
             target_os: env::var("CARGO_CFG_TARGET_OS").unwrap(),
             target_string: env::var("TARGET").unwrap(),
             target_vendor: env::var("CARGO_CFG_TARGET_VENDOR").unwrap(),

--- a/libm/configure.rs
+++ b/libm/configure.rs
@@ -13,7 +13,7 @@ pub struct Config {
     pub target_triple: String,
     pub target_arch: String,
     pub target_env: String,
-    pub target_family: Option<String>,
+    pub target_families: Vec<String>,
     pub target_os: String,
     pub target_string: String,
     pub target_vendor: String,
@@ -25,6 +25,9 @@ pub struct Config {
 impl Config {
     pub fn from_env() -> Self {
         let target_triple = env::var("TARGET").unwrap();
+        let target_families = env::var("CARGO_CFG_TARGET_FAMILY")
+            .map(|feats| feats.split(',').map(ToOwned::to_owned).collect())
+            .unwrap_or_default();
         let target_features = env::var("CARGO_CFG_TARGET_FEATURE")
             .map(|feats| feats.split(',').map(ToOwned::to_owned).collect())
             .unwrap_or_default();
@@ -41,7 +44,7 @@ impl Config {
             cargo_features,
             target_arch: env::var("CARGO_CFG_TARGET_ARCH").unwrap(),
             target_env: env::var("CARGO_CFG_TARGET_ENV").unwrap(),
-            target_family: env::var("CARGO_CFG_TARGET_FAMILY").ok(),
+            target_families,
             target_os: env::var("CARGO_CFG_TARGET_OS").unwrap(),
             target_string: env::var("TARGET").unwrap(),
             target_vendor: env::var("CARGO_CFG_TARGET_VENDOR").unwrap(),


### PR DESCRIPTION
`cfg(target_family = "...")` can be set multiple times, and thus `CARGO_CFG_TARGET_FAMILY` can also contain comma-separated values, similar to `CARGO_CFG_TARGET_FEATURE`.

This allows `cargo build --target wasm32-unknown-emscripten -p musl-math-sys` to work, and will become more important if we were to add e.g. `cfg(target_family = "darwin")` in the future as discussed in https://github.com/rust-lang/rust/issues/100343.