### PR TITLE
Set `codegen-units=1` for benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ codegen-units = 1
 lto = "fat"
 
 [profile.bench]
+codegen-units = 1
 # Required for gungraun
 debug = true
 strip = false


### PR DESCRIPTION
This should remove some of the nondeterminism in benchmark results observed in rust-lang/compiler-builtins#935.

ci: allow-regressions