### PR TITLE
publish via trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,7 @@ jobs:
   release-plz:
     name: Release-plz
     runs-on: ubuntu-24.04
+    environment: publish
     steps:
       - uses: actions/checkout@v6
         with:
@@ -18,7 +19,6 @@ jobs:
       - name: Install Rust (rustup)
         run: rustup update nightly --no-self-update && rustup default nightly
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: release-plz/action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
The environment was created in https://github.com/rust-lang/team/pull/2322:
<img width="1674" height="592" alt="image" src="https://github.com/user-attachments/assets/7d4fa694-6f30-4961-abf1-9f9be95a169b" />

- [x] blocked by https://github.com/rust-lang/team/pull/2326
