### PR TITLE
ci: Run powerpc64-unknown-linux-musl on selfhosted runner

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -74,6 +74,8 @@ jobs:
           os: ubuntu-24.04
         - target: powerpc64-unknown-linux-gnu
           os: ubuntu-24.04
+        - target: powerpc64-unknown-linux-musl
+          os: ["self-hosted", "linux", "powerpc64", "musl"]
         - target: powerpc64le-unknown-linux-gnu
           os: ubuntu-24.04
         - target: powerpc64le-unknown-linux-gnu


### PR DESCRIPTION
Since they are now registered and set up, we can start running jobs on them.

ci: test-libm