### PR TITLE
hexagon: use a single global_asm! block for source-order stability

### DIFF
--- a/compiler-builtins/src/hexagon.rs
+++ b/compiler-builtins/src/hexagon.rs
@@ -44,69 +44,34 @@ intrinsics! {
     }
 }
 
-global_asm!(include_str!("hexagon/func_macro.s"), options(raw));
-
+// All hexagon assembly must live in ONE `global_asm!` invocation, and
+// `func_macro.s` must come first.
 global_asm!(
+    include_str!("hexagon/func_macro.s"),
     include_str!("hexagon/common_entry_exit_abi1.s"),
-    options(raw)
-);
-
-global_asm!(
     include_str!("hexagon/common_entry_exit_abi2.s"),
-    options(raw)
-);
-
-global_asm!(
     include_str!("hexagon/common_entry_exit_legacy.s"),
-    options(raw)
-);
-
-global_asm!(include_str!("hexagon/dfaddsub.s"), options(raw));
-
-global_asm!(include_str!("hexagon/dfdiv.s"), options(raw));
-
-global_asm!(include_str!("hexagon/dffma.s"), options(raw));
-
-global_asm!(include_str!("hexagon/dfminmax.s"), options(raw));
-
-global_asm!(include_str!("hexagon/dfmul.s"), options(raw));
-
-global_asm!(include_str!("hexagon/dfsqrt.s"), options(raw));
-
-global_asm!(include_str!("hexagon/divdi3.s"), options(raw));
-
-global_asm!(include_str!("hexagon/divsi3.s"), options(raw));
-
-global_asm!(include_str!("hexagon/fastmath2_dlib_asm.s"), options(raw));
-
-global_asm!(include_str!("hexagon/fastmath2_ldlib_asm.s"), options(raw));
-
-global_asm!(
+    include_str!("hexagon/dfaddsub.s"),
+    include_str!("hexagon/dfdiv.s"),
+    include_str!("hexagon/dffma.s"),
+    include_str!("hexagon/dfminmax.s"),
+    include_str!("hexagon/dfmul.s"),
+    include_str!("hexagon/dfsqrt.s"),
+    include_str!("hexagon/divdi3.s"),
+    include_str!("hexagon/divsi3.s"),
+    include_str!("hexagon/fastmath2_dlib_asm.s"),
+    include_str!("hexagon/fastmath2_ldlib_asm.s"),
     include_str!("hexagon/memcpy_forward_vp4cp4n2.s"),
-    options(raw)
-);
-
-global_asm!(
     include_str!("hexagon/memcpy_likely_aligned.s"),
+    include_str!("hexagon/moddi3.s"),
+    include_str!("hexagon/modsi3.s"),
+    include_str!("hexagon/sfdiv_opt.s"),
+    include_str!("hexagon/sfsqrt_opt.s"),
+    include_str!("hexagon/udivdi3.s"),
+    include_str!("hexagon/udivmoddi4.s"),
+    include_str!("hexagon/udivmodsi4.s"),
+    include_str!("hexagon/udivsi3.s"),
+    include_str!("hexagon/umoddi3.s"),
+    include_str!("hexagon/umodsi3.s"),
     options(raw)
 );
-
-global_asm!(include_str!("hexagon/moddi3.s"), options(raw));
-
-global_asm!(include_str!("hexagon/modsi3.s"), options(raw));
-
-global_asm!(include_str!("hexagon/sfdiv_opt.s"), options(raw));
-
-global_asm!(include_str!("hexagon/sfsqrt_opt.s"), options(raw));
-
-global_asm!(include_str!("hexagon/udivdi3.s"), options(raw));
-
-global_asm!(include_str!("hexagon/udivmoddi4.s"), options(raw));
-
-global_asm!(include_str!("hexagon/udivmodsi4.s"), options(raw));
-
-global_asm!(include_str!("hexagon/udivsi3.s"), options(raw));
-
-global_asm!(include_str!("hexagon/umoddi3.s"), options(raw));
-
-global_asm!(include_str!("hexagon/umodsi3.s"), options(raw));


### PR DESCRIPTION
Since rust-lang/rust#145358 ("Sort mono items by symbol name", merged 2025-08-22), rustc sorts mono items within a codegen unit by symbol name rather than source order unless -Zcodegen-source-order is passed.

That breaks func_macro.s, which defines asm macros for use by "later" files.

Merge all includes into one global_asm! call. A single MonoItem cannot be reordered against itself, so the source order becomes the order the assembler sees. The file set and its order are unchanged, and all these items already shared one codegen unit, so object-file granularity is unaffected.

Closes: https://github.com/rust-lang/compiler-builtins/issues/1240