### PR TITLE
tests: add tests for fdim(f)

### DIFF
--- a/libm/src/math/fdim.rs
+++ b/libm/src/math/fdim.rs
@@ -2,8 +2,8 @@
 ///
 /// Determines the positive difference between arguments, returning:
 /// * x - y if x > y, or
-/// * +0    if x <= y, or
-/// * NAN   if either argument is NAN.
+/// * +0 if x <= y, or
+/// * NAN if either argument is NAN.
 ///
 /// A range error may occur.
 #[cfg(f16_enabled)]
@@ -16,8 +16,8 @@ pub fn fdimf16(x: f16, y: f16) -> f16 {
 ///
 /// Determines the positive difference between arguments, returning:
 /// * x - y if x > y, or
-/// * +0    if x <= y, or
-/// * NAN   if either argument is NAN.
+/// * +0 if x <= y, or
+/// * NAN if either argument is NAN.
 ///
 /// A range error may occur.
 #[cfg_attr(assert_no_panic, no_panic::no_panic)]
@@ -29,8 +29,8 @@ pub fn fdimf(x: f32, y: f32) -> f32 {
 ///
 /// Determines the positive difference between arguments, returning:
 /// * x - y if x > y, or
-/// * +0    if x <= y, or
-/// * NAN   if either argument is NAN.
+/// * +0 if x <= y, or
+/// * NAN if either argument is NAN.
 ///
 /// A range error may occur.
 #[cfg_attr(assert_no_panic, no_panic::no_panic)]
@@ -42,12 +42,110 @@ pub fn fdim(x: f64, y: f64) -> f64 {
 ///
 /// Determines the positive difference between arguments, returning:
 /// * x - y if x > y, or
-/// * +0    if x <= y, or
-/// * NAN   if either argument is NAN.
+/// * +0 if x <= y, or
+/// * NAN if either argument is NAN.
 ///
 /// A range error may occur.
 #[cfg(f128_enabled)]
 #[cfg_attr(assert_no_panic, no_panic::no_panic)]
 pub fn fdimf128(x: f128, y: f128) -> f128 {
     super::generic::fdim(x, y)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::support::{Float, Hex};
+
+    macro_rules! cases {
+        ($f:ty) => {
+            [
+                // x = -inf
+                (<$f>::NEG_INFINITY, <$f>::NEG_INFINITY, 0.0),
+                (<$f>::NEG_INFINITY, -1.0, 0.0),
+                (<$f>::NEG_INFINITY, -0.0, 0.0),
+                (<$f>::NEG_INFINITY, 0.0, 0.0),
+                (<$f>::NEG_INFINITY, 1.0, 0.0),
+                (<$f>::NEG_INFINITY, <$f>::INFINITY, 0.0),
+                (<$f>::NEG_INFINITY, <$f>::NAN, <$f>::NAN),
+                // x = -1.0
+                (-1.0, <$f>::NEG_INFINITY, <$f>::INFINITY),
+                (-1.0, -1.0, 0.0),
+                (-1.0, -0.0, 0.0),
+                (-1.0, 0.0, 0.0),
+                (-1.0, 1.0, 0.0),
+                (-1.0, <$f>::INFINITY, 0.0),
+                (-1.0, <$f>::NAN, <$f>::NAN),
+                // x = -0.0
+                (-0.0, <$f>::NEG_INFINITY, <$f>::INFINITY),
+                (-0.0, -1.0, 1.0),
+                (-0.0, -0.0, 0.0),
+                (-0.0, 0.0, 0.0),
+                (-0.0, 1.0, 0.0),
+                (-0.0, <$f>::INFINITY, 0.0),
+                (-0.0, <$f>::NAN, <$f>::NAN),
+                // x = 0.0
+                (0.0, <$f>::NEG_INFINITY, <$f>::INFINITY),
+                (0.0, -1.0, 1.0),
+                (0.0, -0.0, 0.0),
+                (0.0, 0.0, 0.0),
+                (0.0, 1.0, 0.0),
+                (0.0, <$f>::INFINITY, 0.0),
+                (0.0, <$f>::NAN, <$f>::NAN),
+                // x = 1.0
+                (1.0, <$f>::NEG_INFINITY, <$f>::INFINITY),
+                (1.0, -1.0, 2.0),
+                (1.0, -0.0, 1.0),
+                (1.0, 0.0, 1.0),
+                (1.0, 1.0, 0.0),
+                (1.0, <$f>::INFINITY, 0.0),
+                (1.0, <$f>::NAN, <$f>::NAN),
+                // x = inf
+                (<$f>::INFINITY, <$f>::NEG_INFINITY, <$f>::INFINITY),
+                (<$f>::INFINITY, -1.0, <$f>::INFINITY),
+                (<$f>::INFINITY, -0.0, <$f>::INFINITY),
+                (<$f>::INFINITY, 0.0, <$f>::INFINITY),
+                (<$f>::INFINITY, 1.0, <$f>::INFINITY),
+                (<$f>::INFINITY, <$f>::INFINITY, 0.0),
+                (<$f>::INFINITY, <$f>::NAN, <$f>::NAN),
+                // x = nan
+                (<$f>::NAN, <$f>::NEG_INFINITY, <$f>::NAN),
+                (<$f>::NAN, -1.0, <$f>::NAN),
+                (<$f>::NAN, -0.0, <$f>::NAN),
+                (<$f>::NAN, 0.0, <$f>::NAN),
+                (<$f>::NAN, 1.0, <$f>::NAN),
+                (<$f>::NAN, <$f>::INFINITY, <$f>::NAN),
+                (<$f>::NAN, <$f>::NAN, <$f>::NAN),
+            ]
+        };
+    }
+
+    #[track_caller]
+    fn check<F: Float>(f: fn(F, F) -> F, cases: &[(F, F, F)]) {
+        for &(x, y, exp_res) in cases {
+            let val = f(x, y);
+            assert_biteq!(val, exp_res, "fdim({x:?}, {y:?}) ({} {})", Hex(x), Hex(y));
+        }
+    }
+
+    #[test]
+    #[cfg(f16_enabled)]
+    fn check_f16() {
+        check::<f16>(super::super::fdimf16, &cases!(f16));
+    }
+
+    #[test]
+    fn check_f32() {
+        check::<f32>(super::super::fdimf, &cases!(f32));
+    }
+
+    #[test]
+    fn check_f64() {
+        check::<f64>(super::super::fdim, &cases!(f64));
+    }
+
+    #[test]
+    #[cfg(f128_enabled)]
+    fn check_f128() {
+        check::<f128>(super::super::fdimf128, &cases!(f128));
+    }
 }


### PR DESCRIPTION
* This PR aims to increase test coverage, taking a report generated by llvm-cov as a baseline reference.
* a comparison of the test coverage before and after:

```bash
> cargo +nightly llvm-cov -p compiler_builtins -p libm | grep fdim 1> baseline_cov.txt && cat baseline_cov.txt
math/fdim.rs                                      10                10     0.00%           2                 2     0.00%           6                 6     0.00%           0                 0         -
math/generic/fdim.rs                               5                 5     0.00%           1                 1     0.00%           3                 3     0.00%           0                 0         -
```
```bash
› cargo +nightly llvm-cov -p compiler_builtins -p libm | grep fdim 1> changed_cov.txt && cat changed_cov.txt
math/fdim.rs                                      78                 0   100.00%           7                 0   100.00%          38                 0   100.00%           0                 0         -
math/generic/fdim.rs                               5                 0   100.00%           1                 0   100.00%           3                 0   100.00%           0                 0         -

```

Sidenote, there are many branches where test coverage is low or nonexistent, I was thinking of opening an issue to track this and hopefully encourage others to add their own tests on branches lacking coverage, is such an issue welcome? I wouldn't want to clutter the project.