### PR TITLE
ci: use CARGO_TARGET_DIR instead of .dockerenv for nextest config

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -166,7 +166,7 @@ else
         cmd=(cargo nextest run --max-fail=10)
 
         # Workaround for https://github.com/nextest-rs/nextest/issues/2066
-        if [ -f /.dockerenv ]; then
+        if [ -n "${CARGO_TARGET_DIR:-}" ]; then
             cfg_file="/tmp/nextest-config.toml"
             echo "[store]" >> "$cfg_file"
             echo "dir = \"$CARGO_TARGET_DIR/nextest\"" >> "$cfg_file"


### PR DESCRIPTION
The .dockerenv check was a workaround for Docker CI where the checkout is mounted read-only. However, its presence does not reliably indicate that the filesystem is unwritable.

Use CARGO_TARGET_DIR as the condition instead, which directly captures when a custom writable target directory is in use and avoids false assumptions.