### PR TITLE
test: Cover compiler-builtins integer arithmetic in libm-test

### DIFF
--- a/crates/libm-macros/src/shared.rs
+++ b/crates/libm-macros/src/shared.rs
@@ -595,6 +595,157 @@ const ALL_OPERATIONS_NESTED: &[NestedOp] = &[
         fn_list: &["itof_u128_f128"],
         scope: OpScope::BuiltinsPublic,
     },
+    /* int arithmetic */
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I32, Ty::I32],
+            returns: &[Ty::I32],
+        },
+        c_sig: None,
+        fn_list: &["idiv_i32", "imod_i32"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I32, Ty::I32],
+            returns: &[Ty::I32, Ty::I32],
+        },
+        c_sig: None,
+        fn_list: &["idivmod_i32"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I32, Ty::I32],
+            returns: &[Ty::I32, Ty::Bool],
+        },
+        c_sig: None,
+        fn_list: &["imulo_i32"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U32, Ty::U32],
+            returns: &[Ty::U32],
+        },
+        c_sig: None,
+        fn_list: &["idiv_u32", "imod_u32"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U32, Ty::U32],
+            returns: &[Ty::U32, Ty::U32],
+        },
+        c_sig: None,
+        fn_list: &["idivmod_u32"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I64, Ty::I64],
+            returns: &[Ty::I64],
+        },
+        c_sig: None,
+        fn_list: &["idiv_i64", "imod_i64"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I64, Ty::I64],
+            returns: &[Ty::I64, Ty::I64],
+        },
+        c_sig: None,
+        fn_list: &["idivmod_i64"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U64, Ty::U64],
+            returns: &[Ty::U64],
+        },
+        c_sig: None,
+        fn_list: &["idiv_u64", "imod_u64", "imul_u64"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U64, Ty::U64],
+            returns: &[Ty::U64, Ty::U64],
+        },
+        c_sig: None,
+        fn_list: &["idivmod_u64"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I64, Ty::I64],
+            returns: &[Ty::I64, Ty::Bool],
+        },
+        c_sig: None,
+        fn_list: &["imulo_i64"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I128, Ty::I128],
+            returns: &[Ty::I128],
+        },
+        c_sig: None,
+        fn_list: &[
+            "iadd_i128",
+            "idiv_i128",
+            "imod_i128",
+            "imul_i128",
+            "isub_i128",
+        ],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I128, Ty::I128],
+            returns: &[Ty::I128, Ty::I128],
+        },
+        c_sig: None,
+        fn_list: &["idivmod_i128"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::I128, Ty::I128],
+            returns: &[Ty::I128, Ty::Bool],
+        },
+        c_sig: None,
+        fn_list: &["iaddo_i128", "imulo_i128", "isubo_i128"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U128, Ty::U128],
+            returns: &[Ty::U128],
+        },
+        c_sig: None,
+        fn_list: &["iadd_u128", "idiv_u128", "imod_u128", "isub_u128"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U128, Ty::U128],
+            returns: &[Ty::U128, Ty::U128],
+        },
+        c_sig: None,
+        fn_list: &["idivmod_u128"],
+        scope: OpScope::BuiltinsPublic,
+    },
+    NestedOp {
+        rust_sig: Signature {
+            args: &[Ty::U128, Ty::U128],
+            returns: &[Ty::U128, Ty::Bool],
+        },
+        c_sig: None,
+        fn_list: &["iaddo_u128", "imulo_u128", "isubo_u128"],
+        scope: OpScope::BuiltinsPublic,
+    },
     /* int shifts */
     NestedOp {
         rust_sig: Signature {

--- a/crates/util/src/main.rs
+++ b/crates/util/src/main.rs
@@ -310,7 +310,7 @@ impl_parse_tuple!(f64);
 impl_parse_tuple_via_rug!(f128);
 
 macro_rules! impl_parse_tuple_int {
-    ($ty:ty) => {
+    (@skip_u32 $ty:ty) => {
         impl ParseTuple for ($ty,) {
             fn parse(input: &[&str]) -> Self {
                 assert_eq!(input.len(), 1, "expected a single argument, got {input:?}");
@@ -318,7 +318,7 @@ macro_rules! impl_parse_tuple_int {
             }
         }
 
-        impl ParseTuple for ($ty, u32) {
+        impl ParseTuple for ($ty, $ty) {
             fn parse(input: &[&str]) -> Self {
                 assert_eq!(input.len(), 2, "expected two arguments, got {input:?}");
                 (parse(input, 0), parse(input, 1))
@@ -332,12 +332,22 @@ macro_rules! impl_parse_tuple_int {
             }
         }
     };
+    ($ty:ty) => {
+        impl_parse_tuple_int!(@skip_u32 $ty);
+
+        impl ParseTuple for ($ty, u32) {
+            fn parse(input: &[&str]) -> Self {
+                assert_eq!(input.len(), 2, "expected two arguments, got {input:?}");
+                (parse(input, 0), parse(input, 1))
+            }
+        }
+    };
 }
 
 impl_parse_tuple_int!(i32);
 impl_parse_tuple_int!(i64);
 impl_parse_tuple_int!(i128);
-impl_parse_tuple_int!(u32);
+impl_parse_tuple_int!(@skip_u32 u32);
 impl_parse_tuple_int!(u64);
 impl_parse_tuple_int!(u128);
 

--- a/libm-test/src/builtins_wrapper.rs
+++ b/libm-test/src/builtins_wrapper.rs
@@ -58,6 +58,43 @@ macro_rules! cb_op {
             compiler_builtins::float::$mod::$cb_name(a, b) >= 0
         }
     };
+    (@int_binop_oflow $ty:ty, $mod:ident, $cb_name:ident, $new_name:ident) => {
+        pub fn $new_name(a: $ty, b: $ty) -> ($ty, bool) {
+            let mut oflow = 0;
+            let res = compiler_builtins::int::$mod::$cb_name(a, b, &mut oflow);
+            (res, oflow != 0)
+        }
+    };
+
+    // Make division by 0 well-defined so testing is easier.
+    (@int_div $ty:ty, $mod:ident, $cb_name:ident, $new_name:ident) => {
+        pub fn $new_name(a: $ty, b: $ty) -> $ty {
+            if b == 0 {
+                return <$ty>::MIN;
+            }
+            compiler_builtins::int::$mod::$cb_name(a, b)
+        }
+    };
+    (@int_divmod $ty:ty, $mod:ident, $cb_name:ident, $new_name:ident) => {
+        pub fn $new_name(a: $ty, b: $ty) -> ($ty, $ty) {
+            if b == 0 {
+                return (<$ty>::MIN, <$ty>::MIN);
+            }
+            let mut rem = 0;
+            let div = compiler_builtins::int::$mod::$cb_name(a, b, &mut rem);
+            (div, rem)
+        }
+    };
+    (@int_udivmod $ty:ty, $mod:ident, $cb_name:ident, $new_name:ident) => {
+        pub fn $new_name(a: $ty, b: $ty) -> ($ty, $ty) {
+            if b == 0 {
+                return (<$ty>::MIN, <$ty>::MIN);
+            }
+            let mut rem = 0;
+            let div = compiler_builtins::int::$mod::$cb_name(a, b, Some(&mut rem));
+            (div, rem)
+        }
+    };
 }
 
 #[cfg(f16_enabled)]
@@ -218,6 +255,42 @@ cb_op!(conv, __floatunditf, itof_u64_f128, (a: u64) -> f128);
 cb_op!(conv, __floatuntitf, itof_u128_f128, (a: u128) -> f128);
 
 /* int ops */
+
+cb_op!(@int addsub, __rust_i128_add, iadd_i128, (a: i128, b: i128) -> i128);
+cb_op!(@int addsub, __rust_i128_sub, isub_i128, (a: i128, b: i128) -> i128);
+cb_op!(@int addsub, __rust_u128_add, iadd_u128, (a: u128, b: u128) -> u128);
+cb_op!(@int addsub, __rust_u128_sub, isub_u128, (a: u128, b: u128) -> u128);
+cb_op!(@int_binop_oflow i128, addsub, __rust_i128_addo, iaddo_i128);
+cb_op!(@int_binop_oflow i128, addsub, __rust_i128_subo, isubo_i128);
+cb_op!(@int_binop_oflow u128, addsub, __rust_u128_addo, iaddo_u128);
+cb_op!(@int_binop_oflow u128, addsub, __rust_u128_subo, isubo_u128);
+
+cb_op!(@int mul, __muldi3, imul_u64, (a: u64, b: u64) -> u64);
+cb_op!(@int mul, __multi3, imul_i128, (a: i128, b: i128) -> i128);
+cb_op!(@int_binop_oflow i32, mul, __mulosi4, imulo_i32);
+cb_op!(@int_binop_oflow i64, mul, __mulodi4, imulo_i64);
+cb_op!(@int_binop_oflow i128, mul, __muloti4, imulo_i128);
+cb_op!(@int_binop_oflow u128, mul, __rust_u128_mulo, imulo_u128);
+
+cb_op!(@int_div i32, sdiv, __divsi3, idiv_i32);
+cb_op!(@int_div i64, sdiv, __divdi3, idiv_i64);
+cb_op!(@int_div i128, sdiv, __divti3, idiv_i128);
+cb_op!(@int_div i32, sdiv, __modsi3, imod_i32);
+cb_op!(@int_div i64, sdiv, __moddi3, imod_i64);
+cb_op!(@int_div i128, sdiv, __modti3, imod_i128);
+cb_op!(@int_divmod i32, sdiv, __divmodsi4, idivmod_i32);
+cb_op!(@int_divmod i64, sdiv, __divmoddi4, idivmod_i64);
+cb_op!(@int_divmod i128, sdiv, __divmodti4, idivmod_i128);
+
+cb_op!(@int_div u32, udiv, __udivsi3, idiv_u32);
+cb_op!(@int_div u64, udiv, __udivdi3, idiv_u64);
+cb_op!(@int_div u128, udiv, __udivti3, idiv_u128);
+cb_op!(@int_div u32, udiv, __umodsi3, imod_u32);
+cb_op!(@int_div u64, udiv, __umoddi3, imod_u64);
+cb_op!(@int_div u128, udiv, __umodti3, imod_u128);
+cb_op!(@int_udivmod u32, udiv, __udivmodsi4, idivmod_u32);
+cb_op!(@int_udivmod u64, udiv, __udivmoddi4, idivmod_u64);
+cb_op!(@int_udivmod u128, udiv, __udivmodti4, idivmod_u128);
 
 cb_op!(@int shift, __ashlsi3, ashl_u32, (a: u32, b: u32) -> u32);
 cb_op!(@int shift, __ashldi3, ashl_u64, (a: u64, b: u32) -> u64);

--- a/libm-test/src/domain.rs
+++ b/libm-test/src/domain.rs
@@ -247,6 +247,15 @@ pub fn get_domain<F: Float, I: Int>(
         BaseName::Itof => &EitherPrim::UNBOUNDED1[..],
 
         // Integer ops
+        BaseName::Iadd => &EitherPrim::UNBOUNDED2[..],
+        BaseName::Iaddo => &EitherPrim::UNBOUNDED2[..],
+        BaseName::Isub => &EitherPrim::UNBOUNDED2[..],
+        BaseName::Isubo => &EitherPrim::UNBOUNDED2[..],
+        BaseName::Imul => &EitherPrim::UNBOUNDED2[..],
+        BaseName::Imulo => &EitherPrim::UNBOUNDED2[..],
+        BaseName::Idiv => &EitherPrim::UNBOUNDED2[..],
+        BaseName::Imod => &EitherPrim::UNBOUNDED2[..],
+        BaseName::Idivmod => &EitherPrim::UNBOUNDED2[..],
         // Shifts technically aren't unbounded, but its range is restricted elsewhere in
         // our test generators.
         BaseName::Ashl => &EitherPrim::UNBOUNDED2[..],

--- a/libm-test/src/generate/case_list.rs
+++ b/libm-test/src/generate/case_list.rs
@@ -468,6 +468,136 @@ fn itof_u128_f128_cases() -> Vec<TestCase<op::itof_u128_f128::Routine>> {
     vec![]
 }
 
+/* int arithmetic */
+
+fn iadd_i128_cases() -> Vec<TestCase<op::iadd_i128::Routine>> {
+    vec![]
+}
+
+fn iadd_u128_cases() -> Vec<TestCase<op::iadd_u128::Routine>> {
+    vec![]
+}
+
+fn iaddo_i128_cases() -> Vec<TestCase<op::iaddo_i128::Routine>> {
+    vec![]
+}
+
+fn iaddo_u128_cases() -> Vec<TestCase<op::iaddo_u128::Routine>> {
+    vec![]
+}
+
+fn isub_i128_cases() -> Vec<TestCase<op::isub_i128::Routine>> {
+    vec![]
+}
+
+fn isub_u128_cases() -> Vec<TestCase<op::isub_u128::Routine>> {
+    vec![]
+}
+
+fn isubo_i128_cases() -> Vec<TestCase<op::isubo_i128::Routine>> {
+    vec![]
+}
+
+fn isubo_u128_cases() -> Vec<TestCase<op::isubo_u128::Routine>> {
+    vec![]
+}
+
+fn idiv_i128_cases() -> Vec<TestCase<op::idiv_i128::Routine>> {
+    vec![]
+}
+
+fn idiv_i32_cases() -> Vec<TestCase<op::idiv_i32::Routine>> {
+    vec![]
+}
+
+fn idiv_i64_cases() -> Vec<TestCase<op::idiv_i64::Routine>> {
+    vec![]
+}
+
+fn idiv_u128_cases() -> Vec<TestCase<op::idiv_u128::Routine>> {
+    vec![]
+}
+
+fn idiv_u32_cases() -> Vec<TestCase<op::idiv_u32::Routine>> {
+    vec![]
+}
+
+fn idiv_u64_cases() -> Vec<TestCase<op::idiv_u64::Routine>> {
+    vec![]
+}
+
+fn idivmod_i128_cases() -> Vec<TestCase<op::idivmod_i128::Routine>> {
+    vec![]
+}
+
+fn idivmod_i32_cases() -> Vec<TestCase<op::idivmod_i32::Routine>> {
+    vec![]
+}
+
+fn idivmod_i64_cases() -> Vec<TestCase<op::idivmod_i64::Routine>> {
+    vec![]
+}
+
+fn idivmod_u128_cases() -> Vec<TestCase<op::idivmod_u128::Routine>> {
+    vec![]
+}
+
+fn idivmod_u32_cases() -> Vec<TestCase<op::idivmod_u32::Routine>> {
+    vec![]
+}
+
+fn idivmod_u64_cases() -> Vec<TestCase<op::idivmod_u64::Routine>> {
+    vec![]
+}
+
+fn imod_i128_cases() -> Vec<TestCase<op::imod_i128::Routine>> {
+    vec![]
+}
+
+fn imod_i32_cases() -> Vec<TestCase<op::imod_i32::Routine>> {
+    vec![]
+}
+
+fn imod_i64_cases() -> Vec<TestCase<op::imod_i64::Routine>> {
+    vec![]
+}
+
+fn imod_u128_cases() -> Vec<TestCase<op::imod_u128::Routine>> {
+    vec![]
+}
+
+fn imod_u32_cases() -> Vec<TestCase<op::imod_u32::Routine>> {
+    vec![]
+}
+
+fn imod_u64_cases() -> Vec<TestCase<op::imod_u64::Routine>> {
+    vec![]
+}
+
+fn imul_i128_cases() -> Vec<TestCase<op::imul_i128::Routine>> {
+    vec![]
+}
+
+fn imul_u64_cases() -> Vec<TestCase<op::imul_u64::Routine>> {
+    vec![]
+}
+
+fn imulo_i128_cases() -> Vec<TestCase<op::imulo_i128::Routine>> {
+    vec![]
+}
+
+fn imulo_i32_cases() -> Vec<TestCase<op::imulo_i32::Routine>> {
+    vec![]
+}
+
+fn imulo_i64_cases() -> Vec<TestCase<op::imulo_i64::Routine>> {
+    vec![]
+}
+
+fn imulo_u128_cases() -> Vec<TestCase<op::imulo_u128::Routine>> {
+    vec![]
+}
+
 /* int shifts */
 
 fn ashl_u32_cases() -> Vec<TestCase<op::ashl_u32::Routine>> {

--- a/libm-test/src/generate/edge_cases.rs
+++ b/libm-test/src/generate/edge_cases.rs
@@ -315,7 +315,7 @@ impl_edge_case_input!(f64);
 impl_edge_case_input!(f128);
 
 macro_rules! impl_edge_case_input_int {
-    ($ity:ty) => {
+    (@skip_u32 $ity:ty) => {
         impl<Op> EdgeCaseInput<Op> for ($ity,)
         where
             Op: MathOp<RustArgs = Self>,
@@ -326,6 +326,23 @@ macro_rules! impl_edge_case_input_int {
                 (iter0, steps0)
             }
         }
+
+        impl<Op> EdgeCaseInput<Op> for ($ity, $ity)
+        where
+            Op: MathOp<RustArgs = Self>,
+        {
+            fn get_cases(ctx: &CheckCtx) -> (impl Iterator<Item = Self>, u64) {
+                let (iter0, steps0) = int_edge_cases(ctx, 0);
+                let (iter1, steps1) = int_edge_cases(ctx, 1);
+                let iter =
+                    iter0.flat_map(move |first| iter1.clone().map(move |second| (first, second)));
+                let count = steps0.checked_mul(steps1).unwrap();
+                (iter, count)
+            }
+        }
+    };
+    ($ity:ty) => {
+        impl_edge_case_input_int!(@skip_u32 $ity);
 
         impl<Op> EdgeCaseInput<Op> for ($ity, u32)
         where
@@ -346,7 +363,7 @@ macro_rules! impl_edge_case_input_int {
 impl_edge_case_input_int!(i32);
 impl_edge_case_input_int!(i64);
 impl_edge_case_input_int!(i128);
-impl_edge_case_input_int!(u32);
+impl_edge_case_input_int!(@skip_u32 u32);
 impl_edge_case_input_int!(u64);
 impl_edge_case_input_int!(u128);
 

--- a/libm-test/src/generate/random.rs
+++ b/libm-test/src/generate/random.rs
@@ -120,7 +120,7 @@ impl_random_input!(f64);
 impl_random_input!(f128);
 
 macro_rules! impl_random_input_int {
-    ($ity:ty) => {
+    (@skip_u32 $ity:ty) => {
         impl RandomInput for ($ity,) {
             fn get_cases(ctx: &CheckCtx) -> (impl Iterator<Item = Self>, u64) {
                 let count = iteration_count(ctx, 0);
@@ -130,11 +130,27 @@ macro_rules! impl_random_input_int {
             }
         }
 
+        impl RandomInput for ($ity, $ity) {
+            fn get_cases(ctx: &CheckCtx) -> (impl Iterator<Item = Self>, u64) {
+                let count0 = iteration_count(ctx, 0);
+                let count1 = iteration_count(ctx, 1);
+                let range0 = int_range::<$ity>(ctx, 0).unwrap_or(full_range());
+                let range1 = int_range::<$ity>(ctx, 1).unwrap_or(full_range());
+                let iter = random_ints(count0, range0).flat_map(move |f1: $ity| {
+                    random_ints(count1, range1.clone()).map(move |f2: $ity| (f1, f2))
+                });
+                (iter, count0 * count1)
+            }
+        }
+    };
+    ($ity:ty) => {
+        impl_random_input_int!(@skip_u32 $ity);
+
         impl RandomInput for ($ity, u32) {
             fn get_cases(ctx: &CheckCtx) -> (impl Iterator<Item = Self>, u64) {
                 let count0 = iteration_count(ctx, 0);
                 let count1 = iteration_count(ctx, 1);
-                let range0 = int_range::<$ity>(ctx, 1).unwrap_or(full_range());
+                let range0 = int_range::<$ity>(ctx, 0).unwrap_or(full_range());
                 let range1 = int_range::<u32>(ctx, 1).unwrap_or(full_range());
                 let iter = random_ints(count0, range0).flat_map(move |f1: $ity| {
                     random_ints(count1, range1.clone()).map(move |f2: u32| (f1, f2))
@@ -148,7 +164,7 @@ macro_rules! impl_random_input_int {
 impl_random_input_int!(i32);
 impl_random_input_int!(i64);
 impl_random_input_int!(i128);
-impl_random_input_int!(u32);
+impl_random_input_int!(@skip_u32 u32);
 impl_random_input_int!(u64);
 impl_random_input_int!(u128);
 

--- a/libm-test/src/generate/spaced.rs
+++ b/libm-test/src/generate/spaced.rs
@@ -254,7 +254,7 @@ impl_spaced_input!(f64);
 impl_spaced_input!(f128);
 
 macro_rules! impl_spaced_input_int {
-    ($ity:ty) => {
+    (@skip_u32 $ity:ty) => {
         impl<Op> SpacedInput<Op> for ($ity,)
         where
             Op: MathOp<RustArgs = Self>,
@@ -275,6 +275,38 @@ macro_rules! impl_spaced_input_int {
                 }
             }
         }
+
+        impl<Op> SpacedInput<Op> for ($ity, $ity)
+        where
+            Op: MathOp<RustArgs = Self>,
+        {
+            fn get_cases(ctx: &CheckCtx) -> (impl Iterator<Item = Self>, u64) {
+                let range0 = int_range(ctx, 0).unwrap_or(full_range());
+                let range1 = int_range(ctx, 1).unwrap_or(full_range());
+                let max_steps0 = iteration_count(ctx, 0);
+                let max_steps1 = iteration_count(ctx, 0);
+                match value_count_int::<Arg0<Op>>() {
+                    Some(count) if count <= max_steps0 && count < max_steps1 => {
+                        let iter = range0.flat_map(move |first| {
+                            range1.clone().map(move |second| (first, second))
+                        });
+                        (EitherIter::A(iter), count.checked_mul(count).unwrap())
+                    }
+                    _ => {
+                        let (iter0, steps0) = linear_ints::<Arg0<Op>>(range0, max_steps0);
+                        let (iter1, steps1) = linear_ints::<Arg1<Op>>(range1, max_steps1);
+                        let iter = iter0.flat_map(move |first| {
+                            iter1.clone().map(move |second| (first, second))
+                        });
+                        let count = steps0.checked_mul(steps1).unwrap();
+                        (EitherIter::B(iter), count)
+                    }
+                }
+            }
+        }
+    };
+    ($ity:ty) => {
+        impl_spaced_input_int!(@skip_u32 $ity);
 
         impl<Op> SpacedInput<Op> for ($ity, u32)
         where
@@ -310,7 +342,7 @@ macro_rules! impl_spaced_input_int {
 impl_spaced_input_int!(i32);
 impl_spaced_input_int!(i64);
 impl_spaced_input_int!(i128);
-impl_spaced_input_int!(u32);
+impl_spaced_input_int!(@skip_u32 u32);
 impl_spaced_input_int!(u64);
 impl_spaced_input_int!(u128);
 

--- a/libm-test/src/mpfloat.rs
+++ b/libm-test/src/mpfloat.rs
@@ -6,7 +6,7 @@
 use std::cmp::Ordering;
 
 use rug::Assign;
-use rug::az::{self, Az, CheckedCast, WrappingAs};
+use rug::az::{self, Az, CheckedCast, OverflowingCast, WrappingAs};
 use rug::float::Round::Nearest;
 use rug::ops::{
     AddAssignRound, DivAssignRound, MulAssignRound, PowAssignRound, RemAssignRound, SubAssignRound,
@@ -215,10 +215,42 @@ libm_macros::for_each_function! {
         gtf16,
         gtf32,
         gtf64,
+        iadd_i128,
+        iadd_u128,
+        iaddo_i128,
+        iaddo_u128,
+        idiv_i128,
+        idiv_i32,
+        idiv_i64,
+        idiv_u128,
+        idiv_u32,
+        idiv_u64,
+        idivmod_i128,
+        idivmod_i32,
+        idivmod_i64,
+        idivmod_u128,
+        idivmod_u32,
+        idivmod_u64,
         ilogb,
         ilogbf,
         ilogbf128,
         ilogbf16,
+        imod_i128,
+        imod_i32,
+        imod_i64,
+        imod_u128,
+        imod_u32,
+        imod_u64,
+        imul_i128,
+        imul_u64,
+        imulo_i128,
+        imulo_i32,
+        imulo_i64,
+        imulo_u128,
+        isub_i128,
+        isub_u128,
+        isubo_i128,
+        isubo_u128,
         itof_i128_f128,
         itof_i128_f32,
         itof_i128_f64,
@@ -1040,6 +1072,77 @@ impl MpOp for crate::op::nextafterf::Routine {
 macro_rules! impl_int_ops {
     ($ity:ty) => {
         paste::paste! {
+            impl MpOp for crate::op::[<idiv_ $ity>]::Routine {
+                type MpTy = MpInt;
+
+                fn new_mp() -> Self::MpTy {
+                    MpInt::new()
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    if input.1 == 0 {
+                        // Make divide by 0 well-defined to match our wrappers.
+                        return <$ity>::MIN;
+                    }
+                    this.assign(input.0);
+                    *this /= input.1;
+                    (&*this).wrapping_as::<Self::RustRet>()
+                }
+            }
+
+            impl MpOp for crate::op::[<imod_ $ity>]::Routine {
+                type MpTy = MpInt;
+
+                fn new_mp() -> Self::MpTy {
+                    MpInt::new()
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    if input.1 == 0 {
+                        // Make divide by 0 well-defined to match our wrappers.
+                        return <$ity>::MIN;
+                    }
+                    this.assign(input.0);
+                    *this %= input.1;
+                    (&*this).wrapping_as::<Self::RustRet>()
+                }
+            }
+
+            impl MpOp for crate::op::[<idivmod_ $ity>]::Routine {
+                type MpTy = (MpInt, MpInt);
+
+                fn new_mp() -> Self::MpTy {
+                    (MpInt::new(), MpInt::new())
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    if input.1 == 0 {
+                        // Make divide by 0 well-defined to match our wrappers.
+                        return (<$ity>::MIN, <$ity>::MIN);
+                    }
+                    this.0.assign(input.0);
+                    this.1.assign(input.1);
+                    this.0.div_rem_mut(&mut this.1);
+                    (
+                        (&this.0).wrapping_as::<Ret0<Self>>(),
+                        (&this.1).wrapping_as::<Ret1<Self>>(),
+                    )
+                }
+            }
+        }
+    };
+}
+
+impl_int_ops!(i32);
+impl_int_ops!(i64);
+impl_int_ops!(i128);
+impl_int_ops!(u32);
+impl_int_ops!(u64);
+impl_int_ops!(u128);
+
+macro_rules! impl_unsigned_int_ops {
+    ($ity:ty) => {
+        paste::paste! {
             impl MpOp for crate::op::[<ashl_ $ity>]::Routine {
                 type MpTy = MpInt;
 
@@ -1099,9 +1202,9 @@ macro_rules! impl_int_ops {
     };
 }
 
-impl_int_ops!(u32);
-impl_int_ops!(u64);
-impl_int_ops!(u128);
+impl_unsigned_int_ops!(u32);
+impl_unsigned_int_ops!(u64);
+impl_unsigned_int_ops!(u128);
 
 macro_rules! impl_signed_int_ops {
     ($ity:ty) => {
@@ -1117,7 +1220,21 @@ macro_rules! impl_signed_int_ops {
                     assert!(input.1 < Arg0::<Self>::BITS, "got UB shift {}", input.1);
                     this.assign(input.0);
                     *this >>= input.1;
-                    (&*this).wrapping_as::<Arg0<Self>>()
+                    (&*this).wrapping_as::<Self::RustRet>()
+                }
+            }
+
+            impl MpOp for crate::op::[<imulo_ $ity>]::Routine {
+                type MpTy = MpInt;
+
+                fn new_mp() -> Self::MpTy {
+                    MpInt::new()
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    this.assign(input.0);
+                    *this *= input.1;
+                    (&*this).overflowing_cast()
                 }
             }
         }
@@ -1127,3 +1244,110 @@ macro_rules! impl_signed_int_ops {
 impl_signed_int_ops!(i32);
 impl_signed_int_ops!(i64);
 impl_signed_int_ops!(i128);
+
+macro_rules! impl_u128_i128_int_ops {
+    ($ity:ty) => {
+        paste::paste! {
+            impl MpOp for crate::op::[<iadd_ $ity>]::Routine {
+                type MpTy = MpInt;
+
+                fn new_mp() -> Self::MpTy {
+                    MpInt::new()
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    this.assign(input.0);
+                    *this += input.1;
+                    (&*this).wrapping_as::<Self::RustRet>()
+                }
+            }
+
+            impl MpOp for crate::op::[<isub_ $ity>]::Routine {
+                type MpTy = MpInt;
+
+                fn new_mp() -> Self::MpTy {
+                    MpInt::new()
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    this.assign(input.0);
+                    *this -= input.1;
+                    (&*this).wrapping_as::<Self::RustRet>()
+                }
+            }
+
+            impl MpOp for crate::op::[<iaddo_ $ity>]::Routine {
+                type MpTy = MpInt;
+
+                fn new_mp() -> Self::MpTy {
+                    MpInt::new()
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    this.assign(input.0);
+                    *this += input.1;
+                    (&*this).overflowing_cast()
+                }
+            }
+
+            impl MpOp for crate::op::[<isubo_ $ity>]::Routine {
+                type MpTy = MpInt;
+
+                fn new_mp() -> Self::MpTy {
+                    MpInt::new()
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    this.assign(input.0);
+                    *this -= input.1;
+                    (&*this).overflowing_cast()
+                }
+            }
+        }
+    };
+}
+
+impl_u128_i128_int_ops!(i128);
+impl_u128_i128_int_ops!(u128);
+
+impl MpOp for crate::op::imul_u64::Routine {
+    type MpTy = MpInt;
+
+    fn new_mp() -> Self::MpTy {
+        MpInt::new()
+    }
+
+    fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+        this.assign(input.0);
+        *this *= input.1;
+        (&*this).wrapping_as()
+    }
+}
+
+impl MpOp for crate::op::imul_i128::Routine {
+    type MpTy = MpInt;
+
+    fn new_mp() -> Self::MpTy {
+        MpInt::new()
+    }
+
+    fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+        this.assign(input.0);
+        *this *= input.1;
+        (&*this).wrapping_as()
+    }
+}
+
+impl MpOp for crate::op::imulo_u128::Routine {
+    type MpTy = MpInt;
+
+    fn new_mp() -> Self::MpTy {
+        MpInt::new()
+    }
+
+    fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+        this.assign(input.0);
+        *this *= input.1;
+        (&*this).overflowing_cast()
+    }
+}

--- a/libm-test/src/precision.rs
+++ b/libm-test/src/precision.rs
@@ -24,19 +24,23 @@ pub fn default_ulp(ctx: &CheckCtx) -> Option<u32> {
         Bn::Powi => 1000,
 
         // Operations that only return non-float results
-        Bn::Eq
-        | Bn::Ne
-        | Bn::Gt
-        | Bn::Ge
-        | Bn::Lt
-        | Bn::Le
-        | Bn::Unord
-        | Bn::Ilogb
-        | Bn::Ashl
+        Bn::Eq | Bn::Ne | Bn::Gt | Bn::Ge | Bn::Lt | Bn::Le | Bn::Unord | Bn::Ilogb => return None,
+
+        // Integer ops
+        Bn::Ashl
         | Bn::Ashr
         | Bn::Lshr
         | Bn::LeadingZeros
-        | Bn::TrailingZeros => return None,
+        | Bn::TrailingZeros
+        | Bn::Iadd
+        | Bn::Iaddo
+        | Bn::Isub
+        | Bn::Isubo
+        | Bn::Imul
+        | Bn::Imulo
+        | Bn::Idiv
+        | Bn::Imod
+        | Bn::Idivmod => return None,
 
         // Convrsion operations must be precise.
         Bn::Extend | Bn::Narrow | Bn::Ftoi | Bn::Itof => 0,
@@ -556,9 +560,16 @@ impl MaybeOverride<(i128,)> for SpecialCase {}
 impl MaybeOverride<(u32,)> for SpecialCase {}
 impl MaybeOverride<(u64,)> for SpecialCase {}
 impl MaybeOverride<(u128,)> for SpecialCase {}
+
+impl MaybeOverride<(i32, i32)> for SpecialCase {}
+impl MaybeOverride<(i64, i64)> for SpecialCase {}
+impl MaybeOverride<(i128, i128)> for SpecialCase {}
+impl MaybeOverride<(u32, u32)> for SpecialCase {}
+impl MaybeOverride<(u64, u64)> for SpecialCase {}
+impl MaybeOverride<(u128, u128)> for SpecialCase {}
+
 impl MaybeOverride<(i32, u32)> for SpecialCase {}
 impl MaybeOverride<(i64, u32)> for SpecialCase {}
 impl MaybeOverride<(i128, u32)> for SpecialCase {}
-impl MaybeOverride<(u32, u32)> for SpecialCase {}
 impl MaybeOverride<(u64, u32)> for SpecialCase {}
 impl MaybeOverride<(u128, u32)> for SpecialCase {}

--- a/libm-test/src/test_traits.rs
+++ b/libm-test/src/test_traits.rs
@@ -428,6 +428,22 @@ macro_rules! impl_tuples {
 }
 
 impl_tuples!(
+    (i32, i32);
+    (i64, i64);
+    (i128, i128);
+
+    (u32, u32);
+    (u64, u64);
+    (u128, u128);
+
+    (i32, bool);
+    (i64, bool);
+    (i128, bool);
+
+    (u32, bool);
+    (u64, bool);
+    (u128, bool);
+
     (f32, i32);
     (f64, i32);
     (f32, f32);


### PR DESCRIPTION
Add the following to the test infrastructure:

* `__rust_i128_add`
* `__rust_i128_sub`
* `__rust_u128_add`
* `__rust_u128_sub`
* `__rust_i128_addo`
* `__rust_i128_subo`
* `__rust_u128_addo`
* `__rust_u128_subo`
* `__muldi3`
* `__multi3`
* `__mulosi4`
* `__mulodi4`
* `__muloti4`
* `__rust_u128_mulo`
* `__divsi3`
* `__divdi3`
* `__divti3`
* `__modsi3`
* `__moddi3`
* `__modti3`
* `__divmodsi4`
* `__divmoddi4`
* `__divmodti4`
* `__udivsi3`
* `__udivdi3`
* `__udivti3`
* `__umodsi3`
* `__umoddi3`
* `__umodti3`
* `__udivmodsi4`
* `__udivmoddi4`
* `__udivmodti4`