### PR TITLE
libm: Reenable sincosf tests on ppc64

### DIFF
--- a/libm/src/math/sincosf.rs
+++ b/libm/src/math/sincosf.rs
@@ -122,8 +122,6 @@ pub fn sincosf(x: f32) -> (f32, f32) {
     }
 }
 
-// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
-#[cfg(not(target_arch = "powerpc64"))]
 #[cfg(test)]
 mod tests {
     use super::sincosf;


### PR DESCRIPTION
This was missed in 6e91b0346c3d (“Revert "Disable broken powerpc64 test due to
 https://github.com/rust-lang/rust/issues/88520"”).