### PR TITLE
c-b: Preserve the NaN sign bit in soft-float addition

### DIFF
--- a/builtins-test/tests/addsub.rs
+++ b/builtins-test/tests/addsub.rs
@@ -117,6 +117,67 @@ macro_rules! float_sum {
 mod float_addsub {
     use super::*;
 
+    macro_rules! nan_sign_test {
+        ($name:ident, $f:ty, $add:path, $one:expr, $snan:expr, $qnan:expr) => {
+            #[test]
+            fn $name() {
+                let one = <$f>::from_bits($one);
+
+                for (input_bits, expected_bits) in [($snan, $qnan), ($qnan, $qnan)] {
+                    let input = <$f>::from_bits(input_bits);
+                    assert_eq!($add(input, one).to_bits(), expected_bits);
+                    assert_eq!($add(one, input).to_bits(), expected_bits);
+                }
+            }
+        };
+    }
+
+    #[cfg(f16_enabled)]
+    nan_sign_test!(
+        addhf3_preserves_nan_sign,
+        f16,
+        compiler_builtins::float::add::__addhf3,
+        0x3c00,
+        0xfc01,
+        0xfe01
+    );
+    nan_sign_test!(
+        addsf3_preserves_nan_sign,
+        f32,
+        compiler_builtins::float::add::__addsf3,
+        0x3f80_0000,
+        0xff80_0001,
+        0xffc0_0001
+    );
+    nan_sign_test!(
+        adddf3_preserves_nan_sign,
+        f64,
+        compiler_builtins::float::add::__adddf3,
+        0x3ff0_0000_0000_0000,
+        0xfff0_0000_0000_0001,
+        0xfff8_0000_0000_0001
+    );
+    #[cfg(f128_enabled)]
+    #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
+    nan_sign_test!(
+        addtf3_preserves_nan_sign,
+        f128,
+        compiler_builtins::float::add::__addtf3,
+        0x3fff_0000_0000_0000_0000_0000_0000_0000,
+        0xffff_0000_0000_0000_0000_0000_0000_0001,
+        0xffff_8000_0000_0000_0000_0000_0000_0001
+    );
+    #[cfg(f128_enabled)]
+    #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
+    nan_sign_test!(
+        addkf3_preserves_nan_sign,
+        f128,
+        compiler_builtins::float::add::__addkf3,
+        0x3fff_0000_0000_0000_0000_0000_0000_0000,
+        0xffff_0000_0000_0000_0000_0000_0000_0001,
+        0xffff_8000_0000_0000_0000_0000_0000_0001
+    );
+
     #[cfg(f16_enabled)]
     float_sum! {
         f16, __addhf3, __subhf3, Half, all();

--- a/builtins-test/tests/addsub.rs
+++ b/builtins-test/tests/addsub.rs
@@ -88,7 +88,7 @@ macro_rules! float_sum {
             fn $fn_add() {
                 use core::ops::{Add, Sub};
                 use imp::{$fn_add, $fn_sub};
-                use compiler_builtins::support::Float;
+                use compiler_builtins::{assert_biteq, support::Float};
 
                 fuzz_float_2(N, |x: $f, y: $f| {
                     let add0 = apfloat_fallback!($f, $apfloat_ty, $sys_available, Add::add, x, y);
@@ -108,6 +108,46 @@ macro_rules! float_sum {
                         );
                     }
                 });
+
+                let qnan = <$f as Float>::NAN;
+                let snan = <$f as Float>::SNAN;
+                let qsnan = <$f as Float>::QSNAN;
+                let neg_qnan = <$f as Float>::NEG_NAN;
+                let neg_snan = <$f as Float>::NEG_SNAN;
+                let neg_qsnan = <$f as Float>::NEG_QSNAN;
+                let one = <$f as Float>::ONE;
+
+                let nan_cases = [
+                    (qnan, qnan, qnan, qnan),
+                    (qnan, snan, qnan, qnan),
+                    (qnan, neg_qnan, qnan, qnan),
+                    (qnan, neg_snan, qnan, qnan),
+                    (qnan, one, qnan, qnan),
+                    (snan, qnan, qsnan, qsnan),
+                    (snan, snan, qsnan, qsnan),
+                    (snan, neg_qnan, qsnan, qsnan),
+                    (snan, neg_snan, qsnan, qsnan),
+                    (snan, one, qsnan, qsnan),
+                    (neg_qnan, qnan, neg_qnan, neg_qnan),
+                    (neg_qnan, snan, neg_qnan, neg_qnan),
+                    (neg_qnan, neg_qnan, neg_qnan, neg_qnan),
+                    (neg_qnan, neg_snan, neg_qnan, neg_qnan),
+                    (neg_qnan, one, neg_qnan, neg_qnan),
+                    (neg_snan, qnan, neg_qsnan, neg_qsnan),
+                    (neg_snan, snan, neg_qsnan, neg_qsnan),
+                    (neg_snan, neg_qnan, neg_qsnan, neg_qsnan),
+                    (neg_snan, neg_snan, neg_qsnan, neg_qsnan),
+                    (neg_snan, one, neg_qsnan, neg_qsnan),
+                    (one, qnan, qnan, neg_qnan),
+                    (one, snan, qsnan, neg_qsnan),
+                    (one, neg_qnan, neg_qnan, qnan),
+                    (one, neg_snan, neg_qsnan, qsnan),
+                ];
+
+                for (x, y, add_expected, sub_expected) in nan_cases {
+                    assert_biteq!($fn_add(x, y), add_expected);
+                    assert_biteq!($fn_sub(x, y), sub_expected);
+                }
             }
         )*
     }

--- a/compiler-builtins/src/float/add.rs
+++ b/compiler-builtins/src/float/add.rs
@@ -33,11 +33,11 @@ where
     if a_abs.wrapping_sub(one) >= inf_rep - one || b_abs.wrapping_sub(one) >= inf_rep - one {
         // NaN + anything = qNaN
         if a_abs > inf_rep {
-            return F::from_bits(a_abs | quiet_bit);
+            return F::from_bits(a_rep | quiet_bit);
         }
         // anything + NaN = qNaN
         if b_abs > inf_rep {
-            return F::from_bits(b_abs | quiet_bit);
+            return F::from_bits(b_rep | quiet_bit);
         }
 
         if a_abs == inf_rep {


### PR DESCRIPTION
Only addition, so not closing rust-lang/compiler-builtins#1188.

The NaN branch in `add.rs` returns `F::from_bits(a_abs | quiet_bit)`, and `a_abs` is `a_rep & abs_mask`, so the sign is already gone by then. `-sNaN + 1.0` comes out `+qNaN`.

mul.rs:50 and div.rs:152 already use `a_rep` in the same branch, so add looks like the odd one out. Using `a_rep` still ORs in `quiet_bit`.

Tests in `addsub.rs` check sNaN and qNaN in both operand positions, by bits, f16 through f128. They fail on main.

Sub is `add(a, -b)`, so `a - NaN` now flips b's sign. Left that alone, wasn't sure if it's wanted.

AI disclosure: used an assistant for the investigation and a first draft of the tests.