### PR TITLE
fix tests for lgamma

### DIFF
--- a/libm-test/src/domain.rs
+++ b/libm-test/src/domain.rs
@@ -207,7 +207,7 @@ impl<F: Float, I: Int> EitherPrim<Domain<F>, Domain<I>> {
     .into_prim_float()];
 
     /// Domain for `loggamma`
-    const LGAMMA: [Self; 1] = Self::STRICTLY_POSITIVE;
+    const LGAMMA: [Self; 1] = Self::UNBOUNDED1;
 
     /// Domain for `jn` and `yn`.
     // FIXME: the domain should provide some sort of "reasonable range" so we don't actually test

--- a/libm-test/src/mpfloat.rs
+++ b/libm-test/src/mpfloat.rs
@@ -170,7 +170,9 @@ libm_macros::for_each_function! {
         ldexpf,
         ldexpf128,
         ldexpf16,
+        lgamma,
         lgamma_r,
+        lgammaf,
         lgammaf_r,
         modf,
         modff,
@@ -213,7 +215,6 @@ libm_macros::for_each_function! {
         fmaximum_num | fmaximum_numf | fmaximum_numf16 | fmaximum_numf128 => max,
         fmin | fminf | fminf16 | fminf128 |
         fminimum_num | fminimum_numf | fminimum_numf16 | fminimum_numf128 => min,
-        lgamma | lgammaf => ln_gamma,
         log | logf => ln,
         log1p | log1pf => ln_1p,
         tgamma | tgammaf => gamma,
@@ -573,6 +574,30 @@ impl MpOp for crate::op::lgammaf_r::Routine {
         let (sign, ord) = this.ln_abs_gamma_round(Nearest);
         let ret = prep_retval::<Self::FTy>(this, ord);
         (ret, sign as i32)
+    }
+}
+
+impl MpOp for crate::op::lgamma::Routine {
+    type MpTy = MpFloat;
+
+    fn new_mp() -> Self::MpTy {
+        new_mpfloat::<Self::FTy>()
+    }
+
+    fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+        <crate::op::lgamma_r::Routine as MpOp>::run(this, input).0
+    }
+}
+
+impl MpOp for crate::op::lgammaf::Routine {
+    type MpTy = MpFloat;
+
+    fn new_mp() -> Self::MpTy {
+        new_mpfloat::<Self::FTy>()
+    }
+
+    fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+        <crate::op::lgammaf_r::Routine as MpOp>::run(this, input).0
     }
 }
 


### PR DESCRIPTION
The tests were using `rug::ln_gamma` as a reference for `libm::lgamma`, which actually computes the natural logarithm *of the absolute value* of the Gamma function.

This changes the range of inputs used for the icount-benchmarks of these functions, which causes false regressions in https://github.com/rust-lang/compiler-builtins/actions/runs/21788698368/job/62864230903?pr=1075#step:7:2710
ci: allow-regressions