### PR TITLE
Revert "Avoid inlining `floor` into `rem_pio2`"

### DIFF
--- a/libm/src/math/rem_pio2_large.rs
+++ b/libm/src/math/rem_pio2_large.rs
@@ -13,7 +13,7 @@
  * ====================================================
  */
 
-use super::scalbn;
+use super::{floor, scalbn};
 
 // initial value for jk
 const INIT_JK: [usize; 4] = [3, 4, 4, 6];
@@ -225,14 +225,6 @@ const PIO2: [f64; 8] = [
 /// independent of the exponent of the input.
 #[cfg_attr(assert_no_panic, no_panic::no_panic)]
 pub(crate) fn rem_pio2_large(x: &[f64], y: &mut [f64], e0: i32, prec: usize) -> i32 {
-    // FIXME(rust-lang/rust#144518): Inline assembly would cause `no_panic` to fail
-    // on the callers of this function. As a workaround, avoid inlining `floor` here
-    // when implemented with assembly.
-    #[cfg_attr(x86_no_sse2, inline(never))]
-    extern "C" fn floor(x: f64) -> f64 {
-        super::floor(x)
-    }
-
     let x1p24 = f64::from_bits(0x4170000000000000); // 0x1p24 === 2 ^ 24
     let x1p_24 = f64::from_bits(0x3e70000000000000); // 0x1p_24 === 2 ^ (-24)
 


### PR DESCRIPTION
Starting with LLVM version 22 `nounwind` is now propagated from inline
assembly to functions containing it, meaning this workaround can now be
removed.

This reverts commit c4966f9b0d4323183933e98dea4d0a77f52c0e0a.

Link: https://github.com/llvm/llvm-project/pull/150958
Link: https://github.com/rust-lang/rust/issues/144518