### PR TITLE
add -Zjson-target-spec to custom target workflows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -230,7 +230,8 @@ jobs:
         # poorly with build scripts)
         cargo build -p compiler_builtins -p libm \
           --target etc/thumbv7em-none-eabi-renamed.json \
-          -Zbuild-std=core
+          -Zbuild-std=core \
+          -Zjson-target-spec
 
   # FIXME: move this target to test job once https://github.com/rust-lang/rust/pull/150138 merged.
   build-thumbv6k:
@@ -248,7 +249,8 @@ jobs:
     - run: |
         cargo build -p compiler_builtins -p libm \
           --target etc/thumbv6-none-eabi.json \
-          -Zbuild-std=core
+          -Zbuild-std=core \
+          -Zjson-target-spec
 
   benchmarks:
     name: Benchmarks


### PR DESCRIPTION
With the json target specification format destabilized in https://github.com/rust-lang/rust/pull/150151, `-Zjson-target-spec` is needed for custom targets. This should resolve the CI failures seen in rust-lang/compiler-builtins#1070