### PR TITLE
test: Move `tidy_lists` from `update-api-list.py` to a new crate

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -181,7 +181,10 @@ jobs:
 
     - name: Verify API list
       if: matrix.os == 'ubuntu-24.04' || contains(matrix.os, 'self-hosted')
-      run: python3 etc/update-api-list.py --check
+      run: |
+        # Must be run on the host (not in Docker) because git and fs access is required.
+        python3 etc/update-api-list.py --check
+        cargo test -p update-api-list
 
     # Non-linux tests just use our raw script
     - name: Run locally

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +489,12 @@ dependencies = [
  "wasip3",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gmp-mpfr-sys"
@@ -872,6 +884,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,6 +1259,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
+name = "update-api-list"
+version = "0.1.0"
+dependencies = [
+ "api-list-common",
+ "getopts",
+ "glob",
+ "pretty_assertions",
+ "regex",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1565,12 @@ dependencies = [
  "unicode-xid",
  "wasmparser 0.244.0",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/musl-math-sys",
     "crates/panic-handler",
     "crates/symbol-check",
+    "crates/update-api-list",
     "crates/util",
     "libm",
     "libm-test",
@@ -43,6 +44,7 @@ compiler_builtins = { path = "builtins-shim", default-features = false }
 criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }
 getopts = "0.2.24"
 getrandom = "0.4.1"
+glob = "0.3.3"
 gmp-mpfr-sys = { version = "1.6.8", default-features = false }
 gungraun = "0.17.2"
 heck = "0.5.0"
@@ -56,6 +58,7 @@ no-panic = "0.1.36"
 object = { version = "0.39.0", features = ["wasm"] }
 panic-handler = { path = "crates/panic-handler" }
 paste = "1.0.15"
+pretty_assertions = "1.4.1"
 proc-macro2 = "1.0.106"
 quote = "1.0.44"
 rand = "0.10.0"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -192,7 +192,7 @@ else
 
     # Exclude the macros and utile crates from the rest of the tests to save CI
     # runtime, they shouldn't have anything feature- or opt-level-dependent.
-    cmd+=(--exclude util --exclude libm-macros)
+    cmd+=(--exclude util --exclude libm-macros --exclude update-api-list)
 
     # Test once with intrinsics enabled
     "${cmd[@]}" --features arch,unstable-intrinsics

--- a/crates/update-api-list/Cargo.toml
+++ b/crates/update-api-list/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "update-api-list"
+version = "0.1.0"
+edition = "2024"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+api-list-common.workspace = true
+getopts.workspace = true
+glob.workspace = true
+pretty_assertions.workspace = true
+regex.workspace = true

--- a/crates/update-api-list/src/lib.rs
+++ b/crates/update-api-list/src/lib.rs
@@ -1,0 +1,11 @@
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+pub static WORKSPACE_ROOT: LazyLock<PathBuf> = LazyLock::new(|| {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_owned()
+});

--- a/crates/update-api-list/tests/all.rs
+++ b/crates/update-api-list/tests/all.rs
@@ -1,0 +1,128 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use std::sync::LazyLock;
+
+use pretty_assertions::assert_str_eq;
+use regex::Regex;
+use update_api_list::WORKSPACE_ROOT;
+
+static PUBLIC_FUNCTIONS: LazyLock<Vec<String>> = LazyLock::new(|| {
+    fs::read_to_string(WORKSPACE_ROOT.join("etc/function-list.txt"))
+        .unwrap()
+        .lines()
+        .map(|line| line.trim())
+        .filter(|line| !(line.starts_with("#") || line.is_empty()))
+        .map(|line| line.to_owned())
+        .collect()
+});
+
+/// In each file, check annotations indicating that blocks of code should be sorted or should
+/// include an exhaustive list of all public API.
+#[test]
+fn tidy_lists() {
+    let out = Command::new("git")
+        .arg("ls-files")
+        .current_dir(&*WORKSPACE_ROOT)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    let file_list = str::from_utf8(&out.stdout).unwrap();
+
+    for path in file_list.lines() {
+        let relpath = Path::new(path);
+        let abspath = WORKSPACE_ROOT.join(relpath);
+        if abspath.is_dir() || relpath == file!() {
+            continue;
+        }
+
+        let src = fs::read_to_string(&abspath).unwrap();
+        let lines: Vec<_> = src.lines().collect();
+
+        validate_delimited_block(
+            relpath,
+            &lines,
+            "verify-sorted-start",
+            "verify-sorted-end",
+            ensure_sorted,
+        );
+
+        validate_delimited_block(
+            relpath,
+            &lines,
+            "verify-apilist-start",
+            "verify-apilist-end",
+            ensure_contains_api,
+        );
+    }
+}
+
+/// Identify blocks of code wrapped within `start` and `end`, collect their contents to a list of
+/// strings, and call `validate` for each of those lists.
+fn validate_delimited_block(
+    relpath: &Path,
+    lines: &[&str],
+    start: &str,
+    end: &str,
+    validate: impl Fn(&Path, usize, &[&str]),
+) {
+    let mut block_lines = Vec::new();
+    let mut block_start_line = None;
+    for (mut line_num, line) in lines.iter().enumerate() {
+        line_num += 1;
+
+        if line.contains(start) {
+            block_start_line = Some(line_num);
+            continue;
+        }
+
+        // End of a block, validate its contents
+        if line.contains(end) {
+            let Some(start_line) = block_start_line else {
+                panic!("`{end}` without `{start}` at {relpath:?}:{line_num}");
+            };
+
+            validate(relpath, start_line, &block_lines);
+            block_lines.clear();
+            block_start_line = None;
+            continue;
+        }
+
+        if block_start_line.is_some() {
+            block_lines.push(*line);
+        }
+    }
+
+    if let Some(start_line) = block_start_line {
+        panic!("`{start}` without `{end}` at {relpath:?}:{start_line}");
+    }
+}
+
+/// Given a list of strings, ensure that each public function we have is named somewhere.
+fn ensure_contains_api(relpath: &Path, block_start_line: usize, lines: &[&str]) {
+    let mut not_found = Vec::new();
+
+    for func in &*PUBLIC_FUNCTIONS {
+        // The function name may be on its own or somewhere in a snake case string.
+        let re = Regex::new(&format!(r"(\b|_){func}(\b|_)")).unwrap();
+        if !lines.iter().any(|line| re.is_match(line)) {
+            not_found.push(func);
+        }
+    }
+
+    if not_found.is_empty() {
+        return;
+    }
+
+    panic!("functions not found at {relpath:?}:{block_start_line}: {not_found:?}");
+}
+
+fn ensure_sorted(relpath: &Path, block_start_line: usize, lines: &[&str]) {
+    let mut sorted = lines.to_owned();
+    sorted.sort_unstable();
+    let a = lines.join("\n");
+    let b = sorted.join("\n");
+
+    assert_str_eq!(a, b, "sorted block at {relpath:?}:{block_start_line}");
+}

--- a/etc/update-api-list.py
+++ b/etc/update-api-list.py
@@ -16,7 +16,7 @@ import sys
 from dataclasses import dataclass
 from glob import glob
 from pathlib import Path
-from typing import Any, Callable, TypeAlias
+from typing import Any, TypeAlias
 
 SELF_PATH = Path(__file__)
 ETC_DIR = SELF_PATH.parent
@@ -201,36 +201,6 @@ class Crate:
             with open(out_file, "w") as f:
                 f.write(output)
 
-    def tidy_lists(self) -> None:
-        """In each file, check annotations indicating blocks of code should be sorted or should
-        include all public API.
-        """
-
-        flist = sp.check_output(["git", "ls-files"], cwd=ROOT_DIR, text=True)
-
-        for path in flist.splitlines():
-            fpath = ROOT_DIR.joinpath(path)
-            if fpath.is_dir() or fpath == SELF_PATH:
-                continue
-
-            lines = fpath.read_text().splitlines()
-
-            validate_delimited_block(
-                fpath,
-                lines,
-                "verify-sorted-start",
-                "verify-sorted-end",
-                ensure_sorted,
-            )
-
-            validate_delimited_block(
-                fpath,
-                lines,
-                "verify-apilist-start",
-                "verify-apilist-end",
-                lambda p, n, lines: self.ensure_contains_api(p, n, lines),
-            )
-
     def ensure_contains_api(self, fpath: Path, line_num: int, lines: list[str]):
         """Given a list of strings, ensure that each public function we have is named
         somewhere.
@@ -250,54 +220,6 @@ class Crate:
         relpath = fpath.relative_to(ROOT_DIR)
         eprint(f"functions not found at {relpath}:{line_num}: {not_found}")
         exit(1)
-
-
-def validate_delimited_block(
-    fpath: Path,
-    lines: list[str],
-    start: str,
-    end: str,
-    validate: Callable[[Path, int, list[str]], None],
-) -> None:
-    """Identify blocks of code wrapped within `start` and `end`, collect their contents
-    to a list of strings, and call `validate` for each of those lists.
-    """
-    relpath = fpath.relative_to(ROOT_DIR)
-    block_lines = []
-    block_start_line: None | int = None
-    for line_num, line in enumerate(lines):
-        line_num += 1
-
-        if start in line:
-            block_start_line = line_num
-            continue
-
-        if end in line:
-            if block_start_line is None:
-                eprint(f"`{end}` without `{start}` at {relpath}:{line_num}")
-                exit(1)
-
-            validate(fpath, block_start_line, block_lines)
-            block_lines = []
-            block_start_line = None
-            continue
-
-        if block_start_line is not None:
-            block_lines.append(line)
-
-    if block_start_line is not None:
-        eprint(f"`{start}` without `{end}` at {relpath}:{block_start_line}")
-        exit(1)
-
-
-def ensure_sorted(fpath: Path, block_start_line: int, lines: list[str]) -> None:
-    """Ensure that a list of lines is sorted, otherwise print a diff and exit."""
-    relpath = fpath.relative_to(ROOT_DIR)
-    diff_and_exit(
-        "\n".join(lines),
-        "\n".join(sorted(lines)),
-        f"sorted block at {relpath}:{block_start_line}",
-    )
 
 
 def diff_and_exit(actual: str, expected: str, name: str):
@@ -355,8 +277,6 @@ def ensure_updated_list(check: bool) -> None:
     crate = Crate()
     crate.write_function_list(check)
     crate.write_function_defs(check)
-
-    crate.tidy_lists()
 
 
 def main():


### PR DESCRIPTION
This is the first step of migrating `update-api-list.py` to something that handles the compiler-builtins functions.