### PR TITLE
support: Rename `signed` to `cast_signed` to match `core`

### DIFF
--- a/builtins-test/tests/big.rs
+++ b/builtins-test/tests/big.rs
@@ -21,12 +21,12 @@ fn widen_u128() {
 
 #[test]
 fn widen_i128() {
-    assert_eq!((-1i128).widen(), u256::MAX.signed());
+    assert_eq!((-1i128).widen(), u256::MAX.cast_signed());
     assert_eq!(
         (LOHI_SPLIT as i128).widen(),
         i256([u64::MAX, 0xaaaaaaaaaaaaaaaa, u64::MAX, u64::MAX])
     );
-    assert_eq!((-1i128).zero_widen().unsigned(), (u128::MAX).widen());
+    assert_eq!((-1i128).zero_widen().cast_unsigned(), (u128::MAX).widen());
 }
 
 #[test]

--- a/compiler-builtins/src/int/addsub.rs
+++ b/compiler-builtins/src/int/addsub.rs
@@ -25,10 +25,10 @@ where
     <Self as MinInt>::Unsigned: UAddSub,
 {
     fn add(self, other: Self) -> Self {
-        Self::from_unsigned(self.unsigned().uadd(other.unsigned()))
+        Self::from_unsigned(self.cast_unsigned().uadd(other.cast_unsigned()))
     }
     fn sub(self, other: Self) -> Self {
-        Self::from_unsigned(self.unsigned().usub(other.unsigned()))
+        Self::from_unsigned(self.cast_unsigned().usub(other.cast_unsigned()))
     }
 }
 

--- a/compiler-builtins/src/int/big.rs
+++ b/compiler-builtins/src/int/big.rs
@@ -23,7 +23,7 @@ impl u256 {
     pub const MAX: Self = Self([u64::MAX, u64::MAX, u64::MAX, u64::MAX]);
 
     /// Reinterpret as a signed integer
-    pub fn signed(self) -> i256 {
+    pub fn cast_signed(self) -> i256 {
         i256(self.0)
     }
 }
@@ -37,7 +37,7 @@ pub struct i256(pub [u64; 4]);
 
 impl i256 {
     /// Reinterpret as an unsigned integer
-    pub fn unsigned(self) -> u256 {
+    pub fn cast_unsigned(self) -> u256 {
         u256(self.0)
     }
 }
@@ -233,7 +233,7 @@ impl HInt for i128 {
     type D = i256;
 
     fn widen(self) -> Self::D {
-        let mut ret = self.unsigned().zero_widen().signed();
+        let mut ret = self.cast_unsigned().zero_widen().cast_signed();
         if self.is_negative() {
             ret.0[2] = u64::MAX;
             ret.0[3] = u64::MAX;
@@ -242,11 +242,13 @@ impl HInt for i128 {
     }
 
     fn zero_widen(self) -> Self::D {
-        self.unsigned().zero_widen().signed()
+        self.cast_unsigned().zero_widen().cast_signed()
     }
 
     fn zero_widen_mul(self, rhs: Self) -> Self::D {
-        self.unsigned().zero_widen_mul(rhs.unsigned()).signed()
+        self.cast_unsigned()
+            .zero_widen_mul(rhs.cast_unsigned())
+            .cast_signed()
     }
 
     fn widen_mul(self, rhs: Self) -> Self::D {

--- a/libm-test/src/test_traits.rs
+++ b/libm-test/src/test_traits.rs
@@ -357,8 +357,8 @@ where
             bail!("mismatched infinities");
         }
 
-        let act_bits = actual.to_bits().signed();
-        let exp_bits = expected.to_bits().signed();
+        let act_bits = actual.to_bits().cast_signed();
+        let exp_bits = expected.to_bits().cast_signed();
 
         let ulp_diff = act_bits.checked_sub(exp_bits).unwrap().abs();
 

--- a/libm/src/math/generic/ceil.rs
+++ b/libm/src/math/generic/ceil.rs
@@ -7,7 +7,9 @@
 //! performance seems to be better (based on icount) and it does not seem to experience rounding
 //! errors on i386.
 
-use crate::support::{Float, FpResult, Int, IntTy, MinInt, Status};
+#[allow(unused_imports)] // FIXME(msrv): polyfill for cast_unsigned which requires  1.87
+use crate::support::Int;
+use crate::support::{Float, FpResult, IntTy, MinInt, Status};
 
 #[inline]
 pub fn ceil<F: Float>(x: F) -> F {
@@ -29,7 +31,7 @@ pub fn ceil_status<F: Float>(x: F) -> FpResult<F> {
     let status;
     let res = if e >= 0 {
         // |x| >= 1.0
-        let m = F::SIG_MASK >> e.unsigned();
+        let m = F::SIG_MASK >> e.cast_unsigned();
         if (ix & m) == zero {
             // Portion to be masked is already zero; no adjustment needed.
             return FpResult::ok(x);

--- a/libm/src/math/generic/floor.rs
+++ b/libm/src/math/generic/floor.rs
@@ -7,7 +7,9 @@
 //! performance seems to be better (based on icount) and it does not seem to experience rounding
 //! errors on i386.
 
-use crate::support::{Float, FpResult, Int, IntTy, MinInt, Status};
+#[allow(unused_imports)] // FIXME(msrv): polyfill for cast_unsigned which requires  1.87
+use crate::support::Int;
+use crate::support::{Float, FpResult, IntTy, MinInt, Status};
 
 #[inline]
 pub fn floor<F: Float>(x: F) -> F {
@@ -28,7 +30,7 @@ pub fn floor_status<F: Float>(x: F) -> FpResult<F> {
 
     let res = if e >= 0 {
         // |x| >= 1.0
-        let m = F::SIG_MASK >> e.unsigned();
+        let m = F::SIG_MASK >> e.cast_unsigned();
         if ix & m == zero {
             // Portion to be masked is already zero; no adjustment needed.
             return FpResult::ok(x);

--- a/libm/src/math/generic/fma.rs
+++ b/libm/src/math/generic/fma.rs
@@ -115,8 +115,8 @@ where
         rlo = res;
         rhi = rhi.wrapping_sub(zhi.wrapping_add(IntTy::<F>::from(borrow)));
         if (rhi >> (F::BITS - 1)) != zero {
-            rlo = rlo.signed().wrapping_neg().unsigned();
-            rhi = rhi.signed().wrapping_neg().unsigned() - IntTy::<F>::from(rlo != zero);
+            rlo = rlo.cast_signed().wrapping_neg().cast_unsigned();
+            rhi = rhi.cast_signed().wrapping_neg().cast_unsigned() - IntTy::<F>::from(rlo != zero);
             neg = !neg;
         }
         rhi_nonzero = rhi != zero;
@@ -150,7 +150,7 @@ where
 
     // Use int->float conversion to populate the significand.
     // i is in [1 << (BITS - 2), (1 << (BITS - 1)) - 1]
-    let mut i: F::SignedInt = rhi.signed();
+    let mut i: F::SignedInt = rhi.cast_signed();
 
     if neg {
         i = -i;
@@ -185,7 +185,7 @@ where
                 // Account for truncated bits. One bit will be lost in the `scalbn` call, add
                 // another top bit to avoid double rounding if inexact.
                 let iu: F::Int = (rhi >> 1) | (rhi & one) | (one << (F::BITS - 2));
-                i = iu.signed();
+                i = iu.cast_signed();
 
                 if neg {
                     i = -i;
@@ -201,7 +201,7 @@ where
             // Only round once when scaled
             d = F::EXP_BITS as i32 - 1;
             let sticky = IntTy::<F>::from(rhi << (F::BITS as i32 - d) != zero);
-            i = (((rhi >> d) | sticky) << d).signed();
+            i = (((rhi >> d) | sticky) << d).cast_signed();
 
             if neg {
                 i = -i;

--- a/libm/src/math/generic/trunc.rs
+++ b/libm/src/math/generic/trunc.rs
@@ -1,7 +1,9 @@
 /* SPDX-License-Identifier: MIT
  * origin: musl src/math/trunc.c */
 
-use crate::support::{Float, FpResult, Int, IntTy, MinInt, Status};
+#[allow(unused_imports)] // FIXME(msrv): polyfill for cast_unsigned which requires  1.87
+use crate::support::Int;
+use crate::support::{Float, FpResult, IntTy, MinInt, Status};
 
 #[inline]
 pub fn trunc<F: Float>(x: F) -> F {
@@ -24,7 +26,7 @@ pub fn trunc_status<F: Float>(x: F) -> FpResult<F> {
         !F::SIGN_MASK
     } else {
         // Otherwise, we keep `e` fractional bits and clear the rest.
-        F::SIG_MASK >> e.unsigned()
+        F::SIG_MASK >> e.cast_unsigned()
     };
 
     let cleared = xi & clear_mask;

--- a/libm/src/math/support/big.rs
+++ b/libm/src/math/support/big.rs
@@ -25,7 +25,7 @@ impl u256 {
     };
 
     /// Reinterpret as a signed integer
-    pub fn signed(self) -> i256 {
+    pub fn cast_signed(self) -> i256 {
         i256 {
             lo: self.lo,
             hi: self.hi as i128,
@@ -43,7 +43,7 @@ pub struct i256 {
 
 impl i256 {
     /// Reinterpret as an unsigned integer
-    pub fn unsigned(self) -> u256 {
+    pub fn cast_unsigned(self) -> u256 {
         u256 {
             lo: self.lo,
             hi: self.hi as u128,
@@ -240,11 +240,13 @@ impl HInt for i128 {
     }
 
     fn zero_widen(self) -> Self::D {
-        self.unsigned().zero_widen().signed()
+        self.cast_unsigned().zero_widen().cast_signed()
     }
 
     fn zero_widen_mul(self, rhs: Self) -> Self::D {
-        self.unsigned().zero_widen_mul(rhs.unsigned()).signed()
+        self.cast_unsigned()
+            .zero_widen_mul(rhs.cast_unsigned())
+            .cast_signed()
     }
 
     fn widen_mul(self, _rhs: Self) -> Self::D {
@@ -288,7 +290,7 @@ impl fmt::Debug for u256 {
 
 impl fmt::Debug for i256 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::LowerHex::fmt(&self.unsigned(), f)
+        fmt::LowerHex::fmt(&self.cast_unsigned(), f)
     }
 }
 
@@ -308,6 +310,6 @@ impl fmt::LowerHex for u256 {
 
 impl fmt::LowerHex for i256 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::LowerHex::fmt(&self.unsigned(), f)
+        fmt::LowerHex::fmt(&self.cast_unsigned(), f)
     }
 }

--- a/libm/src/math/support/big/tests.rs
+++ b/libm/src/math/support/big/tests.rs
@@ -2,7 +2,7 @@ extern crate std;
 use std::eprintln;
 
 use super::{HInt, MinInt, i256, u256};
-use crate::support::{Int as _, NarrowingDiv};
+use crate::support::NarrowingDiv;
 
 const LOHI_SPLIT: u128 = 0xaaaaaaaaaaaaaaaaffffffffffffffff;
 
@@ -26,7 +26,7 @@ fn widen_u128() {
 
 #[test]
 fn widen_i128() {
-    assert_eq!((-1i128).widen(), u256::MAX.signed());
+    assert_eq!((-1i128).widen(), u256::MAX.cast_signed());
     assert_eq!(
         (LOHI_SPLIT as i128).widen(),
         i256 {
@@ -34,7 +34,7 @@ fn widen_i128() {
             hi: -1,
         }
     );
-    assert_eq!((-1i128).zero_widen().unsigned(), (u128::MAX).widen());
+    assert_eq!((-1i128).zero_widen().cast_unsigned(), (u128::MAX).widen());
 }
 
 #[test]
@@ -327,12 +327,12 @@ fn i256_shifts() {
 #[test]
 fn div_u256_by_u128() {
     for j in i8::MIN..=i8::MAX {
-        let y: u128 = (j as i128).rotate_right(4).unsigned();
+        let y: u128 = (j as i128).rotate_right(4).cast_unsigned();
         if y == 0 {
             continue;
         }
         for i in i8::MIN..=i8::MAX {
-            let x: u128 = (i as i128).rotate_right(4).unsigned();
+            let x: u128 = (i as i128).rotate_right(4).cast_unsigned();
             let xy = x.widen_mul(y);
             assert_eq!(xy.checked_narrowing_div_rem(y), Some((x, 0)));
             if y != 1 {

--- a/libm/src/math/support/float_traits.rs
+++ b/libm/src/math/support/float_traits.rs
@@ -105,7 +105,7 @@ pub trait Float:
     /// Returns `self` transmuted to `Self::SignedInt`
     #[allow(dead_code)]
     fn to_bits_signed(self) -> Self::SignedInt {
-        self.to_bits().signed()
+        self.to_bits().cast_signed()
     }
 
     /// Check bitwise equality.
@@ -173,7 +173,7 @@ pub trait Float:
 
     /// Extract the exponent and adjust it for bias, not accounting for subnormals or zero.
     fn exp_unbiased(self) -> i32 {
-        self.ex().signed() - (Self::EXP_BIAS as i32)
+        self.ex().cast_signed() - (Self::EXP_BIAS as i32)
     }
 
     /// Returns the significand with no implicit bit (or the "fractional" part)

--- a/libm/src/math/support/int_traits.rs
+++ b/libm/src/math/support/int_traits.rs
@@ -76,8 +76,8 @@ pub trait Int:
     + CastInto<u8>
     + CastInto<usize>
 {
-    fn signed(self) -> OtherSign<Self::Unsigned>;
-    fn unsigned(self) -> Self::Unsigned;
+    fn cast_signed(self) -> OtherSign<Self::Unsigned>;
+    fn cast_unsigned(self) -> Self::Unsigned;
     fn from_unsigned(unsigned: Self::Unsigned) -> Self;
     fn abs(self) -> Self;
     fn unsigned_abs(self) -> Self::Unsigned;
@@ -117,7 +117,7 @@ macro_rules! int_impl_common {
         }
 
         fn logical_shr(self, other: u32) -> Self {
-            Self::from_unsigned(self.unsigned().wrapping_shr(other))
+            Self::from_unsigned(self.cast_unsigned().wrapping_shr(other))
         }
 
         fn is_zero(self) -> bool {
@@ -215,11 +215,11 @@ macro_rules! int_impl {
         }
 
         impl Int for $uty {
-            fn signed(self) -> $ity {
+            fn cast_signed(self) -> $ity {
                 self as $ity
             }
 
-            fn unsigned(self) -> Self {
+            fn cast_unsigned(self) -> Self {
                 self
             }
 
@@ -258,11 +258,11 @@ macro_rules! int_impl {
         }
 
         impl Int for $ity {
-            fn signed(self) -> Self {
+            fn cast_signed(self) -> Self {
                 self
             }
 
-            fn unsigned(self) -> $uty {
+            fn cast_unsigned(self) -> $uty {
                 self as $uty
             }
 


### PR DESCRIPTION
Rename to match the methods that were stabilized in 1.87. Also applies to `unsigned` and `cast_unsigned`.