### PR TITLE
symcheck: Switch to getopts for argument parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ assert_cmd = "2.1.2"
 cc = "1.2.55"
 compiler_builtins = { path = "builtins-shim", default-features = false }
 criterion = { version = "0.6.0", default-features = false, features = ["cargo_bench_support"] }
+getopts = "0.2.24"
 getrandom = "0.3.4"
 gmp-mpfr-sys = { version = "1.6.8", default-features = false }
 gungraun = "0.17.0"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -48,21 +48,21 @@ fi
 # build with the arguments we provide it, then validates the built artifacts.
 SYMCHECK_TEST_TARGET="$target" cargo test -p symbol-check --release
 symcheck=(cargo run -p symbol-check --release)
-symcheck+=(-- build-and-check)
+symcheck+=(-- --build-and-check --target "$target")
 
-"${symcheck[@]}" "$target" -- -p compiler_builtins
-"${symcheck[@]}" "$target" -- -p compiler_builtins --release
-"${symcheck[@]}" "$target" -- -p compiler_builtins --features c
-"${symcheck[@]}" "$target" -- -p compiler_builtins --features c --release
-"${symcheck[@]}" "$target" -- -p compiler_builtins --features no-asm
-"${symcheck[@]}" "$target" -- -p compiler_builtins --features no-asm --release
+"${symcheck[@]}" -- -p compiler_builtins
+"${symcheck[@]}" -- -p compiler_builtins --release
+"${symcheck[@]}" -- -p compiler_builtins --features c
+"${symcheck[@]}" -- -p compiler_builtins --features c --release
+"${symcheck[@]}" -- -p compiler_builtins --features no-asm
+"${symcheck[@]}" -- -p compiler_builtins --features no-asm --release
 
 run_intrinsics_test() {
     build_args=(--verbose --manifest-path builtins-test-intrinsics/Cargo.toml)
     build_args+=("$@")
 
     # symcheck also checks the results of builtins-test-intrinsics
-    "${symcheck[@]}" "$target" -- "${build_args[@]}"
+    "${symcheck[@]}" -- "${build_args[@]}"
 
     # FIXME: we get access violations on Windows, our entrypoint may need to
     # be tweaked.

--- a/crates/symbol-check/Cargo.toml
+++ b/crates/symbol-check/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
+getopts.workspace = true
 object.workspace = true
 regex.workspace = true
 serde_json.workspace = true

--- a/crates/symbol-check/tests/all.rs
+++ b/crates/symbol-check/tests/all.rs
@@ -51,7 +51,7 @@ fn test_duplicates() {
     let status = ar.arg(&dup_out).status().unwrap();
     assert!(status.success());
 
-    let assert = cargo_bin_cmd!().arg("check").arg(&lib_out).assert();
+    let assert = cargo_bin_cmd!().arg("--check").arg(&lib_out).assert();
     assert
         .failure()
         .stderr_contains("duplicate symbols")
@@ -65,7 +65,7 @@ fn test_core_symbols() {
     let dir = tempdir().unwrap();
     let lib_out = dir.path().join("libfoo.rlib");
     rustc_build(&input_dir().join("core_symbols.rs"), &lib_out, |cmd| cmd);
-    let assert = cargo_bin_cmd!().arg("check").arg(&lib_out).assert();
+    let assert = cargo_bin_cmd!().arg("--check").arg(&lib_out).assert();
     assert
         .failure()
         .stderr_contains("found 1 undefined symbols from core")
@@ -77,7 +77,7 @@ fn test_good() {
     let dir = tempdir().unwrap();
     let lib_out = dir.path().join("libfoo.rlib");
     rustc_build(&input_dir().join("good.rs"), &lib_out, |cmd| cmd);
-    let assert = cargo_bin_cmd!().arg("check").arg(&lib_out).assert();
+    let assert = cargo_bin_cmd!().arg("--check").arg(&lib_out).assert();
     assert.success();
 }
 


### PR DESCRIPTION
It would be nice to support a few more flags here, but the current implementation is a bit limited. Switch to `getopts` which should make things a bit easier in the future.