### PR TITLE
Revert "ci: Pin Miri to the 2026-02-11 nightly"

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -301,9 +301,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust (rustup)
-      # FIXME(ci): not working in the 2026-02-11 nightly
-      # https://rust-lang.zulipchat.com/#narrow/channel/269128-miri/topic/build-script-build.20contains.20outdated.20or.20invalid.20JSON/with/573426109
-      run: rustup update nightly-2026-02-10 --no-self-update && rustup default nightly-2026-02-10
+      run: rustup update nightly --no-self-update && rustup default nightly
       shell: bash
     - run: rustup component add miri
     - run: cargo miri setup


### PR DESCRIPTION
The described issue in the reverted commit is no longer relevant.

This reverts commit 870ab266bad7ec0a56abfc433f92e3c2d67a572c.