### PR TITLE
fix testing at lgammaf overflow threshold

### DIFF
--- a/libm-test/src/precision.rs
+++ b/libm-test/src/precision.rs
@@ -222,6 +222,15 @@ impl MaybeOverride<(f32,)> for SpecialCase {
             return XFAIL_NOCHECK;
         }
 
+        // the testing infrastructure doesn't account for allowed ulp in the case of overflow
+        if matches!(ctx.base_name, BaseName::Lgamma | BaseName::LgammaR)
+            && input.0 == 4.0850034e36
+            && expected.is_infinite()
+            && actual == F::MAX
+        {
+            return XFAIL_NOCHECK;
+        }
+
         // FIXME(correctness): lgammaf has high relative inaccuracy near its zeroes
         if matches!(ctx.base_name, BaseName::Lgamma | BaseName::LgammaR)
             && input.0 > -13.0625


### PR DESCRIPTION
The current implementation of lgammaf evaluates to f32::MAX at the first input that would overflow if correctly rounded. This is still well within allowed error, so special case it.