### PR TITLE
ci: Pin Miri to the 2026-02-11 nightly

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -303,7 +303,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust (rustup)
-      run: rustup update nightly --no-self-update && rustup default nightly
+      # FIXME(ci): not working in the 2026-02-11 nightly
+      # https://rust-lang.zulipchat.com/#narrow/channel/269128-miri/topic/build-script-build.20contains.20outdated.20or.20invalid.20JSON/with/573426109
+      run: rustup update nightly-2026-02-10 --no-self-update && rustup default nightly-2026-02-10
       shell: bash
     - run: rustup component add miri
     - run: cargo miri setup


### PR DESCRIPTION
CI is failing with:

    error: failed to run custom build command for `quote v1.0.44`

    Caused by:
      process didn't exit successfully: `/home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/cargo-miri runner /home/runner/work/compiler-builtins/compiler-builtins/target/miri/debug/build/quote-32cc00414fa6f72d/build-script-build` (exit status: 1)
      --- stderr
      fatal error: file "/home/runner/work/compiler-builtins/compiler-builtins/target/miri/debug/build/quote-32cc00414fa6f72d/build-script-build" contains outdated or invalid JSON; try `cargo clean`

Link: https://rust-lang.zulipchat.com/#narrow/channel/269128-miri/topic/build-script-build.20contains.20outdated.20or.20invalid.20JSON/with/573426109