### PR TITLE
Revert "ci: Pin rustc on the native PowerPC job"

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -72,8 +72,6 @@ jobs:
           os: ubuntu-24.04
         - target: powerpc64le-unknown-linux-gnu
           os: ubuntu-24.04-ppc64le
-          # FIXME(rust#151807): remove once PPC builds work again.
-          channel: nightly-2026-01-23
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-24.04
         - target: s390x-unknown-linux-gnu


### PR DESCRIPTION
The nightly has the LLVM bump that resolves the relevant issue.

This reverts commit 99d1fc7752b0e09cff5729cd4f3783d23c23cb66.

Link: https://github.com/rust-lang/rust/pull/152428