### PR TITLE
libm: Reenable should_panic tests on ppc64le

### DIFF
--- a/libm/src/math/support/big/tests.rs
+++ b/libm/src/math/support/big/tests.rs
@@ -261,8 +261,6 @@ fn shr_u256() {
 #[test]
 #[should_panic]
 #[cfg(debug_assertions)]
-// FIXME(ppc): ppc64le seems to have issues with `should_panic` tests.
-#[cfg(not(all(target_arch = "powerpc64", target_endian = "little")))]
 fn shr_u256_overflow() {
     // Like regular shr, panic on overflow with debug assertions
     let _ = u256::MAX >> 256;

--- a/libm/src/math/support/hex_float.rs
+++ b/libm/src/math/support/hex_float.rs
@@ -846,8 +846,6 @@ mod parse_tests {
 }
 
 #[cfg(test)]
-// FIXME(ppc): something with `should_panic` tests cause a SIGILL with ppc64le
-#[cfg(not(all(target_arch = "powerpc64", target_endian = "little")))]
 mod tests_panicking {
     extern crate std;
     use super::*;


### PR DESCRIPTION
The tests pass successfully for me on powerpc64le-unknown-linux-gnu with nightly 1.95.

Closes rust-lang/compiler-builtins#835