### PR TITLE
Fix generated assembly for the `outline-atomics` feature in Apple AArch64 targets 

### DIFF
--- a/builtins-test/tests/lse.rs
+++ b/builtins-test/tests/lse.rs
@@ -2,6 +2,45 @@
 #![feature(macro_metavar_expr_concat)]
 #![cfg(target_arch = "aarch64")]
 
+use std::sync::Mutex;
+
+use compiler_builtins::aarch64_outline_atomics::{get_have_lse_atomics, set_have_lse_atomics};
+use compiler_builtins::int::{Int, MinInt};
+use compiler_builtins::{foreach_bytes, foreach_ordering};
+
+#[track_caller]
+fn with_maybe_lse_atomics(use_lse: bool, f: impl FnOnce()) {
+    // Ensure tests run in parallel don't interleave global settings
+    static LOCK: Mutex<()> = Mutex::new(());
+    let _g = LOCK.lock().unwrap();
+    let old = get_have_lse_atomics();
+    // safety: as the caller of the unsafe fn `set_have_lse_atomics`, we
+    // have to ensure the CPU supports LSE. This is why we make this assertion.
+    if use_lse || old {
+        assert!(std::arch::is_aarch64_feature_detected!("lse"));
+    }
+    unsafe { set_have_lse_atomics(use_lse) };
+    f();
+    unsafe { set_have_lse_atomics(old) };
+}
+
+pub fn run_fuzz_tests_with_lse_variants<I: Int, F: Fn(I, I) + Copy>(n: u32, f: F)
+where
+    <I as MinInt>::Unsigned: Int,
+{
+    // We use `fuzz_2` because our subject function `f` requires two inputs
+    let test_fn = || {
+        builtins_test::fuzz_2(n, f);
+    };
+    // Always run without LSE
+    with_maybe_lse_atomics(false, test_fn);
+
+    // Conditionally run with LSE
+    if std::arch::is_aarch64_feature_detected!("lse") {
+        with_maybe_lse_atomics(true, test_fn);
+    }
+}
+
 /// Translate a byte size to a Rust type.
 macro int_ty {
     (1) => { u8 },
@@ -15,16 +54,17 @@ mod cas {
     pub(super) macro test($_ordering:ident, $bytes:tt, $name:ident) {
         #[test]
         fn $name() {
-            builtins_test::fuzz_2(10000, |expected: super::int_ty!($bytes), new| {
+            crate::run_fuzz_tests_with_lse_variants(10000, |expected: super::int_ty!($bytes), new| {
                 let mut target = expected.wrapping_add(10);
+                let ret: super::int_ty!($bytes) = unsafe {
+                    compiler_builtins::aarch64_outline_atomics::$name::$name(
+                        expected,
+                        new,
+                        &mut target,
+                    )
+                };
                 assert_eq!(
-                    unsafe {
-                        compiler_builtins::aarch64_outline_atomics::$name::$name(
-                            expected,
-                            new,
-                            &mut target,
-                        )
-                    },
+                    ret,
                     expected.wrapping_add(10),
                     "return value should always be the previous value",
                 );
@@ -35,15 +75,17 @@ mod cas {
                 );
 
                 target = expected;
+                let ret: super::int_ty!($bytes) = unsafe {
+                    compiler_builtins::aarch64_outline_atomics::$name::$name(
+                        expected,
+                        new,
+                        &mut target,
+                    )
+                };
                 assert_eq!(
-                    unsafe {
-                        compiler_builtins::aarch64_outline_atomics::$name::$name(
-                            expected,
-                            new,
-                            &mut target,
-                        )
-                    },
-                    expected
+                    ret,
+                    expected,
+                    "the new return value should always be the previous value (i.e. the first parameter passed to the function)",
                 );
                 assert_eq!(target, new, "should have updated target");
             });
@@ -59,16 +101,21 @@ mod swap {
     pub(super) macro test($_ordering:ident, $bytes:tt, $name:ident) {
         #[test]
         fn $name() {
-            builtins_test::fuzz_2(10000, |left: super::int_ty!($bytes), mut right| {
-                let orig_right = right;
-                assert_eq!(
-                    unsafe {
-                        compiler_builtins::aarch64_outline_atomics::$name::$name(left, &mut right)
-                    },
-                    orig_right
-                );
-                assert_eq!(left, right);
-            });
+            crate::run_fuzz_tests_with_lse_variants(
+                10000,
+                |left: super::int_ty!($bytes), mut right| {
+                    let orig_right = right;
+                    assert_eq!(
+                        unsafe {
+                            compiler_builtins::aarch64_outline_atomics::$name::$name(
+                                left, &mut right,
+                            )
+                        },
+                        orig_right
+                    );
+                    assert_eq!(left, right);
+                },
+            );
         }
     }
 }
@@ -80,7 +127,7 @@ macro_rules! test_op {
                 ($_ordering:ident, $bytes:tt, $name:ident) => {
                     #[test]
                     fn $name() {
-                        builtins_test::fuzz_2(10000, |old, val| {
+                        crate::run_fuzz_tests_with_lse_variants(10000, |old, val| {
                             let mut target = old;
                             let op: fn(super::int_ty!($bytes), super::int_ty!($bytes)) -> _ = $($op)*;
                             let expected = op(old, val);
@@ -98,7 +145,6 @@ test_op!(add, |left, right| left.wrapping_add(right));
 test_op!(clr, |left, right| left & !right);
 test_op!(xor, std::ops::BitXor::bitxor);
 test_op!(or, std::ops::BitOr::bitor);
-use compiler_builtins::{foreach_bytes, foreach_ordering};
 compiler_builtins::foreach_cas!(cas::test);
 compiler_builtins::foreach_cas16!(test_cas16);
 compiler_builtins::foreach_swp!(swap::test);

--- a/compiler-builtins/src/aarch64_outline_atomics.rs
+++ b/compiler-builtins/src/aarch64_outline_atomics.rs
@@ -34,6 +34,19 @@ intrinsics! {
     }
 }
 
+/// Function to enable/disable LSE. To be used only for testing purposes.
+#[cfg(feature = "mangled-names")]
+pub unsafe fn set_have_lse_atomics(has_lse: bool) {
+    let lse_flag = if has_lse { 1 } else { 0 };
+    HAVE_LSE_ATOMICS.store(lse_flag, Ordering::Relaxed);
+}
+
+/// Function to obtain whether LSE is enabled or not. To be used only for testing purposes.
+#[cfg(feature = "mangled-names")]
+pub fn get_have_lse_atomics() -> bool {
+    HAVE_LSE_ATOMICS.load(Ordering::Relaxed) != 0
+}
+
 /// Translate a byte size to a Rust type.
 #[rustfmt::skip]
 macro_rules! int_ty {

--- a/compiler-builtins/src/lib.rs
+++ b/compiler-builtins/src/lib.rs
@@ -57,7 +57,12 @@ pub mod arm;
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
 pub mod aarch64;
 
-#[cfg(all(target_arch = "aarch64", target_feature = "outline-atomics"))]
+// Note that we enable the module on "mangled-names" because that is the default feature
+// in the builtins-test tests. So this is a way of enabling the module during testing.
+#[cfg(all(
+    target_arch = "aarch64",
+    any(target_feature = "outline-atomics", feature = "mangled-names")
+))]
 pub mod aarch64_outline_atomics;
 
 #[cfg(target_arch = "avr")]


### PR DESCRIPTION
**Context**

See https://github.com/rust-lang/rust/issues/149634#issuecomment-3727134152.

Most of the credit goes to https://github.com/tgross35/rust/commit/76a4adc3a28352912188622cfade5ae0b672bcbd.

**Summary**

The main fixes are (as per [Trevor's comment on the issue in rust-lang/rust](https://github.com/rust-lang/rust/issues/149634#issuecomment-3611270146)):

- Replacing semicolons (`;`) in the concatenated macros by newlines (`\n`)
- Properly accounting for Mach-O vs ELF AArch64 relocation specifier syntax
  - As a side note, while learning about these differences, I found [this blog post](https://maskray.me/blog/2025-03-16-relocation-generation-in-assemblers) by [MaskRay](https://github.com/MaskRay) quite useful
  
Additionally, I added some doc comments to explain the differences between Apple/Mach-O vs Linux/ELF syntax wrt to the relocation types.