### PR TITLE
Revert "ci: Temporarily disable native PPC and s390x jobs"

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -70,14 +70,14 @@ jobs:
           os: ubuntu-24.04
         - target: powerpc64le-unknown-linux-gnu
           os: ubuntu-24.04
-        # - target: powerpc64le-unknown-linux-gnu
-        #   os: ubuntu-24.04-ppc64le
-        #   # FIXME(rust#151807): remove once PPC builds work again.
-        #   channel: nightly-2026-01-23
+        - target: powerpc64le-unknown-linux-gnu
+          os: ubuntu-24.04-ppc64le
+          # FIXME(rust#151807): remove once PPC builds work again.
+          channel: nightly-2026-01-23
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-24.04
-        # - target: s390x-unknown-linux-gnu
-        #   os: ubuntu-24.04-s390x
+        - target: s390x-unknown-linux-gnu
+          os: ubuntu-24.04-s390x
         - target: thumbv6m-none-eabi
           os: ubuntu-24.04
         - target: thumbv7em-none-eabi


### PR DESCRIPTION
These were disabled due to permission issues, which should now be resolved.

This reverts commit 28e0556a7bca6ca828186d9de74d30c7cb45db5e.