### PR TITLE
For panic=unwind on Wasm targets, define __cpp_exception tag

### DIFF
--- a/compiler-builtins/src/lib.rs
+++ b/compiler-builtins/src/lib.rs
@@ -75,4 +75,7 @@ pub mod x86;
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 
+#[cfg(target_family = "wasm")]
+pub mod wasm;
+
 pub mod probestack;

--- a/compiler-builtins/src/wasm.rs
+++ b/compiler-builtins/src/wasm.rs
@@ -1,0 +1,23 @@
+//! Builtins for WebAssembly targets.
+
+// Define the __cpp_exception tag that LLVM's wasm exception handling requires.
+// This must be provided since LLVM commit
+// aee99e8015daa9f53ab1fd4e5b24cc4c694bdc4a which changed the tag from being
+// weakly defined in each object file to being an external reference that must
+// be linked from somewhere.
+//
+// In LLVM's compiler-rt this is provided by
+// compiler-rt/lib/builtins/wasm/__cpp_exception.S
+//
+// Emscripten provides this tag in its runtime libraries, so we don't need to
+// define it for Emscripten targets. Including this in Emscripten would break
+// the wasm-cpp-exception-tag test.
+#[cfg(not(target_os = "emscripten"))]
+core::arch::global_asm!(
+    ".globl __cpp_exception",
+    #[cfg(target_pointer_width = "64")]
+    ".tagtype __cpp_exception i64",
+    #[cfg(target_pointer_width = "32")]
+    ".tagtype __cpp_exception i32",
+    "__cpp_exception:",
+);


### PR DESCRIPTION
Since llvm/llvm-project#159143, llvm no longer weak links the __cpp_exception tag into each object that uses it. They are now defined in compiler-rt. Rust doesn't seem to get them from compiler-rt so llvm decides they need to be imported. This adds them to libunwind.

See also rust-lang/rust#152241 which includes a test for this change.