### PR TITLE
fix expm1f overflow threshold

### DIFF
--- a/libm-test/src/precision.rs
+++ b/libm-test/src/precision.rs
@@ -218,27 +218,6 @@ impl MaybeOverride<(f16,)> for SpecialCase {}
 
 impl MaybeOverride<(f32,)> for SpecialCase {
     fn check_float<F: Float>(input: (f32,), actual: F, expected: F, ctx: &CheckCtx) -> CheckAction {
-        if ctx.base_name == BaseName::Expm1
-            && !input.0.is_infinite()
-            && input.0 > 80.0
-            && actual.is_infinite()
-            && !expected.is_infinite()
-        {
-            // we return infinity but the number is representable
-            if ctx.basis == CheckBasis::Musl {
-                return XFAIL_NOCHECK;
-            }
-            return XFAIL("expm1 representable numbers");
-        }
-
-        if ctx.base_name == BaseName::Sinh && input.0.abs() > 80.0 && actual.is_nan() {
-            // we return some NaN that should be real values or infinite
-            if ctx.basis == CheckBasis::Musl {
-                return XFAIL_NOCHECK;
-            }
-            return XFAIL("sinh unexpected NaN");
-        }
-
         if (ctx.base_name == BaseName::Lgamma || ctx.base_name == BaseName::LgammaR)
             && input.0 > 4e36
             && expected.is_infinite()

--- a/libm/src/math/expm1f.rs
+++ b/libm/src/math/expm1f.rs
@@ -13,7 +13,6 @@
  * ====================================================
  */
 
-const O_THRESHOLD: f32 = 8.8721679688e+01; /* 0x42b17180 */
 const LN2_HI: f32 = 6.9313812256e-01; /* 0x3f317180 */
 const LN2_LO: f32 = 9.0580006145e-06; /* 0x3717f7d1 */
 const INV_LN2: f32 = 1.4426950216e+00; /* 0x3fb8aa3b */
@@ -50,7 +49,8 @@ pub fn expm1f(mut x: f32) -> f32 {
         if sign {
             return -1.;
         }
-        if x > O_THRESHOLD {
+        if hx > 0x42b17217 {
+            /* x > log(FLT_MAX) */
             x *= x1p127;
             return x;
         }


### PR DESCRIPTION
Due to an erroneous overflow threshold, `expm1f` was incorrectly returning `inf` for inputs in the range `[88.72169, 88.72283]`. This additionally caused `sinhf` to return `NaN` for inputs in that range.

The bug was ported from the original in musl, which has since been fixed in
https://git.musl-libc.org/cgit/musl/commit/?id=964104f9f0e056cf58d9defa0b716d7756f040f6