### PR TITLE
Remove `[no-mentions]` handler in our triagebot config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -12,10 +12,6 @@ exclude_titles = ["Rustc pull update"]
 [issue-links]
 check-commits = false
 
-# Prevents mentions in commits to avoid users being spammed
-# Documentation at: https://forge.rust-lang.org/triagebot/no-mentions.html
-[no-mentions]
-
 # Enable issue transfers within the org
 # Documentation at: https://forge.rust-lang.org/triagebot/transfer.html
 [transfer]


### PR DESCRIPTION
This PR removes the `[no-mentions]` handler in our triagebot config as [GitHub is removing notifications for @-mentions in commit messages on December 8th 2025.](https://github.blog/changelog/2025-11-07-removing-notifications-for-mentions-in-commit-messages/)

cf. https://github.com/rust-lang/triagebot/issues/2225