### PR TITLE
compiler-builtins: Enable AArch64 `__chkstk` for MinGW

### DIFF
--- a/compiler-builtins/src/aarch64.rs
+++ b/compiler-builtins/src/aarch64.rs
@@ -4,7 +4,7 @@ use core::intrinsics;
 
 intrinsics! {
     #[unsafe(naked)]
-    #[cfg(target_os = "uefi")]
+    #[cfg(any(all(windows, target_env = "gnu"), target_os = "uefi"))]
     pub unsafe extern "custom" fn __chkstk() {
         core::arch::naked_asm!(
             ".p2align 2",


### PR DESCRIPTION
Similarly to i686 and X86_64 MinGW targets, Rust needs to provide the right chkstk symbol for AArch64 to avoid relying on the linker to provide it.

CC https://github.com/rust-lang/rust/issues/150725