### PR TITLE
ci: Add configuration for renovatebot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,7 @@
   extends: [
     "config:recommended",
     ":maintainLockFilesMonthly",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   packageRules: [
     {


### PR DESCRIPTION
Based on the configuration for bors [1].

[1]: https://github.com/rust-lang/bors/blob/d89bfc24e8e7add3b03af3ab7307cd3b2a1af879/.github/renovate.json5