### PR TITLE
Ignore unused_unsafe lint in libm/src/math/arch/x86/detect.rs

### DIFF
--- a/libm/src/math/arch/x86/detect.rs
+++ b/libm/src/math/arch/x86/detect.rs
@@ -39,6 +39,8 @@ pub fn get_cpu_features() -> Flags {
 /// Implementation is taken from [std-detect][std-detect].
 ///
 /// [std-detect]: https://github.com/rust-lang/stdarch/blob/690b3a6334d482874163bd6fcef408e0518febe9/crates/std_detect/src/detect/os/x86.rs#L142
+// FIXME(msrv): Remove unsafe block around __cpuid once https://github.com/rust-lang/stdarch/pull/1935 is available in MSRV.
+#[allow(unused_unsafe)]
 fn load_x86_features() -> Flags {
     let mut value = Flags::empty();
 


### PR DESCRIPTION
This fixes CI failure on the current main branch.

```
error: unnecessary `unsafe` block
  --> builtins-shim/../compiler-builtins/src/math/../../../libm/src/math/arch/x86/detect.rs:60:5
   |
60 |     unsafe {
   |     ^^^^^^ unnecessary `unsafe` block
   |
   = note: `-D unused-unsafe` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unused_unsafe)]`

error: unnecessary `unsafe` block
  --> builtins-shim/../compiler-builtins/src/math/../../../libm/src/math/arch/x86/detect.rs:75:40
   |
75 |     let CpuidResult { ecx, edx, .. } = unsafe { __cpuid(0x0000_0001_u32) };
   |                                        ^^^^^^ unnecessary `unsafe` block

error: unnecessary `unsafe` block
  --> builtins-shim/../compiler-builtins/src/math/../../../libm/src/math/arch/x86/detect.rs:85:44
   |
85 |         let CpuidResult { ebx, edx, .. } = unsafe { __cpuid(0x0000_0007_u32) };
   |                                            ^^^^^^ unnecessary `unsafe` block

error: unnecessary `unsafe` block
  --> builtins-shim/../compiler-builtins/src/math/../../../libm/src/math/arch/x86/detect.rs:89:39
   |
89 |         let CpuidResult { eax, .. } = unsafe { __cpuid_count(0x0000_0007_u32, 0x0000_0001_u32) };
   |                                       ^^^^^^ unnecessary `unsafe` block

error: unnecessary `unsafe` block
  --> builtins-shim/../compiler-builtins/src/math/../../../libm/src/math/arch/x86/detect.rs:96:35
   |
96 |     let extended_max_basic_leaf = unsafe { __cpuid(0x8000_0000_u32) }.eax;
   |                                   ^^^^^^ unnecessary `unsafe` block

error: unnecessary `unsafe` block
   --> builtins-shim/../compiler-builtins/src/math/../../../libm/src/math/arch/x86/detect.rs:101:39
    |
101 |         let CpuidResult { ecx, .. } = unsafe { __cpuid(0x8000_0001_u32) };
    |                                       ^^^^^^ unnecessary `unsafe` block
```

https://github.com/rust-lang/compiler-builtins/actions/runs/20535934632/job/58994139370#step:17:261