### PR TITLE
 ci: build and test with s390x-resolute runner

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -93,6 +93,8 @@ jobs:
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-26.04
         - target: s390x-unknown-linux-gnu
+          os: self-hosted-linux-s390x-resolute-large-rust # resolute == ubuntu-26.04
+        - target: s390x-unknown-linux-gnu
           os: ubuntu-24.04-s390x
         - target: thumbv6m-none-eabi
           os: ubuntu-26.04

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -92,6 +92,8 @@ jobs:
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-24.04
         - target: s390x-unknown-linux-gnu
+          os: self-hosted-linux-s390x-resolute-medium-rust
+        - target: s390x-unknown-linux-gnu
           os: ubuntu-24.04-s390x
         - target: thumbv6m-none-eabi
           os: ubuntu-24.04


### PR DESCRIPTION
We'd like to this add new `s390x` runner to `compiler-builtins`. 

This new runner is provided by Canonical. After some iteration alongside with Canonical folks, the `large` runner offers hardware spec similar to the existing s390x provided by IBM and [delivers similar build times](https://github.com/rust-lang/compiler-builtins/actions/runs/31516313575/job/93862267593?pr=1227).

Moreover, it runs on ubuntu-26.04 rather than ubuntu-24.04, and it features a Github integration more friendly to `t-infra`, since the related Github App requires less permissions to run. 

We don't need to remove the s390x IBM runners right now. We propose having both s390x runners running side by side for a while and circle back after a few PRs, sticking with the Canonical one afterwards if everything goes well.