### PR TITLE
ci: Update the default branch name in remaining workflow files

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,7 +5,7 @@ permissions:
   contents: write
 
 on:
-  push: { branches: [master] }
+  push: { branches: [main] }
 
 jobs:
   release-plz:

--- a/.github/workflows/rustc-pull.yml
+++ b/.github/workflows/rustc-pull.yml
@@ -17,7 +17,7 @@ jobs:
       zulip-stream-id: 219381
       zulip-topic: 'compiler-builtins subtree sync automation'
       zulip-bot-email: "compiler-builtins-ci-bot@rust-lang.zulipchat.com"
-      pr-base-branch: master
+      pr-base-branch: main
       branch-name: rustc-pull
     secrets:
       zulip-api-token: ${{ secrets.ZULIP_API_TOKEN }}


### PR DESCRIPTION
Missed as part of 936db7f5e890 ("ci: Update the default branch name").