### PR TITLE
meta: Allow `unused_features`

### DIFF
--- a/builtins-test-intrinsics/src/main.rs
+++ b/builtins-test-intrinsics/src/main.rs
@@ -3,7 +3,7 @@
 // compiling a C implementation and forget to implement that intrinsic in Rust, this file will fail
 // to link due to the missing intrinsic (symbol).
 
-#![allow(internal_features)]
+#![allow(internal_features, unused_features)]
 #![deny(dead_code)]
 #![feature(f128)]
 #![feature(f16)]

--- a/builtins-test/tests/addsub.rs
+++ b/builtins-test/tests/addsub.rs
@@ -1,4 +1,4 @@
-#![allow(unused_macros)]
+#![allow(unused_macros, unused_features)]
 #![cfg_attr(f16_enabled, feature(f16))]
 #![cfg_attr(f128_enabled, feature(f128))]
 

--- a/builtins-test/tests/conv.rs
+++ b/builtins-test/tests/conv.rs
@@ -1,8 +1,9 @@
 #![cfg_attr(f128_enabled, feature(f128))]
 #![cfg_attr(f16_enabled, feature(f16))]
 // makes configuration easier
-#![allow(unused_macros)]
+#![allow(unused_features)]
 #![allow(unused_imports)]
+#![allow(unused_macros)]
 
 use builtins_test::*;
 use compiler_builtins::float::Float;

--- a/builtins-test/tests/div_rem.rs
+++ b/builtins-test/tests/div_rem.rs
@@ -1,5 +1,5 @@
 #![feature(f128)]
-#![allow(unused_macros)]
+#![allow(unused_macros, unused_features)]
 
 use builtins_test::*;
 use compiler_builtins::int::sdiv::{__divmoddi4, __divmodsi4, __divmodti4};

--- a/builtins-test/tests/float_pow.rs
+++ b/builtins-test/tests/float_pow.rs
@@ -1,4 +1,4 @@
-#![allow(unused_macros)]
+#![allow(unused_macros, unused_features)]
 #![cfg_attr(f128_enabled, feature(f128))]
 
 #[cfg_attr(x86_no_sse, allow(unused))]

--- a/builtins-test/tests/lse.rs
+++ b/builtins-test/tests/lse.rs
@@ -1,3 +1,4 @@
+#![allow(unused_features)]
 #![feature(decl_macro)] // so we can use pub(super)
 #![feature(macro_metavar_expr_concat)]
 #![cfg(all(target_arch = "aarch64", feature = "mangled-names"))]

--- a/builtins-test/tests/mul.rs
+++ b/builtins-test/tests/mul.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(f16_enabled, feature(f16))]
 #![cfg_attr(f128_enabled, feature(f128))]
-#![allow(unused_macros)]
+#![allow(unused_macros, unused_features)]
 
 use builtins_test::*;
 

--- a/crates/libm-macros/tests/basic.rs
+++ b/crates/libm-macros/tests/basic.rs
@@ -1,3 +1,4 @@
+#![allow(unused_features)]
 #![feature(f16)]
 #![feature(f128)]
 // `STATUS_DLL_NOT_FOUND` on i686 MinGW, not worth looking into.


### PR DESCRIPTION
These warnings are showing up on the most recent nightly:

    error: feature `f128` is declared but not used
     --> builtins-test/tests/addsub.rs:3:35
      |
    3 | #![cfg_attr(f128_enabled, feature(f128))]
      |                                   ^^^^