### PR TITLE
Fix the type of `CmpResult` on wasm64

### DIFF
--- a/compiler-builtins/src/float/cmp.rs
+++ b/compiler-builtins/src/float/cmp.rs
@@ -7,8 +7,9 @@ use crate::support::{Float, MinInt, cfg_if};
 // [1]: https://github.com/llvm/llvm-project/blob/0cf3c437c18ed27d9663d87804a9a15ff6874af2/compiler-rt/lib/builtins/fp_compare_impl.inc#L11-L27
 // [2]: https://gcc.gnu.org/onlinedocs/gccint/Soft-float-library-routines.html#Comparison-functions-1
 cfg_if! {
-    if #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))] {
+    if #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_family = "wasm"))] {
         // Aarch64 uses `int` rather than a pointer-sized value.
+        // `getCmpLibcallReturnType` for WASM is always set to i32.
         pub type CmpResult = i32;
     } else if #[cfg(target_arch = "avr")] {
         // AVR uses a single byte.


### PR DESCRIPTION
resolve rust-lang/compiler-builtins#1199