### PR TITLE
test: Cover compiler-builtins int to float conversion in libm-test

### DIFF
--- a/crates/libm-macros/src/shared.rs
+++ b/crates/libm-macros/src/shared.rs
@@ -111,6 +111,7 @@ const ALL_OPERATIONS_NESTED: &[NestedOp] = &[
         fn_list: &["powif128"],
         scope: OpScope::BuiltinsPublic,
     },
+    /* Comparison */
     NestedOp {
         rust_sig: Signature {
             args: &[Ty::F16, Ty::F16],
@@ -161,6 +162,7 @@ const ALL_OPERATIONS_NESTED: &[NestedOp] = &[
         ],
         scope: OpScope::BuiltinsPublic,
     },
+    /* conversion */
     NestedOp {
         rust_sig: Signature {
             args: &[Ty::F16],
@@ -429,6 +431,168 @@ const ALL_OPERATIONS_NESTED: &[NestedOp] = &[
         },
         c_sig: None,
         fn_list: &["ftoi_f128_u128"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I32],
+            returns: &[Ty::F32],
+        },
+        c_sig: None,
+        fn_list: &["itof_i32_f32"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I64],
+            returns: &[Ty::F32],
+        },
+        c_sig: None,
+        fn_list: &["itof_i64_f32"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I128],
+            returns: &[Ty::F32],
+        },
+        c_sig: None,
+        fn_list: &["itof_i128_f32"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I32],
+            returns: &[Ty::F64],
+        },
+        c_sig: None,
+        fn_list: &["itof_i32_f64"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I64],
+            returns: &[Ty::F64],
+        },
+        c_sig: None,
+        fn_list: &["itof_i64_f64"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I128],
+            returns: &[Ty::F64],
+        },
+        c_sig: None,
+        fn_list: &["itof_i128_f64"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I32],
+            returns: &[Ty::F128],
+        },
+        c_sig: None,
+        fn_list: &["itof_i32_f128"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I64],
+            returns: &[Ty::F128],
+        },
+        c_sig: None,
+        fn_list: &["itof_i64_f128"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I128],
+            returns: &[Ty::F128],
+        },
+        c_sig: None,
+        fn_list: &["itof_i128_f128"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U32],
+            returns: &[Ty::F32],
+        },
+        c_sig: None,
+        fn_list: &["itof_u32_f32"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U64],
+            returns: &[Ty::F32],
+        },
+        c_sig: None,
+        fn_list: &["itof_u64_f32"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U128],
+            returns: &[Ty::F32],
+        },
+        c_sig: None,
+        fn_list: &["itof_u128_f32"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U32],
+            returns: &[Ty::F64],
+        },
+        c_sig: None,
+        fn_list: &["itof_u32_f64"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U64],
+            returns: &[Ty::F64],
+        },
+        c_sig: None,
+        fn_list: &["itof_u64_f64"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U128],
+            returns: &[Ty::F64],
+        },
+        c_sig: None,
+        fn_list: &["itof_u128_f64"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U32],
+            returns: &[Ty::F128],
+        },
+        c_sig: None,
+        fn_list: &["itof_u32_f128"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U64],
+            returns: &[Ty::F128],
+        },
+        c_sig: None,
+        fn_list: &["itof_u64_f128"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U128],
+            returns: &[Ty::F128],
+        },
+        c_sig: None,
+        fn_list: &["itof_u128_f128"],
         scope: OpScope::BuiltinsPublic,
     },
     /*******************

--- a/crates/util/src/main.rs
+++ b/crates/util/src/main.rs
@@ -309,6 +309,31 @@ impl_parse_tuple!(f64);
 #[cfg(f128_enabled)]
 impl_parse_tuple_via_rug!(f128);
 
+macro_rules! impl_parse_tuple_int {
+    ($ty:ty) => {
+        impl ParseTuple for ($ty,) {
+            fn parse(input: &[&str]) -> Self {
+                assert_eq!(input.len(), 1, "expected a single argument, got {input:?}");
+                (parse(input, 0),)
+            }
+        }
+
+        impl FromStrRadix for $ty {
+            fn from_str_radix(s: &str, radix: u32) -> Result<Self, ParseIntError> {
+                let s = strip_radix_prefix(s, radix);
+                <$ty>::from_str_radix(s, radix)
+            }
+        }
+    };
+}
+
+impl_parse_tuple_int!(i32);
+impl_parse_tuple_int!(i64);
+impl_parse_tuple_int!(i128);
+impl_parse_tuple_int!(u32);
+impl_parse_tuple_int!(u64);
+impl_parse_tuple_int!(u128);
+
 /// Try to parse the number, printing a nice message on failure.
 fn parse<T: FromStr + FromStrRadix>(input: &[&str], idx: usize) -> T {
     let s = input[idx];
@@ -353,13 +378,6 @@ where
 
 trait FromStrRadix: Sized {
     fn from_str_radix(s: &str, radix: u32) -> Result<Self, ParseIntError>;
-}
-
-impl FromStrRadix for i32 {
-    fn from_str_radix(s: &str, radix: u32) -> Result<Self, ParseIntError> {
-        let s = strip_radix_prefix(s, radix);
-        i32::from_str_radix(s, radix)
-    }
 }
 
 #[cfg(f16_enabled)]

--- a/libm-test/src/builtins_wrapper.rs
+++ b/libm-test/src/builtins_wrapper.rs
@@ -186,3 +186,28 @@ cb_op!(conv, __fixunstfsi, ftoi_f128_u32, (a: f128) -> u32);
 cb_op!(conv, __fixunstfdi, ftoi_f128_u64, (a: f128) -> u64);
 #[cfg(f128_enabled)]
 cb_op!(conv, __fixunstfti, ftoi_f128_u128, (a: f128) -> u128);
+
+cb_op!(conv, __floatsisf, itof_i32_f32, (a: i32) -> f32);
+cb_op!(conv, __floatdisf, itof_i64_f32, (a: i64) -> f32);
+cb_op!(conv, __floattisf, itof_i128_f32, (a: i128) -> f32);
+cb_op!(conv, __floatsidf, itof_i32_f64, (a: i32) -> f64);
+cb_op!(conv, __floatdidf, itof_i64_f64, (a: i64) -> f64);
+cb_op!(conv, __floattidf, itof_i128_f64, (a: i128) -> f64);
+#[cfg(f128_enabled)]
+cb_op!(conv, __floatsitf, itof_i32_f128, (a: i32) -> f128);
+#[cfg(f128_enabled)]
+cb_op!(conv, __floatditf, itof_i64_f128, (a: i64) -> f128);
+#[cfg(f128_enabled)]
+cb_op!(conv, __floattitf, itof_i128_f128, (a: i128) -> f128);
+cb_op!(conv, __floatunsisf, itof_u32_f32, (a: u32) -> f32);
+cb_op!(conv, __floatundisf, itof_u64_f32, (a: u64) -> f32);
+cb_op!(conv, __floatuntisf, itof_u128_f32, (a: u128) -> f32);
+cb_op!(conv, __floatunsidf, itof_u32_f64, (a: u32) -> f64);
+cb_op!(conv, __floatundidf, itof_u64_f64, (a: u64) -> f64);
+cb_op!(conv, __floatuntidf, itof_u128_f64, (a: u128) -> f64);
+#[cfg(f128_enabled)]
+cb_op!(conv, __floatunsitf, itof_u32_f128, (a: u32) -> f128);
+#[cfg(f128_enabled)]
+cb_op!(conv, __floatunditf, itof_u64_f128, (a: u64) -> f128);
+#[cfg(f128_enabled)]
+cb_op!(conv, __floatuntitf, itof_u128_f128, (a: u128) -> f128);

--- a/libm-test/src/domain.rs
+++ b/libm-test/src/domain.rs
@@ -244,6 +244,7 @@ pub fn get_domain<F: Float, I: Int>(
         BaseName::Extend => &EitherPrim::UNBOUNDED1[..],
         BaseName::Narrow => &EitherPrim::UNBOUNDED1[..],
         BaseName::Ftoi => &EitherPrim::UNBOUNDED1[..],
+        BaseName::Itof => &EitherPrim::UNBOUNDED1[..],
 
         // Math functions
         BaseName::Acos => &EitherPrim::INVERSE_TRIG_PERIODIC[..],

--- a/libm-test/src/generate/case_list.rs
+++ b/libm-test/src/generate/case_list.rs
@@ -390,6 +390,84 @@ fn ftoi_f128_u128_cases() -> Vec<TestCase<op::ftoi_f128_u128::Routine>> {
     vec![]
 }
 
+fn itof_i32_f32_cases() -> Vec<TestCase<op::itof_i32_f32::Routine>> {
+    vec![]
+}
+
+fn itof_i64_f32_cases() -> Vec<TestCase<op::itof_i64_f32::Routine>> {
+    vec![]
+}
+
+fn itof_i128_f32_cases() -> Vec<TestCase<op::itof_i128_f32::Routine>> {
+    vec![]
+}
+
+fn itof_i32_f64_cases() -> Vec<TestCase<op::itof_i32_f64::Routine>> {
+    vec![]
+}
+
+fn itof_i64_f64_cases() -> Vec<TestCase<op::itof_i64_f64::Routine>> {
+    vec![]
+}
+
+fn itof_i128_f64_cases() -> Vec<TestCase<op::itof_i128_f64::Routine>> {
+    vec![]
+}
+
+#[cfg(f128_enabled)]
+fn itof_i32_f128_cases() -> Vec<TestCase<op::itof_i32_f128::Routine>> {
+    vec![]
+}
+
+#[cfg(f128_enabled)]
+fn itof_i64_f128_cases() -> Vec<TestCase<op::itof_i64_f128::Routine>> {
+    vec![]
+}
+
+#[cfg(f128_enabled)]
+fn itof_i128_f128_cases() -> Vec<TestCase<op::itof_i128_f128::Routine>> {
+    vec![]
+}
+
+fn itof_u32_f32_cases() -> Vec<TestCase<op::itof_u32_f32::Routine>> {
+    vec![]
+}
+
+fn itof_u64_f32_cases() -> Vec<TestCase<op::itof_u64_f32::Routine>> {
+    vec![]
+}
+
+fn itof_u128_f32_cases() -> Vec<TestCase<op::itof_u128_f32::Routine>> {
+    vec![]
+}
+
+fn itof_u32_f64_cases() -> Vec<TestCase<op::itof_u32_f64::Routine>> {
+    vec![]
+}
+
+fn itof_u64_f64_cases() -> Vec<TestCase<op::itof_u64_f64::Routine>> {
+    vec![]
+}
+
+fn itof_u128_f64_cases() -> Vec<TestCase<op::itof_u128_f64::Routine>> {
+    vec![]
+}
+
+#[cfg(f128_enabled)]
+fn itof_u32_f128_cases() -> Vec<TestCase<op::itof_u32_f128::Routine>> {
+    vec![]
+}
+
+#[cfg(f128_enabled)]
+fn itof_u64_f128_cases() -> Vec<TestCase<op::itof_u64_f128::Routine>> {
+    vec![]
+}
+
+#[cfg(f128_enabled)]
+fn itof_u128_f128_cases() -> Vec<TestCase<op::itof_u128_f128::Routine>> {
+    vec![]
+}
+
 /*******************
  * libm test cases *
  *******************/

--- a/libm-test/src/generate/edge_cases.rs
+++ b/libm-test/src/generate/edge_cases.rs
@@ -298,6 +298,28 @@ impl_edge_case_input!(f64);
 #[cfg(f128_enabled)]
 impl_edge_case_input!(f128);
 
+macro_rules! impl_edge_case_input_int {
+    ($ity:ty) => {
+        impl<Op> EdgeCaseInput<Op> for ($ity,)
+        where
+            Op: MathOp<RustArgs = Self>,
+        {
+            fn get_cases(ctx: &CheckCtx) -> (impl Iterator<Item = Self>, u64) {
+                let (iter0, steps0) = int_edge_cases(ctx, 0);
+                let iter0 = iter0.map(|v| (v,));
+                (iter0, steps0)
+            }
+        }
+    };
+}
+
+impl_edge_case_input_int!(i32);
+impl_edge_case_input_int!(i64);
+impl_edge_case_input_int!(i128);
+impl_edge_case_input_int!(u32);
+impl_edge_case_input_int!(u64);
+impl_edge_case_input_int!(u128);
+
 pub fn get_test_cases<Op>(
     ctx: &CheckCtx,
 ) -> (impl Iterator<Item = Op::RustArgs> + Send + use<'_, Op>, u64)

--- a/libm-test/src/generate/random.rs
+++ b/libm-test/src/generate/random.rs
@@ -2,7 +2,8 @@ use std::env;
 use std::ops::RangeInclusive;
 use std::sync::LazyLock;
 
-use libm::support::Float;
+use libm::support::{Float, Int};
+use rand::distr::uniform::SampleUniform;
 use rand::distr::{Alphanumeric, StandardUniform};
 use rand::prelude::Distribution;
 use rand::{RngExt, SeedableRng};
@@ -10,6 +11,7 @@ use rand_chacha::ChaCha8Rng;
 
 use super::KnownSize;
 use crate::CheckCtx;
+use crate::num::full_range;
 use crate::run_cfg::{int_range, iteration_count};
 
 pub(crate) const SEED_ENV: &str = "LIBM_SEED";
@@ -43,9 +45,12 @@ where
 }
 
 /// Generate a sequence of deterministically random `i32`s within a specified range.
-fn random_ints(count: u64, range: RangeInclusive<i32>) -> impl Iterator<Item = i32> {
+fn random_ints<I>(count: u64, range: RangeInclusive<I>) -> impl Iterator<Item = I>
+where
+    I: Int + SampleUniform,
+{
     let mut rng = ChaCha8Rng::from_seed(*SEED);
-    (0..count).map(move |_| rng.random_range::<i32, _>(range.clone()))
+    (0..count).map(move |_| rng.random_range::<I, _>(range.clone()))
 }
 
 macro_rules! impl_random_input {
@@ -86,7 +91,7 @@ macro_rules! impl_random_input {
             fn get_cases(ctx: &CheckCtx) -> (impl Iterator<Item = Self>, u64) {
                 let count0 = iteration_count(ctx, 0);
                 let count1 = iteration_count(ctx, 1);
-                let range0 = int_range(ctx, 0);
+                let range0 = int_range::<i32>(ctx, 0).unwrap_or(full_range());
                 let iter = random_ints(count0, range0)
                     .flat_map(move |f1: i32| random_floats(count1).map(move |f2: $fty| (f1, f2)));
                 (iter, count0 * count1)
@@ -97,7 +102,7 @@ macro_rules! impl_random_input {
             fn get_cases(ctx: &CheckCtx) -> (impl Iterator<Item = Self>, u64) {
                 let count0 = iteration_count(ctx, 0);
                 let count1 = iteration_count(ctx, 1);
-                let range1 = int_range(ctx, 1);
+                let range1 = int_range::<i32>(ctx, 1).unwrap_or(full_range());
                 let iter = random_floats(count0).flat_map(move |f1: $fty| {
                     random_ints(count1, range1.clone()).map(move |f2: i32| (f1, f2))
                 });
@@ -113,6 +118,26 @@ impl_random_input!(f32);
 impl_random_input!(f64);
 #[cfg(f128_enabled)]
 impl_random_input!(f128);
+
+macro_rules! impl_random_input_int {
+    ($ity:ty) => {
+        impl RandomInput for ($ity,) {
+            fn get_cases(ctx: &CheckCtx) -> (impl Iterator<Item = Self>, u64) {
+                let count = iteration_count(ctx, 0);
+                let range = int_range::<$ity>(ctx, 0).unwrap_or(full_range());
+                let iter = random_ints(count, range).map(|f: $ity| (f,));
+                (iter, count)
+            }
+        }
+    };
+}
+
+impl_random_input_int!(i32);
+impl_random_input_int!(i64);
+impl_random_input_int!(i128);
+impl_random_input_int!(u32);
+impl_random_input_int!(u64);
+impl_random_input_int!(u128);
 
 /// Create a test case iterator.
 pub fn get_test_cases<RustArgs: RandomInput>(

--- a/libm-test/src/generate/spaced.rs
+++ b/libm-test/src/generate/spaced.rs
@@ -1,9 +1,10 @@
 use std::fmt;
 use std::ops::RangeInclusive;
 
-use libm::support::{Float, MinInt};
+use libm::support::{Float, Int, MinInt};
 
 use crate::domain::get_domain;
+use crate::num::full_range;
 use crate::run_cfg::{int_range, iteration_count};
 use crate::{Arg0, Arg1, Arg2, CheckCtx, MathOp, linear_ints, logspace};
 
@@ -69,7 +70,14 @@ fn value_count<F: Float>() -> Option<u64>
 where
     u64: TryFrom<F::Int>,
 {
-    u64::try_from(F::Int::MAX)
+    value_count_int::<F::Int>()
+}
+
+fn value_count_int<I: Int>() -> Option<u64>
+where
+    u64: TryFrom<I::Unsigned>,
+{
+    u64::try_from(I::MAX.abs_diff(I::MIN))
         .ok()
         .and_then(|max| max.checked_add(1))
 }
@@ -180,7 +188,7 @@ macro_rules! impl_spaced_input {
             Op: MathOp<RustArgs = Self>,
         {
             fn get_cases(ctx: &CheckCtx) -> (impl Iterator<Item = Self>, u64) {
-                let range0 = int_range(ctx, 0);
+                let range0 = int_range(ctx, 0).unwrap_or(full_range());
                 let max_steps0 = iteration_count(ctx, 0);
                 let max_steps1 = iteration_count(ctx, 1);
                 match value_count::<Arg1<Op>>() {
@@ -211,7 +219,7 @@ macro_rules! impl_spaced_input {
         {
             fn get_cases(ctx: &CheckCtx) -> (impl Iterator<Item = Self>, u64) {
                 let max_steps0 = iteration_count(ctx, 0);
-                let range1 = int_range(ctx, 1);
+                let range1 = int_range(ctx, 1).unwrap_or(full_range());
                 let max_steps1 = iteration_count(ctx, 1);
                 match value_count::<Arg0<Op>>() {
                     Some(count0) if count0 <= max_steps0 => {
@@ -244,6 +252,38 @@ impl_spaced_input!(f32);
 impl_spaced_input!(f64);
 #[cfg(f128_enabled)]
 impl_spaced_input!(f128);
+
+macro_rules! impl_spaced_input_int {
+    ($ity:ty) => {
+        impl<Op> SpacedInput<Op> for ($ity,)
+        where
+            Op: MathOp<RustArgs = Self>,
+        {
+            fn get_cases(ctx: &CheckCtx) -> (impl Iterator<Item = Self>, u64) {
+                let range = int_range(ctx, 0).unwrap_or(full_range());
+                let max_steps0 = iteration_count(ctx, 0);
+                match value_count_int::<Arg0<Op>>() {
+                    Some(steps0) if steps0 <= max_steps0 => {
+                        let iter0 = range.map(|v| (v,));
+                        (EitherIter::A(iter0), steps0)
+                    }
+                    _ => {
+                        let (iter0, steps0) = linear_ints::<Arg0<Op>>(range, max_steps0);
+                        let iter0 = iter0.map(|v| (v,));
+                        (EitherIter::B(iter0), steps0)
+                    }
+                }
+            }
+        }
+    };
+}
+
+impl_spaced_input_int!(i32);
+impl_spaced_input_int!(i64);
+impl_spaced_input_int!(i128);
+impl_spaced_input_int!(u32);
+impl_spaced_input_int!(u64);
+impl_spaced_input_int!(u128);
 
 /// Create a test case iterator for extensive inputs. Also returns the total test case count.
 pub fn get_test_cases<Op>(

--- a/libm-test/src/mpfloat.rs
+++ b/libm-test/src/mpfloat.rs
@@ -213,6 +213,24 @@ libm_macros::for_each_function! {
         ilogbf,
         ilogbf128,
         ilogbf16,
+        itof_i128_f128,
+        itof_i128_f32,
+        itof_i128_f64,
+        itof_i32_f128,
+        itof_i32_f32,
+        itof_i32_f64,
+        itof_i64_f128,
+        itof_i64_f32,
+        itof_i64_f64,
+        itof_u128_f128,
+        itof_u128_f32,
+        itof_u128_f64,
+        itof_u32_f128,
+        itof_u32_f32,
+        itof_u32_f64,
+        itof_u64_f128,
+        itof_u64_f32,
+        itof_u64_f64,
         jn,
         jnf,
         ldexp,
@@ -828,7 +846,7 @@ macro_rules! impl_extend_trunc {
     };
 }
 
-macro_rules! impl_ftoi {
+macro_rules! impl_ftoi_itof {
     ($fty:ty, $ity:ty) => {
         paste::paste! {
             impl MpOp for crate::op::[<ftoi_ $fty _ $ity>]::Routine {
@@ -851,6 +869,19 @@ macro_rules! impl_ftoi {
                             Self::RustRet::MAX
                         }
                     })
+                }
+            }
+
+            impl MpOp for crate::op::[<itof_ $ity _ $fty>]::Routine {
+                type MpTy = MpFloat;
+
+                fn new_mp() -> Self::MpTy {
+                    new_mpfloat::<Self::RustRet>()
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    this.assign(input.0);
+                    prep_retval::<Self::RustRet>(this, Ordering::Equal)
                 }
             }
         }
@@ -885,30 +916,30 @@ impl_extend_trunc!(f32, f128);
 #[cfg(f128_enabled)]
 impl_extend_trunc!(f64, f128);
 
-impl_ftoi!(f32, i32);
-impl_ftoi!(f32, i64);
-impl_ftoi!(f32, i128);
-impl_ftoi!(f32, u32);
-impl_ftoi!(f32, u64);
-impl_ftoi!(f32, u128);
-impl_ftoi!(f64, i32);
-impl_ftoi!(f64, i64);
-impl_ftoi!(f64, i128);
-impl_ftoi!(f64, u32);
-impl_ftoi!(f64, u64);
-impl_ftoi!(f64, u128);
+impl_ftoi_itof!(f32, i32);
+impl_ftoi_itof!(f32, i64);
+impl_ftoi_itof!(f32, i128);
+impl_ftoi_itof!(f32, u32);
+impl_ftoi_itof!(f32, u64);
+impl_ftoi_itof!(f32, u128);
+impl_ftoi_itof!(f64, i32);
+impl_ftoi_itof!(f64, i64);
+impl_ftoi_itof!(f64, i128);
+impl_ftoi_itof!(f64, u32);
+impl_ftoi_itof!(f64, u64);
+impl_ftoi_itof!(f64, u128);
 #[cfg(f128_enabled)]
-impl_ftoi!(f128, i32);
+impl_ftoi_itof!(f128, i32);
 #[cfg(f128_enabled)]
-impl_ftoi!(f128, i64);
+impl_ftoi_itof!(f128, i64);
 #[cfg(f128_enabled)]
-impl_ftoi!(f128, i128);
+impl_ftoi_itof!(f128, i128);
 #[cfg(f128_enabled)]
-impl_ftoi!(f128, u32);
+impl_ftoi_itof!(f128, u32);
 #[cfg(f128_enabled)]
-impl_ftoi!(f128, u64);
+impl_ftoi_itof!(f128, u64);
 #[cfg(f128_enabled)]
-impl_ftoi!(f128, u128);
+impl_ftoi_itof!(f128, u128);
 
 // `lgamma_r` is not a simple suffix so we can't use the above macro.
 impl MpOp for crate::op::lgamma_r::Routine {

--- a/libm-test/src/num.rs
+++ b/libm-test/src/num.rs
@@ -1,6 +1,7 @@
 //! Helpful numeric operations.
 
 use std::cmp::min;
+use std::fmt;
 use std::ops::RangeInclusive;
 
 use libm::support::Float;
@@ -257,15 +258,20 @@ where
 }
 
 /// Returns an iterator of up to `steps` integers evenly distributed.
-pub fn linear_ints(
-    range: RangeInclusive<i32>,
+pub fn linear_ints<I>(
+    range: RangeInclusive<I>,
     steps: u64,
-) -> (impl Iterator<Item = i32> + Clone, u64) {
-    let steps = steps.checked_sub(1).unwrap();
-    let between = u64::from(range.start().abs_diff(*range.end()));
-    let spacing = i32::try_from((between / steps).max(1)).unwrap();
-    let steps = steps.min(between);
-    let mut x: i32 = *range.start();
+) -> (impl Iterator<Item = I> + Clone, u64)
+where
+    I: Int + TryFrom<u128, Error: fmt::Debug>,
+    u128: TryFrom<I::Unsigned, Error: fmt::Debug>,
+{
+    let spaces: u128 = steps.checked_sub(1).unwrap().into();
+    let between = u128::try_from(range.start().abs_diff(*range.end())).expect("out of u128 range");
+    let spacing = I::try_from((between / spaces).max(1)).unwrap();
+    let steps = spaces.min(between);
+    let steps = u64::try_from(steps).expect("> u64::MAX steps");
+    let mut x: I = *range.start();
     (
         (0..=steps).map(move |_| {
             let res = x;
@@ -276,6 +282,11 @@ pub fn linear_ints(
         }),
         steps + 1,
     )
+}
+
+/// `..` as a `RangeInclusive`.
+pub fn full_range<I: MinInt>() -> RangeInclusive<I> {
+    I::MIN..=I::MAX
 }
 
 #[cfg(test)]

--- a/libm-test/src/precision.rs
+++ b/libm-test/src/precision.rs
@@ -27,7 +27,7 @@ pub fn default_ulp(ctx: &CheckCtx) -> Option<u32> {
         Bn::Eq | Bn::Ne | Bn::Gt | Bn::Ge | Bn::Lt | Bn::Le | Bn::Unord | Bn::Ilogb => return None,
 
         // Convrsion operations must be precise.
-        BaseName::Extend | BaseName::Narrow | BaseName::Ftoi => 0,
+        Bn::Extend | Bn::Narrow | Bn::Ftoi | Bn::Itof => 0,
 
         // Operations that require exact results. This list should correlate with what we
         // have documented at <https://doc.rust-lang.org/std/primitive.f32.html>.
@@ -537,3 +537,10 @@ impl MaybeOverride<(f32, f32, f32)> for SpecialCase {}
 impl MaybeOverride<(f64, f64, f64)> for SpecialCase {}
 #[cfg(f128_enabled)]
 impl MaybeOverride<(f128, f128, f128)> for SpecialCase {}
+
+impl MaybeOverride<(i32,)> for SpecialCase {}
+impl MaybeOverride<(i64,)> for SpecialCase {}
+impl MaybeOverride<(i128,)> for SpecialCase {}
+impl MaybeOverride<(u32,)> for SpecialCase {}
+impl MaybeOverride<(u64,)> for SpecialCase {}
+impl MaybeOverride<(u128,)> for SpecialCase {}

--- a/libm-test/src/run_cfg.rs
+++ b/libm-test/src/run_cfg.rs
@@ -2,7 +2,7 @@
 
 use std::ops::RangeInclusive;
 use std::sync::LazyLock;
-use std::{env, str};
+use std::{env, fmt, str};
 
 use crate::generate::random::{SEED, SEED_ENV};
 use crate::{BaseName, Group, Identifier, test_log};
@@ -347,12 +347,23 @@ pub fn iteration_count(ctx: &CheckCtx, argnum: usize) -> u64 {
     ntests
 }
 
-/// Some tests require that an integer be kept within reasonable limits; generate that here.
-pub fn int_range(ctx: &CheckCtx, argnum: usize) -> RangeInclusive<i32> {
+/// Some tests require that an integer be kept within reasonable limits; if that is needed, retun
+/// a limited range.
+pub fn int_range<I>(ctx: &CheckCtx, argnum: usize) -> Option<RangeInclusive<I>>
+where
+    I: TryFrom<i32, Error: fmt::Debug>,
+{
     let t_env = TestEnv::from_env(ctx);
 
+    let argcount = ctx.fn_ident.math_op().rust_sig.args.len();
+    assert!(
+        argnum < argcount,
+        "requested argnum {argnum} of only {argcount} args"
+    );
+
+    // Use the whole range for most functions.
     if !matches!(ctx.base_name, BaseName::Jn | BaseName::Yn) {
-        return i32::MIN..=i32::MAX;
+        return None;
     }
 
     assert_eq!(
@@ -370,12 +381,14 @@ pub fn int_range(ctx: &CheckCtx, argnum: usize) -> RangeInclusive<i32> {
 
     let extensive_range = (-0xfff)..=0xfffff;
 
-    match ctx.gen_kind {
+    let ret = match ctx.gen_kind {
         _ if ctx.extensive => extensive_range,
         GeneratorKind::Spaced | GeneratorKind::Random => non_extensive_range,
         GeneratorKind::EdgeCases => extensive_range,
         GeneratorKind::List => unimplemented!("shoudn't need range for {:?}", ctx.gen_kind),
-    }
+    };
+
+    Some(I::try_from(*ret.start()).unwrap()..=I::try_from(*ret.end()).unwrap())
 }
 
 /// For domain tests, limit how many asymptotes or specified check points we test.


### PR DESCRIPTION
Add the following to the test infrastructure:

* `itof_i32_f32`
* `itof_i64_f32`
* `itof_i128_f32`
* `itof_i32_f64`
* `itof_i64_f64`
* `itof_i128_f64`
* `itof_i32_f128`
* `itof_i64_f128`
* `itof_i128_f128`
* `itof_u32_f32`
* `itof_u64_f32`
* `itof_u128_f32`
* `itof_u32_f64`
* `itof_u64_f64`
* `itof_u128_f64`
* `itof_u32_f128`
* `itof_u64_f128`
* `itof_u128_f128`