### PR TITLE
remove uses of Ord::clamp in scalbn

### DIFF
--- a/libm/src/math/generic/scalbn.rs
+++ b/libm/src/math/generic/scalbn.rs
@@ -96,14 +96,14 @@ where
             // Work aroudn this by using a different algorithm that calculates the prescale
             // dynamically based on the maximum possible value. This adds more operations per round
             // since it needs to construct the scale, but works better in the general case.
-            let add = -(n + sig_total_bits as i32).clamp(exp_min, sig_total_bits as i32);
+            let add = -(n + sig_total_bits as i32).max(exp_min);
             let mul = F::from_parts(false, (F::EXP_BIAS as i32 - add) as u32, zero);
 
             x *= mul;
             n += add;
 
             if n < exp_min {
-                let add = -(n + sig_total_bits as i32).clamp(exp_min, sig_total_bits as i32);
+                let add = -(n + sig_total_bits as i32).max(exp_min);
                 let mul = F::from_parts(false, (F::EXP_BIAS as i32 - add) as u32, zero);
 
                 x *= mul;


### PR DESCRIPTION
Avoid using `Ord::clamp` in the `f16`-specific part of the generic `scalbn`.

fixes rust-lang/compiler-builtins#1046

It turned out to be redundant anyway, as both callsites follow a pattern like
```
if n < negative_val {
    let foo = (n + positive_val).clamp(negative_val, positive_val);
}
```
and `n < negative_val < 0` implies `n + positive_val < positive_val`.