### PR TITLE
libm: Remove `hexu` in favor of formatting traits on `u256`

### DIFF
--- a/libm-test/tests/u256.rs
+++ b/libm-test/tests/u256.rs
@@ -19,11 +19,6 @@ use rug::ops::NotAssign;
 static BIGINT_U256_MAX: LazyLock<BigInt> =
     LazyLock::new(|| BigInt::from_digits(&[u128::MAX, u128::MAX], Order::Lsf));
 
-/// Copied from the test module.
-fn hexu(v: u256) -> String {
-    format!("0x{:032x}{:032x}", v.hi, v.lo)
-}
-
 fn random_u256(rng: &mut ChaCha8Rng) -> u256 {
     let lo: u128 = rng.random();
     let hi: u128 = rng.random();
@@ -46,25 +41,15 @@ fn from_bigint(bx: &mut BigInt) -> u256 {
     }
 }
 
-fn check_one(
-    x: impl FnOnce() -> String,
-    y: impl FnOnce() -> Option<String>,
-    actual: u256,
-    expected: &mut BigInt,
-) {
+fn check_one(msg: impl Fn() -> String, actual: u256, expected: &mut BigInt) {
     let expected = from_bigint(expected);
     if actual != expected {
-        let xmsg = x();
-        let ymsg = y().map(|y| format!("y:        {y}\n")).unwrap_or_default();
         panic!(
-            "Results do not match\n\
-            input:    {xmsg}\n\
-            {ymsg}\
-            actual:   {}\n\
-            expected: {}\
+            "Test failure: {}\n\
+            actual:   {actual:#x}\n\
+            expected: {expected:#x}\
             ",
-            hexu(actual),
-            hexu(expected),
+            msg()
         )
     }
 }
@@ -82,7 +67,7 @@ fn mp_u256_bitor() {
         assign_bigint(&mut by, y);
         let actual = x | y;
         bx |= &by;
-        check_one(|| hexu(x), || Some(hexu(y)), actual, &mut bx);
+        check_one(|| format!("{x:#x} ^ {y:#x}"), actual, &mut bx);
     }
 }
 
@@ -96,7 +81,7 @@ fn mp_u256_not() {
         assign_bigint(&mut bx, x);
         let actual = !x;
         bx.not_assign();
-        check_one(|| hexu(x), || None, actual, &mut bx);
+        check_one(|| format!("!{x:#x}"), actual, &mut bx);
     }
 }
 
@@ -119,7 +104,7 @@ fn mp_u256_add() {
             y - (u256::MAX - x) - 1_u128.widen()
         };
         bx += &by;
-        check_one(|| hexu(x), || Some(hexu(y)), actual, &mut bx);
+        check_one(|| format!("{x:#x} + {y:#x}"), actual, &mut bx);
     }
 }
 
@@ -140,7 +125,7 @@ fn mp_u256_sub() {
         let actual = if x >= y { x - y } else { y - x };
         bx -= &by;
         bx.abs_mut();
-        check_one(|| hexu(x), || Some(hexu(y)), actual, &mut bx);
+        check_one(|| format!("{x:#x} - {y:#x}"), actual, &mut bx);
     }
 }
 
@@ -155,7 +140,7 @@ fn mp_u256_shl() {
         assign_bigint(&mut bx, x);
         let actual = x << shift;
         bx <<= shift;
-        check_one(|| hexu(x), || Some(shift.to_string()), actual, &mut bx);
+        check_one(|| format!("{x:#x} << {shift}"), actual, &mut bx);
     }
 }
 
@@ -170,12 +155,12 @@ fn mp_u256_shr() {
         assign_bigint(&mut bx, x);
         let actual = x >> shift;
         bx >>= shift;
-        check_one(|| hexu(x), || Some(shift.to_string()), actual, &mut bx);
+        check_one(|| format!("{x:#x} >> {shift}"), actual, &mut bx);
     }
 }
 
 #[test]
-fn mp_u256_widen_mul() {
+fn mp_u256_u128_widen_mul() {
     let mut rng = ChaCha8Rng::from_seed(*SEED);
     let mut bx = BigInt::new();
     let mut by = BigInt::new();
@@ -188,8 +173,7 @@ fn mp_u256_widen_mul() {
         let actual = x.widen_mul(y);
         bx *= &by;
         check_one(
-            || format!("{x:#034x}"),
-            || Some(format!("{y:#034x}")),
+            || format!("{x:#034x}.widen_mul({y:#034x})"),
             actual,
             &mut bx,
         );

--- a/libm/src/math/support/big.rs
+++ b/libm/src/math/support/big.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 mod tests;
 
-use core::ops;
+use core::{fmt, ops};
 
 use super::{DInt, HInt, Int, MinInt};
 
@@ -11,7 +11,7 @@ const U128_LO_MASK: u128 = u64::MAX as u128;
 
 /// A 256-bit unsigned integer represented as two 128-bit native-endian limbs.
 #[allow(non_camel_case_types)]
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub struct u256 {
     pub hi: u128,
     pub lo: u128,
@@ -35,7 +35,7 @@ impl u256 {
 
 /// A 256-bit signed integer represented as two 128-bit native-endian limbs.
 #[allow(non_camel_case_types)]
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub struct i256 {
     pub hi: i128,
     pub lo: u128,
@@ -43,7 +43,6 @@ pub struct i256 {
 
 impl i256 {
     /// Reinterpret as an unsigned integer
-    #[cfg(any(test, feature = "unstable-public-internals"))]
     pub fn unsigned(self) -> u256 {
         u256 {
             lo: self.lo,
@@ -278,5 +277,37 @@ impl DInt for i256 {
 
     fn hi(self) -> Self::H {
         self.hi
+    }
+}
+
+impl fmt::Debug for u256 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(self, f)
+    }
+}
+
+impl fmt::Debug for i256 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.unsigned(), f)
+    }
+}
+
+impl fmt::LowerHex for u256 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        cfg_if! {
+            if #[cfg(feature = "compiler-builtins")] {
+                let _ = f;
+                unimplemented!()
+            } else {
+                let pfx= if f.alternate() { "0x"} else {""};
+                write!(f, "{pfx}{:032x}{:032x}", self.hi, self.lo)
+            }
+        }
+    }
+}
+
+impl fmt::LowerHex for i256 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.unsigned(), f)
     }
 }

--- a/libm/src/math/support/big/tests.rs
+++ b/libm/src/math/support/big/tests.rs
@@ -1,16 +1,10 @@
 extern crate std;
-use std::string::String;
-use std::{eprintln, format};
+use std::eprintln;
 
 use super::{HInt, MinInt, i256, u256};
 use crate::support::{Int as _, NarrowingDiv};
 
 const LOHI_SPLIT: u128 = 0xaaaaaaaaaaaaaaaaffffffffffffffff;
-
-/// Print a `u256` as hex since we can't add format implementations
-fn hexu(v: u256) -> String {
-    format!("0x{:032x}{:032x}", v.hi, v.lo)
-}
 
 #[test]
 fn widen_u128() {
@@ -81,11 +75,9 @@ fn widen_mul_u128() {
         eprintln!(
             "\
             FAILURE ({i}): {a:#034x} * {b:#034x}\n\
-            expected: {}\n\
-            got:      {}\
+            expected: {expected:#x}\n\
+            actual:   {actual:#x}\
             ",
-            hexu(expected),
-            hexu(actual)
         );
     };
 
@@ -121,13 +113,10 @@ fn shr_u256() {
         has_errors = true;
         eprintln!(
             "\
-            FAILURE:  {} >> {b}\n\
-            expected: {}\n\
-            actual:   {}\
+            FAILURE:  {a:#x} >> {b}\n\
+            expected: {expected:#x}\n\
+            actual:   {actual:#x}\
             ",
-            hexu(a),
-            hexu(expected),
-            hexu(actual),
         );
     };
 

--- a/libm/src/math/support/hex_float.rs
+++ b/libm/src/math/support/hex_float.rs
@@ -326,9 +326,9 @@ const fn hex_digit(c: u8) -> Option<u8> {
 
 #[cfg(any(test, feature = "unstable-public-internals"))]
 mod hex_fmt {
-    use core::fmt;
+    use core::fmt::{self, LowerHex};
 
-    use crate::support::{Float, Int};
+    use crate::support::{Float, MinInt};
 
     /// Format a floating point number as its IEEE hex (`%a`) representation.
     pub struct Hexf<F>(pub F);
@@ -461,7 +461,7 @@ mod hex_fmt {
 
     pub struct Hexi<F>(pub F);
 
-    impl<I: Int> fmt::LowerHex for Hexi<I> {
+    impl<I: MinInt + LowerHex> fmt::LowerHex for Hexi<I> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             cfg_if! {
                 if #[cfg(feature = "compiler-builtins")] {


### PR DESCRIPTION
Use the same trick as with other formatting implementations, which makes it possible to get rid of the awkward `-> String` functions.