### PR TITLE
ci: Increase the benchmark rustc version to 2025-12-01

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: full
-  BENCHMARK_RUSTC: nightly-2025-05-28 # Pin the toolchain for reproducable results
+  BENCHMARK_RUSTC: nightly-2025-12-01 # Pin the toolchain for reproducable results
 
 jobs:
   # Determine which tests should be run based on changed files.


### PR DESCRIPTION
Zerocopy (an indirect test dependency) has started requiring recently-stabilized features, so upgrade our benchmark toolchain to match.

ci: allow-regressions