### PR TITLE
Fixes for rustfmt now formatting cfg_select

### DIFF
--- a/compiler-builtins/src/float/cmp.rs
+++ b/compiler-builtins/src/float/cmp.rs
@@ -1,6 +1,6 @@
 #![allow(unreachable_code)]
 
-use crate::support::{Float, MinInt, cfg_select};
+use crate::support::{Float, MinInt, cfg_select_nofmt};
 
 // These definitions should be consistent with LLVM's definition from `getCmpLibcallReturnType`,
 // compiler-rt's definitions [1], GCC's `CMPtype` [2], and `libgcc`. To find the definitions
@@ -12,7 +12,7 @@ use crate::support::{Float, MinInt, cfg_select};
 //
 // [1]: https://github.com/llvm/llvm-project/blob/0cf3c437c18ed27d9663d87804a9a15ff6874af2/compiler-rt/lib/builtins/fp_compare_impl.inc#L11-L27
 // [2]: https://gcc.gnu.org/onlinedocs/gccint/Soft-float-library-routines.html#Comparison-functions-1
-cfg_select! {
+cfg_select_nofmt! {
     any(target_arch = "aarch64", target_arch = "arm64ec", target_family = "wasm") => {
         // Aarch64 uses `int` rather than a pointer-sized value.
         // `getCmpLibcallReturnType` for WASM is always set to i32.

--- a/crates/util/src/main.rs
+++ b/crates/util/src/main.rs
@@ -8,7 +8,7 @@ use std::env;
 use std::num::ParseIntError;
 use std::str::FromStr;
 
-use libm::support::{Float, Hex, cfg_select, hf32, hf64};
+use libm::support::{Float, Hex, hf32, hf64};
 #[cfg(feature = "build-mpfr")]
 use libm_test::mpfloat::MpOp;
 use libm_test::{MathOp, TupleCall, builtins_wrapper};

--- a/crates/util/src/main.rs
+++ b/crates/util/src/main.rs
@@ -158,8 +158,10 @@ fn do_classify(inputs: &[&str]) {
                     continue;
                 }
                 _ => {
-                    panic!("parsing this type requires f128 support and \
-                            the `build-mpfr` feature: `{s}`");
+                    panic!(
+                        "parsing this type requires f128 support and \
+                        the `build-mpfr` feature: `{s}`"
+                    );
                 }
             }
         };

--- a/libm/src/math/arch/mod.rs
+++ b/libm/src/math/arch/mod.rs
@@ -8,7 +8,7 @@
 // Most implementations should be defined here, to ensure they are not made available when
 // soft floats are required.
 #[cfg(all(feature = "arch", not(miri)))]
-cfg_select! {
+cfg_select_nofmt! {
     all(target_arch = "wasm32", intrinsics_enabled) => {
         mod wasm32;
         pub use wasm32::{
@@ -59,7 +59,7 @@ cfg_select! {
 
 // There are certain architecture-specific implementations that are needed for correctness
 // even with `arch` disabled. These are configured here.
-cfg_select! {
+cfg_select_nofmt! {
     x86_no_sse2 => {
         mod i586;
         pub use i586::{

--- a/libm/src/math/mod.rs
+++ b/libm/src/math/mod.rs
@@ -67,7 +67,7 @@ pub mod support;
 #[cfg(not(feature = "unstable-public-internals"))]
 pub(crate) mod support;
 
-cfg_select! {
+cfg_select_nofmt! {
     feature = "unstable-public-internals" => {
         pub mod generic;
     }
@@ -297,7 +297,7 @@ pub use self::tgamma::tgamma;
 pub use self::tgammaf::tgammaf;
 pub use self::trunc::{trunc, truncf};
 
-cfg_select! {
+cfg_select_nofmt! {
     f16_enabled => {
         mod fmaf16;
 
@@ -326,7 +326,7 @@ cfg_select! {
     _ => {}
 }
 
-cfg_select! {
+cfg_select_nofmt! {
     f128_enabled => {
         // verify-sorted-start
         pub use self::ceil::ceilf128;

--- a/libm/src/math/support/big.rs
+++ b/libm/src/math/support/big.rs
@@ -294,7 +294,7 @@ impl fmt::Debug for i256 {
 
 impl fmt::LowerHex for u256 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        cfg_select! {
+        cfg_select_nofmt! {
             feature = "compiler-builtins" => {
                 let _ = f;
                 unimplemented!()

--- a/libm/src/math/support/float_traits.rs
+++ b/libm/src/math/support/float_traits.rs
@@ -337,7 +337,7 @@ macro_rules! float_impl {
                 Self::from_bits(a)
             }
             fn abs(self) -> Self {
-                cfg_select! {
+                cfg_select_nofmt! {
                     // FIXME(msrv): `abs` is available in `core` starting with 1.85.
                     intrinsics_enabled => {
                         self.abs()
@@ -348,7 +348,7 @@ macro_rules! float_impl {
                 }
             }
             fn copysign(self, other: Self) -> Self {
-                cfg_select! {
+                cfg_select_nofmt! {
                     // FIXME(msrv): `copysign` is available in `core` starting with 1.85.
                     intrinsics_enabled => {
                         self.copysign(other)
@@ -359,7 +359,7 @@ macro_rules! float_impl {
                 }
             }
             fn fma(self, y: Self, z: Self) -> Self {
-                cfg_select! {
+                cfg_select_nofmt! {
                     // fma is not yet available in `core`
                     intrinsics_enabled => {
                         core::intrinsics::$fma_intrinsic(self, y, z)

--- a/libm/src/math/support/hex_float.rs
+++ b/libm/src/math/support/hex_float.rs
@@ -448,7 +448,7 @@ mod hex_fmt {
     // Not really a meaningful impl, but makes some generics easier.
     impl DisplayHex for bool {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            cfg_select! {
+            cfg_select_nofmt! {
                 feature = "compiler-builtins" => {
                     let _ = f;
                     unimplemented!()

--- a/libm/src/math/support/macros.rs
+++ b/libm/src/math/support/macros.rs
@@ -1,9 +1,13 @@
 // Because `cfg_select` requires rust verion 1.95 and we support older versions,
 // we use the following replacement until that is no longer true.
+//
+// Doesn't support the syntax that rustfmt changes to, hence not calling it just
+// `cfg_seelect`.
+//
 // FIXME(msrv)
-macro_rules! cfg_select {
+macro_rules! cfg_select_nofmt {
     ({ $($tt:tt)* }) => {{
-        $crate::cfg_select! { $($tt)* }
+        $crate::cfg_select_nofmt! { $($tt)* }
     }};
     (_ => { $($output:tt)* }) => {
         $($output)*
@@ -13,10 +17,10 @@ macro_rules! cfg_select {
         $($( $rest:tt )+)?
     ) => {
         #[cfg($cfg)]
-        cfg_select! { _ => $output }
+        cfg_select_nofmt! { _ => $output }
         $(
             #[cfg(not($cfg))]
-            cfg_select! { $($rest)+ }
+            cfg_select_nofmt! { $($rest)+ }
         )?
     }
 }

--- a/libm/src/math/support/macros.rs
+++ b/libm/src/math/support/macros.rs
@@ -1,7 +1,6 @@
 // Because `cfg_select` requires rust verion 1.95 and we support older versions,
 // we use the following replacement until that is no longer true.
 // FIXME(msrv)
-#[macro_export]
 macro_rules! cfg_select {
     ({ $($tt:tt)* }) => {{
         $crate::cfg_select! { $($tt)* }

--- a/libm/src/math/support/mod.rs
+++ b/libm/src/math/support/mod.rs
@@ -14,7 +14,7 @@ mod modular;
 pub use big::{i256, u256};
 // Clippy seems to have a false positive
 #[allow(unused_imports, clippy::single_component_path_imports)]
-pub use cfg_select;
+pub(crate) use cfg_select;
 pub use env::{FpResult, Round, Status};
 #[allow(unused_imports)]
 pub use float_traits::{Float, HalfRep, IntTy, NarrowFloat, WideFloat};

--- a/libm/src/math/support/mod.rs
+++ b/libm/src/math/support/mod.rs
@@ -14,7 +14,7 @@ mod modular;
 pub use big::{i256, u256};
 // Clippy seems to have a false positive
 #[allow(unused_imports, clippy::single_component_path_imports)]
-pub(crate) use cfg_select;
+pub(crate) use cfg_select_nofmt;
 pub use env::{FpResult, Round, Status};
 #[allow(unused_imports)]
 pub use float_traits::{Float, HalfRep, IntTy, NarrowFloat, WideFloat};
@@ -40,7 +40,7 @@ pub fn cold_path() {
 ///
 /// `y` must not be zero and the result must not overflow (`x > i32::MIN`).
 pub unsafe fn unchecked_div_i32(x: i32, y: i32) -> i32 {
-    cfg_select! {
+    cfg_select_nofmt! {
         all(not(debug_assertions), intrinsics_enabled) => {
             // Temporary macro to avoid panic codegen for division (in debug mode too). At
             // the time of this writing this is only used in a few places, and once
@@ -61,7 +61,7 @@ pub unsafe fn unchecked_div_i32(x: i32, y: i32) -> i32 {
 ///
 /// `y` must not be zero and the result must not overflow (`x > isize::MIN`).
 pub unsafe fn unchecked_div_isize(x: isize, y: isize) -> isize {
-    cfg_select! {
+    cfg_select_nofmt! {
         all(not(debug_assertions), intrinsics_enabled) => {
             unsafe { core::intrinsics::unchecked_div(x, y) }
         }


### PR DESCRIPTION
The latest rustfmt now formats `cfg_select` syntax.

ci: skip-extensive