### PR TITLE
 arm_linux: Add missing memory barrier to atomic_cmpxchg 

### DIFF
--- a/compiler-builtins/src/sync/arm_linux.rs
+++ b/compiler-builtins/src/sync/arm_linux.rs
@@ -5,15 +5,17 @@ use core::{arch, mem};
 // https://www.kernel.org/doc/Documentation/arm/kernel_user_helpers.txt
 unsafe fn __kuser_cmpxchg(oldval: u32, newval: u32, ptr: *mut u32) -> bool {
     // FIXME(volatile): the third parameter is a volatile pointer
-    // SAFETY: kernel docs specify a known address with the given signature
+    // SAFETY: kernel docs specify a known address with the given signature.
+    // And the caller must guarantee that the pointer is valid for read and write
+    // and aligned to the element size.
     let f = unsafe {
         mem::transmute::<_, extern "C" fn(u32, u32, *mut u32) -> u32>(0xffff0fc0usize as *const ())
     };
     f(oldval, newval, ptr) == 0
 }
 
-unsafe fn __kuser_memory_barrier() {
-    // SAFETY: kernel docs specify a known address with the given signature
+fn __kuser_memory_barrier() {
+    // SAFETY: kernel docs specify a known address with the given signature.
     let f = unsafe { mem::transmute::<_, extern "C" fn()>(0xffff0fa0usize as *const ()) };
     f();
 }
@@ -184,7 +186,6 @@ include!("arm_thumb_shared.rs");
 
 intrinsics! {
     pub unsafe extern "C" fn __sync_synchronize() {
-       // SAFETY: preconditions are the same as the calling function.
-       unsafe {  __kuser_memory_barrier() };
+       __kuser_memory_barrier();
     }
 }

--- a/compiler-builtins/src/sync/arm_linux.rs
+++ b/compiler-builtins/src/sync/arm_linux.rs
@@ -107,12 +107,14 @@ unsafe fn atomic_rmw<T, F: Fn(u32) -> u32, G: Fn(u32, u32) -> u32>(ptr: *mut T, 
     let (shift, mask) = get_shift_mask(ptr);
 
     loop {
-        // FIXME(safety): preconditions review needed
+        // SAFETY: the caller must guarantee that the pointer is valid for read and write,
+        // and align_ptr returns the pointer aligned to 32-bit.
         let curval_aligned = unsafe { atomic_load_aligned::<T>(aligned_ptr) };
         let curval = extract_aligned(curval_aligned, shift, mask);
         let newval = f(curval);
         let newval_aligned = insert_aligned(curval_aligned, newval, shift, mask);
-        // FIXME(safety): preconditions review needed
+        // SAFETY: the caller must guarantee that the pointer is valid for read and write,
+        // and align_ptr returns the pointer aligned to 32-bit.
         if unsafe { __kuser_cmpxchg(curval_aligned, newval_aligned, aligned_ptr) } {
             return g(curval, newval);
         }
@@ -125,16 +127,16 @@ unsafe fn atomic_cmpxchg<T>(ptr: *mut T, oldval: u32, newval: u32) -> u32 {
     let (shift, mask) = get_shift_mask(ptr);
 
     loop {
-        // SAFETY: the caller must guarantee that the pointer is valid for read and write
-        // and aligned to the element size.
+        // SAFETY: the caller must guarantee that the pointer is valid for read and write,
+        // and align_ptr returns the pointer aligned to 32-bit.
         let curval_aligned = unsafe { atomic_load_aligned::<T>(aligned_ptr) };
         let curval = extract_aligned(curval_aligned, shift, mask);
         if curval != oldval {
             return curval;
         }
         let newval_aligned = insert_aligned(curval_aligned, newval, shift, mask);
-        // SAFETY: the caller must guarantee that the pointer is valid for read and write
-        // and aligned to the element size.
+        // SAFETY: the caller must guarantee that the pointer is valid for read and write,
+        // and align_ptr returns the pointer aligned to 32-bit.
         if unsafe { __kuser_cmpxchg(curval_aligned, newval_aligned, aligned_ptr) } {
             return oldval;
         }

--- a/compiler-builtins/src/sync/arm_linux.rs
+++ b/compiler-builtins/src/sync/arm_linux.rs
@@ -134,6 +134,9 @@ unsafe fn atomic_cmpxchg<T>(ptr: *mut T, oldval: u32, newval: u32) -> u32 {
         let curval_aligned = unsafe { atomic_load_aligned::<T>(aligned_ptr) };
         let curval = extract_aligned(curval_aligned, shift, mask);
         if curval != oldval {
+            // __sync builtins must have SeqCst semantics. So, failure path, which returns early
+            // without calling __kuser_cmpxchg, must emits a memory barrier.
+            __kuser_memory_barrier();
             return curval;
         }
         let newval_aligned = insert_aligned(curval_aligned, newval, shift, mask);

--- a/compiler-builtins/src/sync/thumbv6k.rs
+++ b/compiler-builtins/src/sync/thumbv6k.rs
@@ -19,7 +19,8 @@ macro_rules! cp15_barrier {
 }
 
 #[instruction_set(arm::a32)]
-unsafe fn fence() {
+fn fence() {
+    // SAFETY: `mcr p15, 0, {zero}, c7, c10, 5` is safe on Armv6k with Arm mode.
     unsafe {
         asm!(
             cp15_barrier!(),
@@ -207,7 +208,6 @@ include!("arm_thumb_shared.rs");
 
 intrinsics! {
     pub unsafe extern "C" fn __sync_synchronize() {
-       // SAFETY: preconditions are the same as the calling function.
-       unsafe { fence() };
+       fence();
     }
 }

--- a/compiler-builtins/src/sync/thumbv6k.rs
+++ b/compiler-builtins/src/sync/thumbv6k.rs
@@ -49,7 +49,7 @@ macro_rules! atomic {
                 // and aligned to the element size.
                 unsafe {
                     asm!(
-                        concat!("ldr", $suffix, " {out}, [{src}]"), // atomic { out = *src }
+                        concat!("ldr", $suffix, " {out}, [{src}]"), // atomic { out = zero_extend(*src) }
                         src = in(reg) src,
                         out = lateout(reg) out,
                         options(nostack, preserves_flags),
@@ -72,19 +72,19 @@ macro_rules! atomic {
                 // LLVM, which omits the preceding fence if no write operation is performed.
                 unsafe {
                     asm!(
-                            concat!("ldrex", $suffix, " {out}, [{dst}]"),      // atomic { out = *dst; EXCLUSIVE = dst }
+                            concat!("ldrex", $suffix, " {out}, [{dst}]"),      // atomic { out = zero_extend(*dst); EXCLUSIVE = dst }
                             "cmp {out}, {old}",                                // if out == old { Z = 1 } else { Z = 0 }
                             "bne 3f",                                          // if Z == 0 { jump 'cmp-fail }
-                            cp15_barrier!(),                                            // fence
+                            cp15_barrier!(),                                   // fence
                         "2:", // 'retry:
                             concat!("strex", $suffix, " {r}, {new}, [{dst}]"), // atomic { if EXCLUSIVE == dst { *dst = new; r = 0 } else { r = 1 }; EXCLUSIVE = None }
                             "cmp {r}, #0",                                     // if r == 0 { Z = 1 } else { Z = 0 }
                             "beq 3f",                                          // if Z == 1 { jump 'success }
-                            concat!("ldrex", $suffix, " {out}, [{dst}]"),      // atomic { out = *dst; EXCLUSIVE = dst }
+                            concat!("ldrex", $suffix, " {out}, [{dst}]"),      // atomic { out = zero_extend(*dst); EXCLUSIVE = dst }
                             "cmp {out}, {old}",                                // if out == old { Z = 1 } else { Z = 0 }
                             "beq 2b",                                          // if Z == 1 { jump 'retry }
                         "3:", // 'cmp-fail | 'success:
-                            cp15_barrier!(),                                            // fence
+                            cp15_barrier!(),                                   // fence
                         dst = in(reg) dst,
                         // Note: this cast must be a zero-extend since loaded value
                         // which compared to it is zero-extended.


### PR DESCRIPTION
This PR contains three commits. The main fix is the last one, and the first two address minor issues such as documentation that I noticed when writing the main fix. I would suggest reviewing by commit, but I can split them into separate PRs if necessary. 

---


Currently, atomic_cmpxchg returns the value obtained from the first relaxed load as-is without calling the kuser helper when comparison fails:

https://github.com/rust-lang/compiler-builtins/blob/5af7a65c0342d3f5ac1d250c7902aaabbfc2bd49/compiler-builtins/src/sync/arm_linux.rs#L130-L134

This is equivalent to `compare_exchange(SeqCst, Relaxed)`, but the `__sync` builtins are expected to have SeqCst semantics in both the success and failure paths, so this is unsound.

This PR fixes this by adding a memory barrier to failure path:

https://github.com/rust-lang/compiler-builtins/blob/c0cdefbe886807089b9a38b3e21a80060caa0472/compiler-builtins/src/sync/arm_linux.rs#L134-L141

Context and Disclosure: This bug had been observed for several years as a rare stress test failure in portable-atomic's CI when testing pre-v6 ARM Linux on ARM hardware (https://gist.github.com/taiki-e/31962f6efe8cc9bc06aa6869bbceb656). In my past investigations, I suspected the bug was with the algorithm used in portable-atomic, so I was unable to identify the cause, but I recently identified the cause by investigating a wider scope with the help of LLMs. (All changes in this PR were written by me.)