### PR TITLE
c-b: Avoid a build script panic from `.unwrap()`

### DIFF
--- a/compiler-builtins/build.rs
+++ b/compiler-builtins/build.rs
@@ -12,6 +12,7 @@ fn main() {
     // Work around building as part of `builtins-shim`: if only `build.rs` is used, Cargo always
     // considers the build dirty because `builtins-shim/build.rs` does not exist. If only
     // `../c-b/build.rs` is used, the same may happen if not built in the workspace.
+    // Note: this may be `None` if CARGO_MANIFEST_DIR doesn't end in a directory name (e.g. ".")
     if let Some(dir) = cfg.manifest_dir.file_name()
         && dir == "builtins-shim"
     {

--- a/compiler-builtins/build.rs
+++ b/compiler-builtins/build.rs
@@ -12,7 +12,9 @@ fn main() {
     // Work around building as part of `builtins-shim`: if only `build.rs` is used, Cargo always
     // considers the build dirty because `builtins-shim/build.rs` does not exist. If only
     // `../c-b/build.rs` is used, the same may happen if not built in the workspace.
-    if cfg.manifest_dir.file_name().unwrap() == "builtins-shim" {
+    if let Some(dir) = cfg.manifest_dir.file_name()
+        && dir == "builtins-shim"
+    {
         println!("cargo::rerun-if-changed=../compiler-builtins/build.rs");
     } else {
         println!("cargo::rerun-if-changed=build.rs");


### PR DESCRIPTION
The current code expects CARGO_MANIFEST_DIR to always end in a directory name, which prevents passing something like ".". We can continue to support that by unwrapping using `if let` first.

Followup to rust-lang/compiler-builtins#1187.