### PR TITLE
triagebot: Switch to `check-commits = "uncanonicalized"`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -10,7 +10,7 @@ exclude_titles = ["Rustc pull update"]
 # when commits are included in subtrees, as well as warning links in commits.
 # Documentation at: https://forge.rust-lang.org/triagebot/issue-links.html
 [issue-links]
-check-commits = false
+check-commits = "uncanonicalized"
 
 # Enable issue transfers within the org
 # Documentation at: https://forge.rust-lang.org/triagebot/transfer.html


### PR DESCRIPTION
There is now the option to check for `#xxxx`-style issue numbers that aren't attached to a specific repo. Enable it here.