### PR TITLE
ci: Resolve audit issues reported by zizmore

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,5 @@
 name: CI
+permissions: {}
 on:
   push: { branches: [main] }
   pull_request:
@@ -28,7 +29,7 @@ jobs:
       extensive_matrix: ${{ steps.script.outputs.extensive_matrix }}
       may_skip_libm_ci: ${{ steps.script.outputs.may_skip_libm_ci }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 500
       - name: Fetch pull request ref
@@ -104,6 +105,8 @@ jobs:
     needs: [calculate_vars]
     env:
       BUILD_ONLY: ${{ matrix.build_only }}
+      JOB_TARGET: ${{ matrix.target }}
+      JOB_CHANNEL: ${{ matrix.channel }}
       MAY_SKIP_LIBM_CI: ${{ needs.calculate_vars.outputs.may_skip_libm_ci }}
     steps:
     - name: Print $HOME
@@ -121,36 +124,38 @@ jobs:
       if: matrix.os == 'ubuntu-24.04-ppc64le' || matrix.os == 'ubuntu-24.04-s390x'
       run: sudo apt-get update && sudo apt-get install -y rustup
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Install Rust (rustup)
       shell: bash
       run: |
         channel="nightly"
         # Account for channels that have required components (MinGW)
-        [ -n "${{ matrix.channel }}" ] && channel="${{ matrix.channel }}"
+        [ -n "$JOB_CHANNEL" ] && channel="$JOB_CHANNEL"
         rustup update "$channel" --no-self-update
         rustup default "$channel"
-        rustup target add "${{ matrix.target }}"
+        rustup target add "$JOB_TARGET"
 
-    - uses: taiki-e/install-action@nextest
+    - uses: taiki-e/install-action@de6bbd1333b8f331563d54a051e542c7dfef81c3 # v2
+      with:
+        tool: nextest@0.9.130
 
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         key: ${{ matrix.target }}
     - name: Cache Docker layers
-      uses: actions/cache@v5
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
       if: matrix.os == 'ubuntu-24.04'
       with:
         path: /tmp/.buildx-cache
         key: ${{ matrix.target }}-buildx-${{ github.sha }}
         restore-keys: ${{ matrix.target }}-buildx-
     # Configure buildx to use Docker layer caching
-    - uses: docker/setup-buildx-action@v4
+    - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
       if: matrix.os == 'ubuntu-24.04'
 
     - name: Cache compiler-rt
       id: cache-compiler-rt
-      uses: actions/cache@v5
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
       with:
         path: compiler-rt
         key: ${{ runner.os }}-compiler-rt-${{ hashFiles('ci/download-compiler-rt.sh') }}
@@ -173,12 +178,12 @@ jobs:
     - name: Run locally
       if: matrix.os != 'ubuntu-24.04'
       shell: bash
-      run: ./ci/run.sh ${{ matrix.target }}
+      run: ./ci/run.sh "$JOB_TARGET"
 
     # Otherwise we use our docker containers to run builds
     - name: Run in Docker
       if: matrix.os == 'ubuntu-24.04'
-      run: ./ci/run-docker.sh ${{ matrix.target }}
+      run: ./ci/run-docker.sh "$JOB_TARGET"
 
     - name: Print test logs if available
       if: always()
@@ -199,14 +204,14 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     # Unlike rustfmt, stable clippy does not work on code with nightly features.
     - name: Install nightly `clippy`
       run: |
         rustup update nightly --no-self-update
         rustup default nightly
         rustup component add clippy
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
     - name: Download musl source
       run: ./ci/update-musl.sh
     - run: cargo clippy --workspace --all-targets
@@ -216,13 +221,13 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Install Rust
       run: |
         rustup update nightly --no-self-update
         rustup default nightly
         rustup component add rust-src
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
     - run: |
         # Ensure we can build with custom target.json files (these can interact
         # poorly with build scripts)
@@ -237,13 +242,13 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Install Rust
       run: |
         rustup update nightly --no-self-update
         rustup default nightly
         rustup component add rust-src
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
     - run: |
         cargo build -p compiler_builtins -p libm \
           --target etc/thumbv6-none-eabi.json \
@@ -262,13 +267,17 @@ jobs:
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-24.04-arm
     runs-on: ${{ matrix.os }}
+    env:
+      JOB_TARGET: ${{ matrix.target }}
     steps:
-    - uses: actions/checkout@v6
-    - uses: taiki-e/install-action@cargo-binstall
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: taiki-e/install-action@de6bbd1333b8f331563d54a051e542c7dfef81c3 # v2
+      with:
+        tool: cargo-binstall@1.17.7
 
     - name: Set up dependencies
       run: ./ci/install-bench-deps.sh
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         key: ${{ matrix.target }}
     - name: Download musl source
@@ -278,10 +287,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
-      run: ./ci/bench-icount.sh ${{ matrix.target }}
+      run: ./ci/bench-icount.sh "$JOB_TARGET"
 
     - name: Upload the benchmark baseline
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       with:
         name: ${{ env.BASELINE_NAME }}
         path: ${{ env.BASELINE_NAME }}.tar.xz
@@ -299,13 +308,13 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Install Rust (rustup)
       run: rustup update nightly --no-self-update && rustup default nightly
       shell: bash
     - run: rustup component add miri
     - run: cargo miri setup
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
     - run: ./ci/miri.sh
 
   msrv:
@@ -315,13 +324,13 @@ jobs:
     env:
       RUSTFLAGS: # No need to check warnings on old MSRV, unset `-Dwarnings`
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Install Rust
       run: |
         msrv="$(perl -ne 'print if s/rust-version\s*=\s*"(.*)"/\1/g' libm/Cargo.toml)"
         echo "MSRV: $msrv"
         rustup update "$msrv" --no-self-update && rustup default "$msrv"
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
     - run: |
         # FIXME(msrv): Remove the workspace Cargo.toml so 1.63 cargo doesn't see
         # `edition = "2024"` and get spooked.
@@ -333,7 +342,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Install nightly `rustfmt`
       run: rustup set profile minimal && rustup default nightly && rustup component add rustfmt
     - run: cargo fmt -- --check
@@ -356,12 +365,12 @@ jobs:
     env:
       TO_TEST: ${{ matrix.to_test }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install Rust
         run: |
           rustup update nightly --no-self-update
           rustup default nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: download musl source
         run: ./ci/update-musl.sh
       - name: Run extensive tests
@@ -387,7 +396,9 @@ jobs:
     # failed" as success. So we have to do some contortions to ensure the job fails if any of its
     # dependencies fails.
     if: always() # make sure this is never "skipped"
+    env:
+      NEEDS: ${{ toJson(needs) }}
     steps:
       # Manually check the status of all dependencies. `if: failure()` does not work.
       - name: check if any dependency failed
-        run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'
+        run: jq --exit-status 'all(.result == "success")' <<< "$NEEDS"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-24.04
     environment: publish
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Install Rust (rustup)
         run: rustup update nightly --no-self-update && rustup default nightly
       - name: Run release-plz
-        uses: release-plz/action@v0.5
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rustc-pull.yml
+++ b/.github/workflows/rustc-pull.yml
@@ -1,6 +1,6 @@
 # Perform a subtree sync (pull) using the josh-sync tool once every few days (or on demand).
 name: rustc-pull
-
+permissions: {}
 on:
   workflow_dispatch:
   schedule:
@@ -13,7 +13,7 @@ env:
 jobs:
   pull:
     if: github.repository == 'rust-lang/compiler-builtins'
-    uses: rust-lang/josh-sync/.github/workflows/rustc-pull.yml@main
+    uses: rust-lang/josh-sync/.github/workflows/rustc-pull.yml@a097aeb82f49801051560482307ceaca7e58bf97 # main
     with:
       github-app-id: ${{ vars.APP_CLIENT_ID }}
       # https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/compiler-builtins.20subtree.20sync.20automation/with/528482375


### PR DESCRIPTION
Resolve the following lints:

* `unpinned-uses`: Pin action versions using `zizmor --fix`
* `excessive-permissions`: Add `permissions: {}` to all workflows
* `template-injection`: This one wasn't too concerning since `${{ ... }}` was only used for `matrix` and `needs` access, but it is easy enough to resolve by storing in an environment variable.

There is a remaining `secrets-outside-env` lint that will be resolved by https://github.com/rust-lang/compiler-builtins/pull/1112.