### PR TITLE
libm: Add LoongArch implementations of fma, rint, and sqrt

### DIFF
--- a/etc/function-definitions.json
+++ b/etc/function-definitions.json
@@ -343,6 +343,7 @@
     "fma": {
         "sources": [
             "libm/src/math/arch/aarch64/fma.rs",
+            "libm/src/math/arch/loongarch/fma.rs",
             "libm/src/math/arch/x86/fma.rs",
             "libm/src/math/fma.rs",
             "libm/src/math/generic/fma.rs"
@@ -352,6 +353,7 @@
     "fmaf": {
         "sources": [
             "libm/src/math/arch/aarch64/fma.rs",
+            "libm/src/math/arch/loongarch/fma.rs",
             "libm/src/math/arch/x86/fma.rs",
             "libm/src/math/fma.rs",
             "libm/src/math/generic/fma.rs"
@@ -832,6 +834,7 @@
         "sources": [
             "libm/src/math/arch/aarch64/rounding.rs",
             "libm/src/math/arch/i586/rounding.rs",
+            "libm/src/math/arch/loongarch/rounding.rs",
             "libm/src/math/arch/wasm32/rounding.rs",
             "libm/src/math/generic/rint.rs",
             "libm/src/math/rint.rs"
@@ -841,6 +844,7 @@
     "rintf": {
         "sources": [
             "libm/src/math/arch/aarch64/rounding.rs",
+            "libm/src/math/arch/loongarch/rounding.rs",
             "libm/src/math/arch/wasm32/rounding.rs",
             "libm/src/math/generic/rint.rs",
             "libm/src/math/rint.rs"
@@ -981,6 +985,7 @@
     "sqrt": {
         "sources": [
             "libm/src/math/arch/aarch64/sqrt.rs",
+            "libm/src/math/arch/loongarch/sqrt.rs",
             "libm/src/math/arch/wasm32/sqrt.rs",
             "libm/src/math/arch/x86/sqrt.rs",
             "libm/src/math/generic/sqrt.rs",
@@ -991,6 +996,7 @@
     "sqrtf": {
         "sources": [
             "libm/src/math/arch/aarch64/sqrt.rs",
+            "libm/src/math/arch/loongarch/sqrt.rs",
             "libm/src/math/arch/wasm32/sqrt.rs",
             "libm/src/math/arch/x86/sqrt.rs",
             "libm/src/math/generic/sqrt.rs",

--- a/libm/src/math/arch/loongarch/fma.rs
+++ b/libm/src/math/arch/loongarch/fma.rs
@@ -1,0 +1,31 @@
+use core::arch::asm;
+
+#[cfg(target_feature = "d")]
+pub fn fma(mut x: f64, y: f64, z: f64) -> f64 {
+    // SAFETY: `fmadd.d` is available with `d and has no side effects.
+    unsafe {
+        asm!(
+            "fmadd.d {x}, {x}, {y}, {z}",
+            x = inout(freg) x,
+            y = in(freg) y,
+            z = in(freg) z,
+            options(nomem, nostack, pure)
+        );
+    }
+    x
+}
+
+#[cfg(target_feature = "f")]
+pub fn fmaf(mut x: f32, y: f32, z: f32) -> f32 {
+    // SAFETY: `fmadd.s` is available with `f` and has no side effects.
+    unsafe {
+        asm!(
+            "fmadd.s {x}, {x}, {y}, {z}",
+            x = inout(freg) x,
+            y = in(freg) y,
+            z = in(freg) z,
+            options(nomem, nostack, pure)
+        );
+    }
+    x
+}

--- a/libm/src/math/arch/loongarch/mod.rs
+++ b/libm/src/math/arch/loongarch/mod.rs
@@ -1,0 +1,16 @@
+//! Architecture-specific support for LoongArch with FPU
+
+mod fma;
+mod rounding;
+mod sqrt;
+
+#[cfg(target_feature = "d")]
+pub use fma::fma;
+#[cfg(target_feature = "f")]
+pub use fma::fmaf;
+#[cfg(target_feature = "lsx")]
+pub use rounding::{rint, rintf};
+#[cfg(target_feature = "d")]
+pub use sqrt::sqrt;
+#[cfg(target_feature = "f")]
+pub use sqrt::sqrtf;

--- a/libm/src/math/arch/loongarch/rounding.rs
+++ b/libm/src/math/arch/loongarch/rounding.rs
@@ -1,0 +1,39 @@
+//! NB: `frint.{s.d}` is technically the correct instruction for C's `rint`.
+//! However, in Rust (and LLVM by default), `rint` is identical to `roundeven`
+//! (no fpenv interaction) so we use the side-effect-free `vfrintrne.{s,d}`.
+//!
+//! In general, C code that calls Rust's libm should assume that fpenv is ignored.
+
+use core::arch::asm;
+
+#[cfg(target_feature = "lsx")]
+pub fn rint(mut x: f64) -> f64 {
+    // SAFETY: `vfrintrne.d` is available with `lsx` and has no side effects.
+    //
+    // `vfrintrne.d` is always round-to-nearest which does not match the
+    // C specification, but Rust does not support rounding modes.
+    unsafe {
+        asm!(
+            "vfrintrne.d {x:w}, {x:w}",
+            x = inout(freg) x,
+            options(nomem, nostack, pure)
+        );
+    }
+    x
+}
+
+#[cfg(target_feature = "lsx")]
+pub fn rintf(mut x: f32) -> f32 {
+    // SAFETY: `vfrintrne.s` is available with `lsx` and has no side effects.
+    //
+    // `vfrintrne.s` is always round-to-nearest which does not match the
+    // C specification, but Rust does not support rounding modes.
+    unsafe {
+        asm!(
+            "vfrintrne.s {x:w}, {x:w}",
+            x = inout(freg) x,
+            options(nomem, nostack, pure)
+        );
+    }
+    x
+}

--- a/libm/src/math/arch/loongarch/sqrt.rs
+++ b/libm/src/math/arch/loongarch/sqrt.rs
@@ -1,0 +1,27 @@
+use core::arch::asm;
+
+#[cfg(target_feature = "d")]
+pub fn sqrt(mut x: f64) -> f64 {
+    // SAFETY: `fsqrt.d` is available with `d` and has no side effects.
+    unsafe {
+        asm!(
+            "fsqrt.d {x}, {x}",
+            x = inout(freg) x,
+            options(nomem, nostack, pure)
+        );
+    }
+    x
+}
+
+#[cfg(target_feature = "f")]
+pub fn sqrtf(mut x: f32) -> f32 {
+    // SAFETY: `fsqrt.s` is available with `f` and has no side effects.
+    unsafe {
+        asm!(
+            "fsqrt.s {x}, {x}",
+            x = inout(freg) x,
+            options(nomem, nostack, pure)
+        );
+    }
+    x
+}

--- a/libm/src/math/arch/mod.rs
+++ b/libm/src/math/arch/mod.rs
@@ -40,6 +40,20 @@ cfg_select! {
             sqrtf16,
         };
     }
+    any(target_arch = "loongarch32", target_arch = "loongarch64") => {
+        mod loongarch;
+
+        #[cfg(target_feature = "d")]
+        pub use loongarch::fma;
+        #[cfg(target_feature = "f")]
+        pub use loongarch::fmaf;
+        #[cfg(target_feature = "lsx")]
+        pub use loongarch::{rint, rintf};
+        #[cfg(target_feature = "d")]
+        pub use loongarch::sqrt;
+        #[cfg(target_feature = "f")]
+        pub use loongarch::sqrtf;
+    }
     _ => {}
 }
 

--- a/libm/src/math/fma.rs
+++ b/libm/src/math/fma.rs
@@ -15,6 +15,7 @@ pub fn fmaf(x: f32, y: f32, z: f32) -> f32 {
         name: fmaf,
         use_arch: any(
             all(target_arch = "aarch64", target_feature = "neon"),
+            all(any(target_arch = "loongarch32", target_arch = "loongarch64"), target_feature = "f"),
             target_feature = "sse2",
         ),
         args: x, y, z,
@@ -32,6 +33,7 @@ pub fn fma(x: f64, y: f64, z: f64) -> f64 {
         name: fma,
         use_arch: any(
             all(target_arch = "aarch64", target_feature = "neon"),
+            all(any(target_arch = "loongarch32", target_arch = "loongarch64"), target_feature = "d"),
             target_feature = "sse2",
         ),
         args: x, y, z,

--- a/libm/src/math/rint.rs
+++ b/libm/src/math/rint.rs
@@ -20,6 +20,7 @@ pub fn rintf(x: f32) -> f32 {
         name: rintf,
         use_arch: any(
             all(target_arch = "aarch64", target_feature = "neon"),
+            all(any(target_arch = "loongarch32", target_arch = "loongarch64"), target_feature = "lsx"),
             all(target_arch = "wasm32", intrinsics_enabled),
         ),
         args: x,
@@ -35,6 +36,7 @@ pub fn rint(x: f64) -> f64 {
         name: rint,
         use_arch: any(
             all(target_arch = "aarch64", target_feature = "neon"),
+            all(any(target_arch = "loongarch32", target_arch = "loongarch64"), target_feature = "lsx"),
             all(target_arch = "wasm32", intrinsics_enabled),
         ),
         use_arch_required: x86_no_sse2,

--- a/libm/src/math/sqrt.rs
+++ b/libm/src/math/sqrt.rs
@@ -22,6 +22,7 @@ pub fn sqrtf(x: f32) -> f32 {
         use_arch: any(
             all(target_arch = "aarch64", target_feature = "neon"),
             all(target_arch = "wasm32", intrinsics_enabled),
+            all(any(target_arch = "loongarch32", target_arch = "loongarch64"), target_feature = "f"),
             target_feature = "sse2"
         ),
         args: x,
@@ -38,6 +39,7 @@ pub fn sqrt(x: f64) -> f64 {
         use_arch: any(
             all(target_arch = "aarch64", target_feature = "neon"),
             all(target_arch = "wasm32", intrinsics_enabled),
+            all(any(target_arch = "loongarch32", target_arch = "loongarch64"), target_feature = "d"),
             target_feature = "sse2"
         ),
         args: x,


### PR DESCRIPTION
Add LoongArch-specific implementations of `fma`, `rint`, and `sqrt` using hardware floating-point instructions and enable architecture dispatch for these operations.