### PR TITLE
ci: Pin rustc on the native PowerPC job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -72,6 +72,8 @@ jobs:
           os: ubuntu-24.04
         - target: powerpc64le-unknown-linux-gnu
           os: ubuntu-24.04-ppc64le
+          # FIXME(rust#151807): remove once PPC builds work again.
+          channel: nightly-2026-01-23
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-24.04
         - target: s390x-unknown-linux-gnu


### PR DESCRIPTION
Recent nightlies have a miscompile on PowerPC hosts. Pin to a known working nightly for now.

Link: https://github.com/rust-lang/rust/issues/151807