### PR TITLE
test: Cover compiler-builtins integer bit ops in libm-test

### DIFF
--- a/crates/libm-macros/src/lib.rs
+++ b/crates/libm-macros/src/lib.rs
@@ -535,6 +535,7 @@ impl ToTokens for Ty {
             Ty::U32 => quote! { u32 },
             Ty::U64 => quote! { u64 },
             Ty::U128 => quote! { u128 },
+            Ty::USize => quote! { usize },
             Ty::Bool => quote! { bool },
             Ty::CInt => quote! { ::core::ffi::c_int },
             Ty::MutF16 => quote! { &'a mut f16 },

--- a/crates/libm-macros/src/shared.rs
+++ b/crates/libm-macros/src/shared.rs
@@ -595,6 +595,116 @@ const ALL_OPERATIONS_NESTED: &[NestedOp] = &[
         fn_list: &["itof_u128_f128"],
         scope: OpScope::BuiltinsPublic,
     },
+    /* int shifts */
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U32, Ty::U32],
+            returns: &[Ty::U32],
+        },
+        c_sig: None,
+        fn_list: &["ashl_u32", "lshr_u32"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U64, Ty::U32],
+            returns: &[Ty::U64],
+        },
+        c_sig: None,
+        fn_list: &["ashl_u64", "lshr_u64"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U128, Ty::U32],
+            returns: &[Ty::U128],
+        },
+        c_sig: None,
+        fn_list: &["ashl_u128", "lshr_u128"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I32, Ty::U32],
+            returns: &[Ty::I32],
+        },
+        c_sig: None,
+        fn_list: &["ashr_i32"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I64, Ty::U32],
+            returns: &[Ty::I64],
+        },
+        c_sig: None,
+        fn_list: &["ashr_i64"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I128, Ty::U32],
+            returns: &[Ty::I128],
+        },
+        c_sig: None,
+        fn_list: &["ashr_i128"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    /* int bitwise ops */
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U32],
+            returns: &[Ty::USize],
+        },
+        c_sig: None,
+        fn_list: &["leading_zeros_u32"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U64],
+            returns: &[Ty::USize],
+        },
+        c_sig: None,
+        fn_list: &["leading_zeros_u64"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U128],
+            returns: &[Ty::USize],
+        },
+        c_sig: None,
+        fn_list: &["leading_zeros_u128"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U32],
+            returns: &[Ty::USize],
+        },
+        c_sig: None,
+        fn_list: &["trailing_zeros_u32"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U64],
+            returns: &[Ty::USize],
+        },
+        c_sig: None,
+        fn_list: &["trailing_zeros_u64"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U128],
+            returns: &[Ty::USize],
+        },
+        c_sig: None,
+        fn_list: &["trailing_zeros_u128"],
+        scope: OpScope::BuiltinsPublic,
+    },
     /*******************
      * libm operations *
      *******************/
@@ -1098,6 +1208,7 @@ pub enum Ty {
     U32,
     U64,
     U128,
+    USize,
     Bool,
     CInt,
     MutF16,
@@ -1119,6 +1230,7 @@ impl Ty {
             Ty::F32 | Ty::I32 | Ty::U32 | Ty::MutF32 | Ty::MutI32 => 32,
             Ty::F64 | Ty::I64 | Ty::U64 | Ty::MutF64 => 64,
             Ty::F128 | Ty::I128 | Ty::U128 | Ty::MutF128 => 128,
+            Ty::USize => usize::BITS,
             // Assume we're not testing on a 16-bit system
             Ty::CInt | Ty::MutCInt => 32,
         }
@@ -1137,6 +1249,7 @@ impl Ty {
             | Ty::U32
             | Ty::U64
             | Ty::U128
+            | Ty::USize
             | Ty::Bool
             | Ty::CInt
             | Ty::MutI32
@@ -1160,6 +1273,7 @@ impl Ty {
             | Ty::U32
             | Ty::U64
             | Ty::U128
+            | Ty::USize
             | Ty::Bool
             | Ty::CInt
             | Ty::MutI32
@@ -1192,6 +1306,7 @@ impl fmt::Display for Ty {
             Ty::U32 => "u32",
             Ty::U64 => "u64",
             Ty::U128 => "u128",
+            Ty::USize => "usize",
             Ty::Bool => "bool",
             Ty::CInt => "::core::ffi::c_int",
             Ty::MutF16 => "&mut f16",

--- a/crates/util/src/main.rs
+++ b/crates/util/src/main.rs
@@ -318,6 +318,13 @@ macro_rules! impl_parse_tuple_int {
             }
         }
 
+        impl ParseTuple for ($ty, u32) {
+            fn parse(input: &[&str]) -> Self {
+                assert_eq!(input.len(), 2, "expected two arguments, got {input:?}");
+                (parse(input, 0), parse(input, 1))
+            }
+        }
+
         impl FromStrRadix for $ty {
             fn from_str_radix(s: &str, radix: u32) -> Result<Self, ParseIntError> {
                 let s = strip_radix_prefix(s, radix);

--- a/libm-test/src/builtins_wrapper.rs
+++ b/libm-test/src/builtins_wrapper.rs
@@ -11,6 +11,11 @@ macro_rules! cb_op {
             compiler_builtins::float::$mod::$cb_name($($arg),*)
         }
     };
+    (@int $mod:ident, $cb_name:ident, $new_name:ident, ($($arg:ident: $ArgTy:ty),*) -> $RetTy:ty) => {
+        pub fn $new_name($($arg: $ArgTy),*) -> $RetTy {
+            compiler_builtins::int::$mod::$cb_name($($arg),*)
+        }
+    };
 
     // Common signatures
     (@binop $ty:ty, $mod:ident, $cb_name:ident, $new_name:ident) => {
@@ -211,3 +216,22 @@ cb_op!(conv, __floatunsitf, itof_u32_f128, (a: u32) -> f128);
 cb_op!(conv, __floatunditf, itof_u64_f128, (a: u64) -> f128);
 #[cfg(f128_enabled)]
 cb_op!(conv, __floatuntitf, itof_u128_f128, (a: u128) -> f128);
+
+/* int ops */
+
+cb_op!(@int shift, __ashlsi3, ashl_u32, (a: u32, b: u32) -> u32);
+cb_op!(@int shift, __ashldi3, ashl_u64, (a: u64, b: u32) -> u64);
+cb_op!(@int shift, __ashlti3, ashl_u128, (a: u128, b: u32) -> u128);
+cb_op!(@int shift, __ashrsi3, ashr_i32, (a: i32, b: u32) -> i32);
+cb_op!(@int shift, __ashrdi3, ashr_i64, (a: i64, b: u32) -> i64);
+cb_op!(@int shift, __ashrti3, ashr_i128, (a: i128, b: u32) -> i128);
+cb_op!(@int shift, __lshrsi3, lshr_u32, (a: u32, b: u32) -> u32);
+cb_op!(@int shift, __lshrdi3, lshr_u64, (a: u64, b: u32) -> u64);
+cb_op!(@int shift, __lshrti3, lshr_u128, (a: u128, b: u32) -> u128);
+
+cb_op!(@int leading_zeros, __clzsi2, leading_zeros_u32, (a: u32) -> usize);
+cb_op!(@int leading_zeros, __clzdi2, leading_zeros_u64, (a: u64) -> usize);
+cb_op!(@int leading_zeros, __clzti2, leading_zeros_u128, (a: u128) -> usize);
+cb_op!(@int trailing_zeros, __ctzsi2, trailing_zeros_u32, (a: u32) -> usize);
+cb_op!(@int trailing_zeros, __ctzdi2, trailing_zeros_u64, (a: u64) -> usize);
+cb_op!(@int trailing_zeros, __ctzti2, trailing_zeros_u128, (a: u128) -> usize);

--- a/libm-test/src/domain.rs
+++ b/libm-test/src/domain.rs
@@ -246,6 +246,15 @@ pub fn get_domain<F: Float, I: Int>(
         BaseName::Ftoi => &EitherPrim::UNBOUNDED1[..],
         BaseName::Itof => &EitherPrim::UNBOUNDED1[..],
 
+        // Integer ops
+        // Shifts technically aren't unbounded, but its range is restricted elsewhere in
+        // our test generators.
+        BaseName::Ashl => &EitherPrim::UNBOUNDED2[..],
+        BaseName::Ashr => &EitherPrim::UNBOUNDED2[..],
+        BaseName::Lshr => &EitherPrim::UNBOUNDED2[..],
+        BaseName::LeadingZeros => &EitherPrim::UNBOUNDED1[..],
+        BaseName::TrailingZeros => &EitherPrim::UNBOUNDED1[..],
+
         // Math functions
         BaseName::Acos => &EitherPrim::INVERSE_TRIG_PERIODIC[..],
         BaseName::Acosh => &EitherPrim::ACOSH[..],

--- a/libm-test/src/generate/case_list.rs
+++ b/libm-test/src/generate/case_list.rs
@@ -468,6 +468,70 @@ fn itof_u128_f128_cases() -> Vec<TestCase<op::itof_u128_f128::Routine>> {
     vec![]
 }
 
+/* int shifts */
+
+fn ashl_u32_cases() -> Vec<TestCase<op::ashl_u32::Routine>> {
+    vec![]
+}
+
+fn ashl_u64_cases() -> Vec<TestCase<op::ashl_u64::Routine>> {
+    vec![]
+}
+
+fn ashl_u128_cases() -> Vec<TestCase<op::ashl_u128::Routine>> {
+    vec![]
+}
+
+fn ashr_i32_cases() -> Vec<TestCase<op::ashr_i32::Routine>> {
+    vec![]
+}
+
+fn ashr_i64_cases() -> Vec<TestCase<op::ashr_i64::Routine>> {
+    vec![]
+}
+
+fn ashr_i128_cases() -> Vec<TestCase<op::ashr_i128::Routine>> {
+    vec![]
+}
+
+fn lshr_u32_cases() -> Vec<TestCase<op::lshr_u32::Routine>> {
+    vec![]
+}
+
+fn lshr_u64_cases() -> Vec<TestCase<op::lshr_u64::Routine>> {
+    vec![]
+}
+
+fn lshr_u128_cases() -> Vec<TestCase<op::lshr_u128::Routine>> {
+    vec![]
+}
+
+/* int bitwise ops */
+
+fn leading_zeros_u32_cases() -> Vec<TestCase<op::leading_zeros_u32::Routine>> {
+    vec![]
+}
+
+fn leading_zeros_u64_cases() -> Vec<TestCase<op::leading_zeros_u64::Routine>> {
+    vec![]
+}
+
+fn leading_zeros_u128_cases() -> Vec<TestCase<op::leading_zeros_u128::Routine>> {
+    vec![]
+}
+
+fn trailing_zeros_u32_cases() -> Vec<TestCase<op::trailing_zeros_u32::Routine>> {
+    vec![]
+}
+
+fn trailing_zeros_u64_cases() -> Vec<TestCase<op::trailing_zeros_u64::Routine>> {
+    vec![]
+}
+
+fn trailing_zeros_u128_cases() -> Vec<TestCase<op::trailing_zeros_u128::Routine>> {
+    vec![]
+}
+
 /*******************
  * libm test cases *
  *******************/

--- a/libm-test/src/generate/edge_cases.rs
+++ b/libm-test/src/generate/edge_cases.rs
@@ -169,6 +169,22 @@ where
         int_count_around((emin_sn - emax).cast(), near_points, &mut values);
     }
 
+    if matches!(
+        ctx.base_name,
+        BaseName::Ashl | BaseName::Ashr | BaseName::Lshr
+    ) {
+        // Don't test shift values that are allowed to invoke UB.
+        let max = match ctx.fn_ident.math_op().rust_sig.args[0] {
+            Ty::U32 | Ty::I32 => 31,
+            Ty::U64 | Ty::I64 => 63,
+            Ty::U128 | Ty::I128 => 127,
+            ty => panic!("unexpected type {ty}"),
+        };
+        let max: I = max.cast();
+        int_count_around(max, near_points, &mut values);
+        values.retain(|v| *v <= max);
+    }
+
     values.sort();
     values.dedup();
     let count = values.len().try_into().unwrap();
@@ -308,6 +324,20 @@ macro_rules! impl_edge_case_input_int {
                 let (iter0, steps0) = int_edge_cases(ctx, 0);
                 let iter0 = iter0.map(|v| (v,));
                 (iter0, steps0)
+            }
+        }
+
+        impl<Op> EdgeCaseInput<Op> for ($ity, u32)
+        where
+            Op: MathOp<RustArgs = Self>,
+        {
+            fn get_cases(ctx: &CheckCtx) -> (impl Iterator<Item = Self>, u64) {
+                let (iter0, steps0) = int_edge_cases(ctx, 0);
+                let (iter1, steps1) = int_edge_cases(ctx, 1);
+                let iter =
+                    iter0.flat_map(move |first| iter1.clone().map(move |second| (first, second)));
+                let count = steps0.checked_mul(steps1).unwrap();
+                (iter, count)
             }
         }
     };

--- a/libm-test/src/generate/random.rs
+++ b/libm-test/src/generate/random.rs
@@ -129,6 +129,19 @@ macro_rules! impl_random_input_int {
                 (iter, count)
             }
         }
+
+        impl RandomInput for ($ity, u32) {
+            fn get_cases(ctx: &CheckCtx) -> (impl Iterator<Item = Self>, u64) {
+                let count0 = iteration_count(ctx, 0);
+                let count1 = iteration_count(ctx, 1);
+                let range0 = int_range::<$ity>(ctx, 1).unwrap_or(full_range());
+                let range1 = int_range::<u32>(ctx, 1).unwrap_or(full_range());
+                let iter = random_ints(count0, range0).flat_map(move |f1: $ity| {
+                    random_ints(count1, range1.clone()).map(move |f2: u32| (f1, f2))
+                });
+                (iter, count0 * count1)
+            }
+        }
     };
 }
 

--- a/libm-test/src/generate/spaced.rs
+++ b/libm-test/src/generate/spaced.rs
@@ -275,6 +275,35 @@ macro_rules! impl_spaced_input_int {
                 }
             }
         }
+
+        impl<Op> SpacedInput<Op> for ($ity, u32)
+        where
+            Op: MathOp<RustArgs = Self>,
+        {
+            fn get_cases(ctx: &CheckCtx) -> (impl Iterator<Item = Self>, u64) {
+                let range0 = int_range(ctx, 0).unwrap_or(full_range());
+                let range1 = int_range(ctx, 1).unwrap_or(full_range());
+                let max_steps0 = iteration_count(ctx, 0);
+                let max_steps1 = iteration_count(ctx, 0);
+                match value_count_int::<Arg0<Op>>() {
+                    Some(count) if count <= max_steps0 && count < max_steps1 => {
+                        let iter = range0.flat_map(move |first| {
+                            range1.clone().map(move |second| (first, second))
+                        });
+                        (EitherIter::A(iter), count.checked_mul(count).unwrap())
+                    }
+                    _ => {
+                        let (iter0, steps0) = linear_ints::<Arg0<Op>>(range0, max_steps0);
+                        let (iter1, steps1) = linear_ints::<Arg1<Op>>(range1, max_steps1);
+                        let iter = iter0.flat_map(move |first| {
+                            iter1.clone().map(move |second| (first, second))
+                        });
+                        let count = steps0.checked_mul(steps1).unwrap();
+                        (EitherIter::B(iter), count)
+                    }
+                }
+            }
+        }
     };
 }
 

--- a/libm-test/src/mpfloat.rs
+++ b/libm-test/src/mpfloat.rs
@@ -6,12 +6,12 @@
 use std::cmp::Ordering;
 
 use rug::Assign;
-pub use rug::Float as MpFloat;
-use rug::az::{self, Az, CheckedCast};
+use rug::az::{self, Az, CheckedCast, WrappingAs};
 use rug::float::Round::Nearest;
 use rug::ops::{
     AddAssignRound, DivAssignRound, MulAssignRound, PowAssignRound, RemAssignRound, SubAssignRound,
 };
+pub use rug::{Float as MpFloat, Integer as MpInt};
 
 use crate::{Arg0, Arg1, Arg2, Float, MathOp, Ret0, Ret1};
 
@@ -139,6 +139,12 @@ libm_macros::for_each_function! {
         addf16,
         addf32,
         addf64,
+        ashl_u128,
+        ashl_u32,
+        ashl_u64,
+        ashr_i128,
+        ashr_i32,
+        ashr_i64,
         ceil,
         ceilf,
         ceilf128,
@@ -237,6 +243,9 @@ libm_macros::for_each_function! {
         ldexpf,
         ldexpf128,
         ldexpf16,
+        leading_zeros_u128,
+        leading_zeros_u32,
+        leading_zeros_u64,
         lef128,
         lef16,
         lef32,
@@ -245,6 +254,9 @@ libm_macros::for_each_function! {
         lgamma_r,
         lgammaf,
         lgammaf_r,
+        lshr_u128,
+        lshr_u32,
+        lshr_u64,
         ltf128,
         ltf16,
         ltf32,
@@ -294,6 +306,9 @@ libm_macros::for_each_function! {
         subf16,
         subf32,
         subf64,
+        trailing_zeros_u128,
+        trailing_zeros_u32,
+        trailing_zeros_u64,
         trunc,
         truncf,
         truncf128,
@@ -1021,3 +1036,94 @@ impl MpOp for crate::op::nextafterf::Routine {
         unimplemented!("nextafter does not yet have a MPFR operation");
     }
 }
+
+macro_rules! impl_int_ops {
+    ($ity:ty) => {
+        paste::paste! {
+            impl MpOp for crate::op::[<ashl_ $ity>]::Routine {
+                type MpTy = MpInt;
+
+                fn new_mp() -> Self::MpTy {
+                    MpInt::new()
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    assert!(input.1 < Arg0::<Self>::BITS, "got UB shift {}", input.1);
+                    this.assign(input.0);
+                    *this <<= input.1;
+                    (&*this).wrapping_as::<Arg0<Self>>()
+                }
+            }
+
+            impl MpOp for crate::op::[<lshr_ $ity>]::Routine {
+                type MpTy = MpInt;
+
+                fn new_mp() -> Self::MpTy {
+                    MpInt::new()
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    assert!(input.1 < Arg0::<Self>::BITS, "got UB shift {}", input.1);
+                    this.assign(input.0);
+                    *this >>= input.1;
+                    (&*this).wrapping_as::<Arg0<Self>>()
+                }
+            }
+
+            impl MpOp for crate::op::[<leading_zeros_ $ity>]::Routine {
+                type MpTy = MpInt;
+
+                fn new_mp() -> Self::MpTy {
+                    MpInt::new()
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    this.assign(input.0);
+                    (Arg0::<Self>::BITS - this.significant_bits()).try_into().unwrap()
+                }
+            }
+
+            impl MpOp for crate::op::[<trailing_zeros_ $ity>]::Routine {
+                type MpTy = MpInt;
+
+                fn new_mp() -> Self::MpTy {
+                    MpInt::new()
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    this.assign(input.0);
+                    this.find_one(0).unwrap_or(Arg0::<Self>::BITS).try_into().unwrap()
+                }
+            }
+        }
+    };
+}
+
+impl_int_ops!(u32);
+impl_int_ops!(u64);
+impl_int_ops!(u128);
+
+macro_rules! impl_signed_int_ops {
+    ($ity:ty) => {
+        paste::paste! {
+            impl MpOp for crate::op::[<ashr_ $ity>]::Routine {
+                type MpTy = MpInt;
+
+                fn new_mp() -> Self::MpTy {
+                    MpInt::new()
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    assert!(input.1 < Arg0::<Self>::BITS, "got UB shift {}", input.1);
+                    this.assign(input.0);
+                    *this >>= input.1;
+                    (&*this).wrapping_as::<Arg0<Self>>()
+                }
+            }
+        }
+    };
+}
+
+impl_signed_int_ops!(i32);
+impl_signed_int_ops!(i64);
+impl_signed_int_ops!(i128);

--- a/libm-test/src/precision.rs
+++ b/libm-test/src/precision.rs
@@ -24,7 +24,19 @@ pub fn default_ulp(ctx: &CheckCtx) -> Option<u32> {
         Bn::Powi => 1000,
 
         // Operations that only return non-float results
-        Bn::Eq | Bn::Ne | Bn::Gt | Bn::Ge | Bn::Lt | Bn::Le | Bn::Unord | Bn::Ilogb => return None,
+        Bn::Eq
+        | Bn::Ne
+        | Bn::Gt
+        | Bn::Ge
+        | Bn::Lt
+        | Bn::Le
+        | Bn::Unord
+        | Bn::Ilogb
+        | Bn::Ashl
+        | Bn::Ashr
+        | Bn::Lshr
+        | Bn::LeadingZeros
+        | Bn::TrailingZeros => return None,
 
         // Convrsion operations must be precise.
         Bn::Extend | Bn::Narrow | Bn::Ftoi | Bn::Itof => 0,
@@ -544,3 +556,9 @@ impl MaybeOverride<(i128,)> for SpecialCase {}
 impl MaybeOverride<(u32,)> for SpecialCase {}
 impl MaybeOverride<(u64,)> for SpecialCase {}
 impl MaybeOverride<(u128,)> for SpecialCase {}
+impl MaybeOverride<(i32, u32)> for SpecialCase {}
+impl MaybeOverride<(i64, u32)> for SpecialCase {}
+impl MaybeOverride<(i128, u32)> for SpecialCase {}
+impl MaybeOverride<(u32, u32)> for SpecialCase {}
+impl MaybeOverride<(u64, u32)> for SpecialCase {}
+impl MaybeOverride<(u128, u32)> for SpecialCase {}

--- a/libm-test/src/run_cfg.rs
+++ b/libm-test/src/run_cfg.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 use std::{env, fmt, str};
 
 use crate::generate::random::{SEED, SEED_ENV};
-use crate::{BaseName, Group, Identifier, test_log};
+use crate::{BaseName, Group, Identifier, Ty, test_log};
 
 /// The environment variable indicating which extensive tests should be run.
 pub const EXTENSIVE_ENV: &str = "LIBM_EXTENSIVE_TESTS";
@@ -361,6 +361,22 @@ where
         "requested argnum {argnum} of only {argcount} args"
     );
 
+    // Shift operations can have UB if the shift value exceeds their range
+    if matches!(
+        ctx.base_name,
+        BaseName::Ashl | BaseName::Ashr | BaseName::Lshr
+    ) && argnum == 1
+    {
+        let max = match ctx.fn_ident.math_op().rust_sig.args[0] {
+            Ty::U32 | Ty::I32 => 31,
+            Ty::U64 | Ty::I64 => 63,
+            Ty::U128 | Ty::I128 => 127,
+            ty => panic!("unexpected type {ty}"),
+        };
+
+        return Some(map_range(0..=max));
+    }
+
     // Use the whole range for most functions.
     if !matches!(ctx.base_name, BaseName::Jn | BaseName::Yn) {
         return None;
@@ -388,7 +404,14 @@ where
         GeneratorKind::List => unimplemented!("shoudn't need range for {:?}", ctx.gen_kind),
     };
 
-    Some(I::try_from(*ret.start()).unwrap()..=I::try_from(*ret.end()).unwrap())
+    Some(map_range(ret))
+}
+
+fn map_range<I>(r: RangeInclusive<i32>) -> RangeInclusive<I>
+where
+    I: TryFrom<i32, Error: fmt::Debug>,
+{
+    I::try_from(*r.start()).unwrap()..=I::try_from(*r.end()).unwrap()
 }
 
 /// For domain tests, limit how many asymptotes or specified check points we test.

--- a/libm-test/src/test_traits.rs
+++ b/libm-test/src/test_traits.rs
@@ -249,7 +249,7 @@ where
     Ok(())
 }
 
-impl_int!(u16, i16, u32, i32, u64, i64, u128, i128);
+impl_int!(u16, i16, u32, i32, u64, i64, u128, i128, usize);
 
 /* trait implementations for floats */
 


### PR DESCRIPTION
Add the following to the test infrastructure:

* `__ashlsi3`
* `__ashldi3`
* `__ashlti3`
* `__ashrsi3`
* `__ashrdi3`
* `__ashrti3`
* `__lshrsi3`
* `__lshrdi3`
* `__lshrti3`
* `__clzsi2`
* `__clzdi2`
* `__clzti2`
* `__ctzsi2`
* `__ctzdi2`
* `__ctzti2`