### PR TITLE
libm: do not use arch-specific implementations with Miri

### DIFF
--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 set -eux
 
+# We need to disable the randomness that Miri intentionally introduces when
+# performing floating-point operations
 # We need Tree Borrows as some of our raw pointer patterns are not
 # compatible with Stacked Borrows.
-export MIRIFLAGS="-Zmiri-tree-borrows"
+export MIRIFLAGS="-Zmiri-deterministic-floats -Zmiri-tree-borrows"
 
 # One target that sets `mem_unaligned` and one that does not,
 # and a big-endian target.
@@ -20,4 +22,10 @@ for target in "${targets[@]}"; do
         --no-default-features \
         --target "$target" \
         -- mem
+
+    # Run the `libm` tests as well, but not `libm-test` to avoid this taking
+    # too long.
+    cargo miri test \
+        --manifest-path libm/Cargo.toml \
+        --target "$target"
 done

--- a/libm/src/math/arch/mod.rs
+++ b/libm/src/math/arch/mod.rs
@@ -7,7 +7,7 @@
 
 // Most implementations should be defined here, to ensure they are not made available when
 // soft floats are required.
-#[cfg(feature = "arch")]
+#[cfg(all(feature = "arch", not(miri)))]
 cfg_select! {
     all(target_arch = "wasm32", intrinsics_enabled) => {
         mod wasm32;

--- a/libm/src/math/support/big/tests.rs
+++ b/libm/src/math/support/big/tests.rs
@@ -488,6 +488,7 @@ fn i256_shifts() {
     }
 }
 #[test]
+#[cfg_attr(miri, ignore)] // This test is very slow when using Miri
 fn div_u256_by_u128() {
     for j in i8::MIN..=i8::MAX {
         let y: u128 = (j as i128).rotate_right(4).unsigned();

--- a/libm/src/math/support/hex_float.rs
+++ b/libm/src/math/support/hex_float.rs
@@ -586,6 +586,7 @@ mod parse_tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // This test is very slow when using Miri
     fn test_parse_any() {
         for k in -149..=127 {
             let s = format!("0x1p{k}");
@@ -677,6 +678,7 @@ mod parse_tests {
         }
     }
     #[test]
+    #[cfg_attr(miri, ignore)] // This test is very slow when using Miri
     fn long_tail() {
         for k in 1..1000 {
             let s = format!("0x1.{}p0", "0".repeat(k));

--- a/libm/src/math/support/int_traits/narrowing_div.rs
+++ b/libm/src/math/support/int_traits/narrowing_div.rs
@@ -153,6 +153,7 @@ mod test {
     use super::{HInt, NarrowingDiv};
 
     #[test]
+    #[cfg_attr(miri, ignore)] // This test is very slow when using Miri
     fn inverse_mul() {
         for x in 0..=u8::MAX {
             for y in 1..=u8::MAX {

--- a/libm/src/math/support/macros.rs
+++ b/libm/src/math/support/macros.rs
@@ -54,8 +54,8 @@ macro_rules! select_implementation {
             }
         }
 
-        // By default, never use arch-specific implementations if `arch` is disabled.
-        #[cfg(feature = "arch")]
+        // By default, never use arch-specific implementations if `arch` is disabled or with Miri.
+        #[cfg(all(feature = "arch", not(miri)))]
         select_implementation! {
             @cfg $($use_arch)?;
             // Wrap in `if true` to avoid unused warnings

--- a/libm/src/math/support/modular.rs
+++ b/libm/src/math/support/modular.rs
@@ -231,6 +231,7 @@ mod test {
     use crate::support::modular::Reducer;
 
     #[test]
+    #[cfg_attr(miri, ignore)] // This test is very slow when using Miri
     fn reducer_ops() {
         for n in 33..=63_u8 {
             for x in 0..2 * n {
@@ -259,6 +260,7 @@ mod test {
         }
     }
     #[test]
+    #[cfg_attr(miri, ignore)] // This test is very slow when using Miri
     fn reduction_u8() {
         for y in 1..64u8 {
             for x in 0..2 * y {


### PR DESCRIPTION
Miri does not support inline asm statements. Always use the generic implementations under `cfg(miri)`.

Fixes: https://github.com/rust-lang/compiler-builtins/issues/1237