### PR TITLE
replace cfg_if with cfg_select

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1324,7 +1324,6 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 name = "util"
 version = "0.1.0"
 dependencies = [
- "cfg-if",
  "libm 0.2.16",
  "libm-macros",
  "libm-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ anyhow = "1.0.101"
 api-list-common = { path = "crates/api-list-common" }
 assert_cmd = "2.1.2"
 cc = "1.2.56"
-cfg-if = "1.0.4"
 compiler_builtins = { path = "builtins-shim", default-features = false }
 criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }
 getopts = "0.2.24"

--- a/compiler-builtins/src/float/cmp.rs
+++ b/compiler-builtins/src/float/cmp.rs
@@ -1,6 +1,6 @@
 #![allow(unreachable_code)]
 
-use crate::support::{Float, MinInt, cfg_if};
+use crate::support::{Float, MinInt, cfg_select};
 
 // These definitions should be consistent with LLVM's definition from `getCmpLibcallReturnType`,
 // compiler-rt's definitions [1], GCC's `CMPtype` [2], and `libgcc`. To find the definitions
@@ -12,15 +12,17 @@ use crate::support::{Float, MinInt, cfg_if};
 //
 // [1]: https://github.com/llvm/llvm-project/blob/0cf3c437c18ed27d9663d87804a9a15ff6874af2/compiler-rt/lib/builtins/fp_compare_impl.inc#L11-L27
 // [2]: https://gcc.gnu.org/onlinedocs/gccint/Soft-float-library-routines.html#Comparison-functions-1
-cfg_if! {
-    if #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_family = "wasm"))] {
+cfg_select! {
+    any(target_arch = "aarch64", target_arch = "arm64ec", target_family = "wasm") => {
         // Aarch64 uses `int` rather than a pointer-sized value.
         // `getCmpLibcallReturnType` for WASM is always set to i32.
         pub type CmpResult = i32;
-    } else if #[cfg(target_arch = "avr")] {
+    }
+    target_arch = "avr" => {
         // AVR uses a single byte.
         pub type CmpResult = i8;
-    } else {
+    }
+    _ => {
         // The default is word-sized. In LLVM's compiler-rt, this is done by using `long long` on
         // LLP64 ABIs and `long` on everything else.
         pub type CmpResult = isize;

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cfg-if.workspace = true
 libm.workspace = true
 libm-macros.workspace = true
 libm-test.workspace = true

--- a/crates/util/src/main.rs
+++ b/crates/util/src/main.rs
@@ -8,8 +8,7 @@ use std::env;
 use std::num::ParseIntError;
 use std::str::FromStr;
 
-use cfg_if::cfg_if;
-use libm::support::{Float, Hex, hf32, hf64};
+use libm::support::{Float, Hex, cfg_select, hf32, hf64};
 #[cfg(feature = "build-mpfr")]
 use libm_test::mpfloat::MpOp;
 use libm_test::{MathOp, TupleCall, builtins_wrapper};
@@ -127,13 +126,14 @@ fn do_eval(basis: &str, op: &str, inputs: &[&str]) {
 fn do_classify(inputs: &[&str]) {
     for s in inputs {
         if let Some(s) = s.strip_suffix("f16") {
-            cfg_if! {
-                if #[cfg(f16_enabled)] {
+            cfg_select! {
+                f16_enabled => {
                     let s = s.trim_end_matches("_");
                     let x: f16 = parse(&[s], 0);
                     classify_print(x);
                     continue;
-                } else {
+                }
+                _ => {
                     panic!("parsing this type requires f16 support: `{s}`");
                 }
             }
@@ -150,13 +150,14 @@ fn do_classify(inputs: &[&str]) {
             continue;
         }
         if let Some(s) = s.strip_suffix("f128") {
-            cfg_if! {
-                if #[cfg(all(f128_enabled, feature = "build-mpfr"))] {
+            cfg_select! {
+                all(f128_enabled, feature = "build-mpfr") => {
                     let s = s.trim_end_matches("_");
                     let x: f128 = parse_rug(&[s], 0);
                     classify_print(x);
                     continue;
-                } else {
+                }
+                _ => {
                     panic!("parsing this type requires f128 support and \
                             the `build-mpfr` feature: `{s}`");
                 }

--- a/libm/src/math/arch/mod.rs
+++ b/libm/src/math/arch/mod.rs
@@ -8,19 +8,21 @@
 // Most implementations should be defined here, to ensure they are not made available when
 // soft floats are required.
 #[cfg(feature = "arch")]
-cfg_if! {
-    if #[cfg(all(target_arch = "wasm32", intrinsics_enabled))] {
+cfg_select! {
+    all(target_arch = "wasm32", intrinsics_enabled) => {
         mod wasm32;
         pub use wasm32::{
             ceil, ceilf, fabs, fabsf, floor, floorf, rint, rintf, sqrt, sqrtf, trunc, truncf,
         };
-    } else if #[cfg(target_feature = "sse2")] {
+    }
+    target_feature = "sse2" => {
         mod x86;
         pub use x86::{sqrt, sqrtf, fma, fmaf};
-    } else if #[cfg(all(
+    }
+    all(
         any(target_arch = "aarch64", target_arch = "arm64ec"),
         target_feature = "neon"
-    ))] {
+    ) => {
         mod aarch64;
 
         pub use aarch64::{
@@ -38,12 +40,13 @@ cfg_if! {
             sqrtf16,
         };
     }
+    _ => {}
 }
 
 // There are certain architecture-specific implementations that are needed for correctness
 // even with `arch` disabled. These are configured here.
-cfg_if! {
-    if #[cfg(x86_no_sse2)] {
+cfg_select! {
+    x86_no_sse2 => {
         mod i586;
         pub use i586::{
             ceil,
@@ -57,4 +60,5 @@ cfg_if! {
             x87_expf,
         };
     }
+    _ => {}
 }

--- a/libm/src/math/mod.rs
+++ b/libm/src/math/mod.rs
@@ -67,10 +67,11 @@ pub mod support;
 #[cfg(not(feature = "unstable-public-internals"))]
 pub(crate) mod support;
 
-cfg_if! {
-    if #[cfg(feature = "unstable-public-internals")] {
+cfg_select! {
+    feature = "unstable-public-internals" => {
         pub mod generic;
-    } else {
+    }
+    _ => {
         mod generic;
     }
 }
@@ -294,8 +295,8 @@ pub use self::tgamma::tgamma;
 pub use self::tgammaf::tgammaf;
 pub use self::trunc::{trunc, truncf};
 
-cfg_if! {
-    if #[cfg(f16_enabled)] {
+cfg_select! {
+    f16_enabled => {
         mod fmaf16;
 
         // verify-sorted-start
@@ -320,10 +321,11 @@ cfg_if! {
         pub use self::trunc::truncf16;
         // verify-sorted-end
     }
+    _ => {}
 }
 
-cfg_if! {
-    if #[cfg(f128_enabled)] {
+cfg_select! {
+    f128_enabled => {
         // verify-sorted-start
         pub use self::ceil::ceilf128;
         pub use self::copysign::copysignf128;
@@ -346,6 +348,7 @@ cfg_if! {
         pub use self::trunc::truncf128;
         // verify-sorted-end
     }
+    _ => {}
 }
 
 #[inline]

--- a/libm/src/math/support/big.rs
+++ b/libm/src/math/support/big.rs
@@ -294,11 +294,12 @@ impl fmt::Debug for i256 {
 
 impl fmt::LowerHex for u256 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        cfg_if! {
-            if #[cfg(feature = "compiler-builtins")] {
+        cfg_select! {
+            feature = "compiler-builtins" => {
                 let _ = f;
                 unimplemented!()
-            } else {
+            }
+            _ => {
                 let pfx= if f.alternate() { "0x"} else {""};
                 write!(f, "{pfx}{:032x}{:032x}", self.hi, self.lo)
             }

--- a/libm/src/math/support/float_traits.rs
+++ b/libm/src/math/support/float_traits.rs
@@ -337,31 +337,34 @@ macro_rules! float_impl {
                 Self::from_bits(a)
             }
             fn abs(self) -> Self {
-                cfg_if! {
+                cfg_select! {
                     // FIXME(msrv): `abs` is available in `core` starting with 1.85.
-                    if #[cfg(intrinsics_enabled)] {
+                    intrinsics_enabled => {
                         self.abs()
-                    } else {
+                    }
+                    _ => {
                         super::super::generic::fabs(self)
                     }
                 }
             }
             fn copysign(self, other: Self) -> Self {
-                cfg_if! {
+                cfg_select! {
                     // FIXME(msrv): `copysign` is available in `core` starting with 1.85.
-                    if #[cfg(intrinsics_enabled)] {
+                    intrinsics_enabled => {
                         self.copysign(other)
-                    } else {
+                    }
+                    _ => {
                         super::super::generic::copysign(self, other)
                     }
                 }
             }
             fn fma(self, y: Self, z: Self) -> Self {
-                cfg_if! {
+                cfg_select! {
                     // fma is not yet available in `core`
-                    if #[cfg(intrinsics_enabled)] {
+                    intrinsics_enabled => {
                         core::intrinsics::$fma_intrinsic(self, y, z)
-                    } else {
+                    }
+                    _ => {
                         super::super::$fma_fn(self, y, z)
                     }
                 }

--- a/libm/src/math/support/hex_float.rs
+++ b/libm/src/math/support/hex_float.rs
@@ -448,11 +448,12 @@ mod hex_fmt {
     // Not really a meaningful impl, but makes some generics easier.
     impl DisplayHex for bool {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            cfg_if! {
-                if #[cfg(feature = "compiler-builtins")] {
+            cfg_select! {
+                feature = "compiler-builtins" => {
                     let _ = f;
                     unimplemented!()
-                } else {
+                }
+                _ => {
                     write!(f, "{self}")
                 }
             }

--- a/libm/src/math/support/macros.rs
+++ b/libm/src/math/support/macros.rs
@@ -1,67 +1,25 @@
-/// `libm` cannot have dependencies, so this is vendored directly from the `cfg-if` crate
-/// (with some comments stripped for compactness).
-macro_rules! cfg_if {
+// Because `cfg_select` requires rust verion 1.95 and we support older versions,
+// we use the following replacement until that is no longer true.
+// FIXME(msrv)
+#[macro_export]
+macro_rules! cfg_select {
+    ({ $($tt:tt)* }) => {{
+        $crate::cfg_select! { $($tt)* }
+    }};
+    (_ => { $($output:tt)* }) => {
+        $($output)*
+    };
     (
-        if #[cfg( $($i_meta:tt)+ )] { $( $i_tokens:tt )* }
+        $cfg:meta => $output:tt
+        $($( $rest:tt )+)?
+    ) => {
+        #[cfg($cfg)]
+        cfg_select! { _ => $output }
         $(
-            else if #[cfg( $($ei_meta:tt)+ )] { $( $ei_tokens:tt )* }
-        )*
-        $(
-            else { $( $e_tokens:tt )* }
+            #[cfg(not($cfg))]
+            cfg_select! { $($rest)+ }
         )?
-    ) => {
-        cfg_if! {
-            @__items () ;
-            (( $($i_meta)+ ) ( $( $i_tokens )* )),
-            $(
-                (( $($ei_meta)+ ) ( $( $ei_tokens )* )),
-            )*
-            $(
-                (() ( $( $e_tokens )* )),
-            )?
-        }
-    };
-
-    // Internal and recursive macro to emit all the items
-    //
-    // Collects all the previous cfgs in a list at the beginning, so they can be
-    // negated. After the semicolon are all the remaining items.
-    (@__items ( $( ($($_:tt)*) , )* ) ; ) => {};
-    (
-        @__items ( $( ($($no:tt)+) , )* ) ;
-        (( $( $($yes:tt)+ )? ) ( $( $tokens:tt )* )),
-        $( $rest:tt , )*
-    ) => {
-        // Emit all items within one block, applying an appropriate #[cfg]. The
-        // #[cfg] will require all `$yes` matchers specified and must also negate
-        // all previous matchers.
-        #[cfg(all(
-            $( $($yes)+ , )?
-            not(any( $( $($no)+ ),* ))
-        ))]
-        // Subtle: You might think we could put `$( $tokens )*` here. But if
-        // that contains multiple items then the `#[cfg(all(..))]` above would
-        // only apply to the first one. By wrapping `$( $tokens )*` in this
-        // macro call, we temporarily group the items into a single thing (the
-        // macro call) that will be included/excluded by the `#[cfg(all(..))]`
-        // as appropriate. If the `#[cfg(all(..))]` succeeds, the macro call
-        // will be included, and then evaluated, producing `$( $tokens )*`. See
-        // also the "issue #90" test below.
-        cfg_if! { @__temp_group $( $tokens )* }
-
-        // Recurse to emit all other items in `$rest`, and when we do so add all
-        // our `$yes` matchers to the list of `$no` matchers as future emissions
-        // will have to negate everything we just matched as well.
-        cfg_if! {
-            @__items ( $( ($($no)+) , )* $( ($($yes)+) , )? ) ;
-            $( $rest , )*
-        }
-    };
-
-    // See the "Subtle" comment above.
-    (@__temp_group $( $tokens:tt )* ) => {
-        $( $tokens )*
-    };
+    }
 }
 
 /// Choose between using an arch-specific implementation and the function body. Returns directly

--- a/libm/src/math/support/mod.rs
+++ b/libm/src/math/support/mod.rs
@@ -14,7 +14,7 @@ mod modular;
 pub use big::{i256, u256};
 // Clippy seems to have a false positive
 #[allow(unused_imports, clippy::single_component_path_imports)]
-pub(crate) use cfg_if;
+pub use cfg_select;
 pub use env::{FpResult, Round, Status};
 #[allow(unused_imports)]
 pub use float_traits::{DFloat, Float, HFloat, HalfRep, IntTy};
@@ -40,8 +40,8 @@ pub fn cold_path() {
 ///
 /// `y` must not be zero and the result must not overflow (`x > i32::MIN`).
 pub unsafe fn unchecked_div_i32(x: i32, y: i32) -> i32 {
-    cfg_if! {
-        if #[cfg(all(not(debug_assertions), intrinsics_enabled))] {
+    cfg_select! {
+        all(not(debug_assertions), intrinsics_enabled) => {
             // Temporary macro to avoid panic codegen for division (in debug mode too). At
             // the time of this writing this is only used in a few places, and once
             // rust-lang/rust#72751 is fixed then this macro will no longer be necessary and
@@ -50,7 +50,8 @@ pub unsafe fn unchecked_div_i32(x: i32, y: i32) -> i32 {
             // Note: I am not sure whether the above comment is still up to date, we need
             // to double check whether panics are elided where we use this.
             unsafe { core::intrinsics::unchecked_div(x, y) }
-        } else {
+        }
+        _ => {
             x / y
         }
     }
@@ -60,10 +61,11 @@ pub unsafe fn unchecked_div_i32(x: i32, y: i32) -> i32 {
 ///
 /// `y` must not be zero and the result must not overflow (`x > isize::MIN`).
 pub unsafe fn unchecked_div_isize(x: isize, y: isize) -> isize {
-    cfg_if! {
-        if #[cfg(all(not(debug_assertions), intrinsics_enabled))] {
+    cfg_select! {
+        all(not(debug_assertions), intrinsics_enabled) => {
             unsafe { core::intrinsics::unchecked_div(x, y) }
-        } else {
+        }
+              _ => {
             x / y
         }
     }


### PR DESCRIPTION
Now that cfg_select is stable, we can replace cfg_if. One difference is that cfg_select needs one branch to match. Therefore an empty default branch is sometimes needed.

EDIT: now using a local impl of cfg_select (thanks @folkertdev [1]) so as not to have to increase msrv.

[1]:[#t-libs > compiler-builtins msrv policy? @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/compiler-builtins.20msrv.20policy.3F/near/606320965)