### PR TITLE
trunc: Use an assembly implementation on i586

### DIFF
--- a/etc/function-definitions.json
+++ b/etc/function-definitions.json
@@ -1044,6 +1044,7 @@
     },
     "trunc": {
         "sources": [
+            "libm/src/math/arch/i586/rounding.rs",
             "libm/src/math/arch/wasm32/rounding.rs",
             "libm/src/math/generic/trunc.rs",
             "libm/src/math/trunc.rs"

--- a/libm/src/math/arch/i586/mod.rs
+++ b/libm/src/math/arch/i586/mod.rs
@@ -11,4 +11,4 @@ mod exp_all;
 mod rounding;
 
 pub use exp_all::{x87_exp, x87_exp2, x87_exp2f, x87_exp10, x87_exp10f, x87_expf};
-pub use rounding::{ceil, floor, rint};
+pub use rounding::{ceil, floor, rint, trunc};

--- a/libm/src/math/arch/i586/rounding.rs
+++ b/libm/src/math/arch/i586/rounding.rs
@@ -72,6 +72,35 @@ pub fn rint(mut x: f64) -> f64 {
     x
 }
 
+pub fn trunc(mut x: f64) -> f64 {
+    // Note that Rust code can technically assume that the rounding mode is always set to round-to-
+    // nearest, so this could just be a `frndint`. Setting the rounding mode anyway is consistent
+    // with what we do in assembly on other architectures.
+    unsafe {
+        core::arch::asm!(
+            "fld qword ptr [{x}]",
+            // Save the FPU control word, using `x` as scratch space.
+            "fstcw [{x}]",
+            // Set rounding control to 0b11 (toward zero).
+            "mov word ptr [{x} + 2], 0x0f7f",
+            "fldcw [{x} + 2]",
+            // Round.
+            "frndint",
+            // Restore FPU control word.
+            "fldcw [{x}]",
+            // Save rounded value to memory.
+            "fstp qword ptr [{x}]",
+            x = in(reg) &mut x,
+            // All the x87 FPU stack is used, all registers must be clobbered
+            out("st(0)") _, out("st(1)") _,
+            out("st(2)") _, out("st(3)") _,
+            out("st(4)") _, out("st(5)") _,
+            out("st(6)") _, out("st(7)") _,
+            options(nostack),
+        );
+    }
+    x
+}
 /* FIXME(msrv): after 1.82, the below can be used to compute control words using `asm_const`:
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/libm/src/math/arch/mod.rs
+++ b/libm/src/math/arch/mod.rs
@@ -49,6 +49,7 @@ cfg_if! {
             ceil,
             floor,
             rint,
+            trunc,
             x87_exp,
             x87_exp10,
             x87_exp10f,

--- a/libm/src/math/trunc.rs
+++ b/libm/src/math/trunc.rs
@@ -31,6 +31,7 @@ pub fn trunc(x: f64) -> f64 {
     select_implementation! {
         name: trunc,
         use_arch: all(target_arch = "wasm32", intrinsics_enabled),
+        use_arch_required: x86_no_sse2,
         args: x,
     }
 


### PR DESCRIPTION
The `trunc` implementation uses integer operations so currently works
fine on i586. However, we already have the other three easy operations
based on `frndint`, so add `trunc` and complete the set.

ci: skip-extensive