### PR TITLE
ci: Unpin rustc on the native PowerPC job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -72,8 +72,6 @@ jobs:
           os: ubuntu-24.04
         - target: powerpc64le-unknown-linux-gnu
           os: ubuntu-24.04-ppc64le
-          # FIXME(rust#151807): remove once PPC builds work again.
-          channel: nightly-2026-01-23
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-24.04
         - target: s390x-unknown-linux-gnu


### PR DESCRIPTION
The miscompile, now addressed by https://github.com/llvm/llvm-project/commit/4bab6aacf6b3fe7465a0a4a75b09de0aad2c726f, is fixed on both LLVM's main branch and release/22.x branch.

Fixes: https://github.com/rust-lang/rust/issues/151807