### PR TITLE
libm: fix acosh & acoshf for negative inputs

### DIFF
--- a/libm-test/src/precision.rs
+++ b/libm-test/src/precision.rs
@@ -266,6 +266,15 @@ impl MaybeOverride<(f64,)> for SpecialCase {
             return XFAIL_NOCHECK;
         }
 
+        if ctx.base_name == BaseName::Acosh
+            && input.0 < 1.0
+            && actual.is_nan()
+            && ctx.basis == CheckBasis::Musl
+        {
+            // Musl sometimes evaluates acosh(negative) to a numeric value
+            return XFAIL_NOCHECK;
+        }
+
         // maybe_check_nan_bits(actual, expected, ctx)
         unop_common(input, actual, expected, ctx)
     }
@@ -295,19 +304,6 @@ fn unop_common<F1: Float, F2: Float>(
     expected: F2,
     ctx: &CheckCtx,
 ) -> CheckAction {
-    if ctx.base_name == BaseName::Acosh
-        && input.0 < F1::NEG_ONE
-        && !(expected.is_nan() && actual.is_nan())
-    {
-        // acoshf is undefined for x <= 1.0, but we return a random result at lower values.
-
-        if ctx.basis == CheckBasis::Musl {
-            return XFAIL_NOCHECK;
-        }
-
-        return XFAIL("acoshf undefined");
-    }
-
     if (ctx.base_name == BaseName::Lgamma || ctx.base_name == BaseName::LgammaR)
         && input.0 < F1::ZERO
         && !input.0.is_infinite()

--- a/libm/src/math/acosh.rs
+++ b/libm/src/math/acosh.rs
@@ -1,4 +1,4 @@
-use super::{log, log1p, sqrt};
+use super::{Float, log, log1p, sqrt};
 
 const LN2: f64 = 0.693147180559945309417232121458176568; /* 0x3fe62e42,  0xfefa39ef*/
 
@@ -9,19 +9,19 @@ const LN2: f64 = 0.693147180559945309417232121458176568; /* 0x3fe62e42,  0xfefa3
 /// `x` must be a number greater than or equal to 1.
 #[cfg_attr(assert_no_panic, no_panic::no_panic)]
 pub fn acosh(x: f64) -> f64 {
-    let u = x.to_bits();
-    let e = ((u >> 52) as usize) & 0x7ff;
+    let ux = x.to_bits();
 
     /* x < 1 domain error is handled in the called functions */
-
-    if e < 0x3ff + 1 {
-        /* |x| < 2, up to 2ulp error in [1,1.125] */
-        return log1p(x - 1.0 + sqrt((x - 1.0) * (x - 1.0) + 2.0 * (x - 1.0)));
+    if (ux & !f64::SIGN_MASK) < 2_f64.to_bits() {
+        /* |x| < 2, invalid if x < 1 */
+        /* up to 2ulp error in [1,1.125] */
+        let x_1 = x - 1.0;
+        log1p(x_1 + sqrt(x_1 * x_1 + 2.0 * x_1))
+    } else if ux < ((1 << 26) as f64).to_bits() {
+        /* 2 <= x < 0x1p26 */
+        log(2.0 * x - 1.0 / (x + sqrt(x * x - 1.0)))
+    } else {
+        /* x >= 0x1p26 or x <= -2 or nan */
+        log(x) + LN2
     }
-    if e < 0x3ff + 26 {
-        /* |x| < 0x1p26 */
-        return log(2.0 * x - 1.0 / (x + sqrt(x * x - 1.0)));
-    }
-    /* |x| >= 0x1p26 or nan */
-    return log(x) + LN2;
 }


### PR DESCRIPTION
The acosh-functions were incorrectly returning finite values for some negative inputs (should be NaN for any `x < 1.0`)

The bug was inherited when originally ported from musl, and this patch follows their fix for single-precision acoshf in https://git.musl-libc.org/cgit/musl/commit/?id=c4c38e6364323b6d83ba3428464e19987b981d7a