### PR TITLE
ci: Enable benchmarks on Aarch64

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -239,6 +239,8 @@ jobs:
         include:
         - target: x86_64-unknown-linux-gnu
           os: ubuntu-24.04
+        - target: aarch64-unknown-linux-gnu
+          os: ubuntu-24.04-arm
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
This was originally attempted at [1], but the numbers seemed to indicate that tests weren't being run or counted completely. That issue appears to be resolved, so add benchmarks for Aarch64.

[1]:  https://github.com/rust-lang/compiler-builtins/pull/930