### PR TITLE
Update Cargo.toml `authors` fields

### DIFF
--- a/builtins-shim/Cargo.toml
+++ b/builtins-shim/Cargo.toml
@@ -11,7 +11,12 @@
 [package]
 name = "compiler_builtins"
 version = "0.1.160"
-authors = ["Jorge Aparicio <japaricious@gmail.com>"]
+authors = [
+    "Alex Crichton <alex@alexcrichton.com>",
+    "Amanieu d'Antras <amanieu@gmail.com>",
+    "Jorge Aparicio <japaricious@gmail.com>",
+    "Trevor Gross <tg@trevorgross.com>",
+]
 description = "Compiler intrinsics used by the Rust compiler."
 repository = "https://github.com/rust-lang/compiler-builtins"
 license = "MIT AND Apache-2.0 WITH LLVM-exception AND (MIT OR Apache-2.0)"

--- a/builtins-test/Cargo.toml
+++ b/builtins-test/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "builtins-test"
 version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2024"
 publish = false
 license = "MIT AND Apache-2.0 WITH LLVM-exception AND (MIT OR Apache-2.0)"

--- a/compiler-builtins/Cargo.toml
+++ b/compiler-builtins/Cargo.toml
@@ -7,7 +7,12 @@
 [package]
 name = "compiler_builtins"
 version = "0.1.160"
-authors = ["Jorge Aparicio <japaricious@gmail.com>"]
+authors = [
+    "Alex Crichton <alex@alexcrichton.com>",
+    "Amanieu d'Antras <amanieu@gmail.com>",
+    "Jorge Aparicio <japaricious@gmail.com>",
+    "Trevor Gross <tg@trevorgross.com>",
+]
 description = "Compiler intrinsics used by the Rust compiler."
 repository = "https://github.com/rust-lang/compiler-builtins"
 license = "MIT AND Apache-2.0 WITH LLVM-exception AND (MIT OR Apache-2.0)"

--- a/crates/panic-handler/Cargo.toml
+++ b/crates/panic-handler/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "panic-handler"
 version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2024"
 publish = false
 

--- a/libm/Cargo.toml
+++ b/libm/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "libm"
 version = "0.2.15"
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
+authors = [
+    "Alex Crichton <alex@alexcrichton.com>",
+    "Amanieu d'Antras <amanieu@gmail.com>",
+    "Jorge Aparicio <japaricious@gmail.com>",
+    "Trevor Gross <tg@trevorgross.com>",
+]
 description = "libm in pure Rust"
 categories = ["no-std"]
 keywords = ["libm", "math"]


### PR DESCRIPTION
Jorge hasn't been very involved with these crates for a while (thank you for getting these super important projects going!). Update the `authors` field to include, as far as I am aware, everyone who has effectively maintained `compiler-builtins` at some point in time.

This field is dropped from non-published crates.