### PR TITLE
ci: Switch the x86 Apple job to the `macos-15-intel` runner

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -89,7 +89,7 @@ jobs:
         - target: x86_64-unknown-linux-gnu
           os: ubuntu-24.04
         - target: x86_64-apple-darwin
-          os: macos-13
+          os: macos-15-intel
         - target: i686-pc-windows-msvc
           os: windows-2025
         - target: x86_64-pc-windows-msvc


### PR DESCRIPTION
`macos-13` is being phased out. Now that GitHub has x86 runners with MacOS 15, switch those.