### PR TITLE
ci: Test on riscv64 using a self-hosted runner

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,6 +44,9 @@ jobs:
   test:
     name: Build and test
     timeout-minutes: 60
+    # NOTE: self-hosted riscv64 runners are experimental and may be flaky.
+    # Do not block CI on failures from this platform for now.
+    continue-on-error: ${{ contains(matrix.os, 'self-hosted') }}
     strategy:
       fail-fast: false
       matrix:
@@ -74,6 +77,8 @@ jobs:
           os: ubuntu-24.04
         - target: powerpc64le-unknown-linux-gnu
           os: ubuntu-24.04-ppc64le
+        - target: riscv64gc-unknown-linux-gnu
+          os: ["self-hosted", "linux", "riscv64"]
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-24.04
         - target: s390x-unknown-linux-gnu
@@ -173,7 +178,7 @@ jobs:
       shell: bash
 
     - name: Verify API list
-      if: matrix.os == 'ubuntu-24.04'
+      if: matrix.os == 'ubuntu-24.04' || contains(matrix.os, 'self-hosted')
       run: python3 etc/update-api-list.py --check
 
     # Non-linux tests just use our raw script


### PR DESCRIPTION
Closes: https://github.com/rust-lang/compiler-builtins/issues/1054

ci: test-libm