### PR TITLE
ci: Compute changed files based on the merge base

### DIFF
--- a/ci/ci-util.py
+++ b/ci/ci-util.py
@@ -229,12 +229,21 @@ class Context:
         assert len(parents) == 2, f"expected two-parent merge but got:\n{parents}"
         base = parents[0].strip()
         incoming = parents[1].strip()
-
         eprint(f"base: {base}, incoming: {incoming}")
+
+        merge_base = sp.check_output(
+            GIT + ["merge-base", base, incoming], text=True
+        ).strip()
+        eprint(f"merge base: {merge_base}")
+
         textlist = sp.check_output(
-            GIT + ["diff", base, incoming, "--name-only"], text=True
+            GIT + ["diff", merge_base, incoming, "--name-only"], text=True
         )
         self.changed = [Path(p) for p in textlist.splitlines()]
+        eprint("all changed: [")
+        for f in self.changed:
+            eprint(f"    {f},")
+        eprint("]")
 
     def is_pr(self) -> bool:
         """Check if we are looking at a PR rather than a push."""
@@ -304,7 +313,7 @@ class Context:
                 eprint("Skipping all extensive tests")
 
         changed = self.changed_routines()
-        eprint(f"Changed: {changed}")
+        eprint(f"changed routines: {changed}")
 
         matrix = []
         total_to_test = 0


### PR DESCRIPTION
`git diff` from `main` doesn't take direction into account, meaning more
files than expected can show up as changed. Diff against the merge base
instead, to only get the list of files changed in the current PR.