### PR TITLE
meta: Clean up lints

### DIFF
--- a/compiler-builtins/src/lib.rs
+++ b/compiler-builtins/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(feature = "compiler-builtins", compiler_builtins)]
-#![cfg_attr(all(target_family = "wasm"), feature(wasm_numeric_instr))]
+#![no_builtins]
+#![no_std]
+//
 #![feature(abi_custom)]
 #![feature(abi_unadjusted)]
 #![feature(asm_experimental_arch)]
@@ -12,8 +14,8 @@
 #![feature(rustc_attrs)]
 #![cfg_attr(f16_enabled, feature(f16))]
 #![cfg_attr(f128_enabled, feature(f128))]
-#![no_builtins]
-#![no_std]
+#![cfg_attr(all(target_family = "wasm"), feature(wasm_numeric_instr))]
+//
 #![allow(unstable_name_collisions)] // FIXME(float_bits_const): remove when stable
 #![allow(unused_features)]
 #![allow(internal_features)]
@@ -21,9 +23,6 @@
 #![allow(clippy::manual_swap)]
 // Support compiling on both stage0 and stage1 which may differ in supported stable features.
 #![allow(stable_features)]
-// By default, disallow this as it is forbidden in edition 2024. There is a lot of unsafe code to
-// be migrated, however, so exceptions exist.
-#![warn(unsafe_op_in_unsafe_fn)]
 
 // We disable #[no_mangle] for tests so that we can verify the test results
 // against the native compiler-rt implementations of the builtins.

--- a/libm/src/lib.rs
+++ b/libm/src/lib.rs
@@ -1,5 +1,6 @@
 //! libm in pure Rust
 #![no_std]
+//
 #![cfg_attr(intrinsics_enabled, allow(internal_features))]
 #![cfg_attr(intrinsics_enabled, feature(core_intrinsics))]
 #![cfg_attr(
@@ -8,21 +9,26 @@
 )]
 #![cfg_attr(f128_enabled, feature(f128))]
 #![cfg_attr(f16_enabled, feature(f16))]
-#![allow(unstable_name_collisions)] // FIXME(float_bits_const): remove when stable
+//
+// The edition is 2021 but we follow 2024 idioms.
+#![deny(rust_2024_compatibility)]
+#![allow(edition_2024_expr_fragment_specifier)]
+//
+// FIXME(float_bits_const): remove when stable
+#![allow(unstable_name_collisions)]
+// Allow idioms that come from ported C or may be more clear
 #![allow(clippy::assign_op_pattern)]
-#![allow(clippy::deprecated_cfg_attr)]
-#![allow(clippy::eq_op)]
-#![allow(clippy::excessive_precision)]
-#![allow(clippy::float_cmp)]
 #![allow(clippy::int_plus_one)]
-#![allow(clippy::just_underscores_and_digits)]
-#![allow(clippy::many_single_char_names)]
-#![allow(clippy::mixed_case_hex_literals)]
 #![allow(clippy::needless_late_init)]
 #![allow(clippy::needless_return)]
-#![allow(clippy::unreadable_literal)]
+// Literals are usually intentional
+#![allow(clippy::excessive_precision)]
+// Allow needed patterns like `(z - z) / (z - z)` and `0.0 / 0.0` that we need for exceptions
+// and rounding.
+#![allow(clippy::eq_op)]
 #![allow(clippy::zero_divided_by_zero)]
-#![forbid(unsafe_op_in_unsafe_fn)]
+// In generic code we use bits like `let _0 = F::ZERO`
+#![allow(clippy::just_underscores_and_digits)]
 
 mod libm_helper;
 mod math;

--- a/libm/src/math/lgammaf_r.rs
+++ b/libm/src/math/lgammaf_r.rs
@@ -178,7 +178,7 @@ pub fn lgammaf_r(mut x: f32) -> (f32, i32) {
                 /* [1.7316,2] */
                 y = 2.0 - x;
                 i = 0;
-            } else if ix >= 0x3F9da620 {
+            } else if ix >= 0x3f9da620 {
                 /* [1.23,1.73] */
                 y = x - TC;
                 i = 1;

--- a/libm/src/math/sin.rs
+++ b/libm/src/math/sin.rs
@@ -88,7 +88,7 @@ mod tests {
     #[test]
     #[cfg_attr(x86_no_sse2, ignore = "FIXME(i586): possible incorrect rounding")]
     fn test_near_pi() {
-        let x = f64::from_bits(0x400921fb000FD5DD); // 3.141592026217707
+        let x = f64::from_bits(0x400921fb000fd5dd); // 3.141592026217707
         let sx = f64::from_bits(0x3ea50d15ced1a4a2); // 6.273720864039205e-7
         assert_eq!(sin(x), sx);
     }


### PR DESCRIPTION
* Deny rust-2024-compatibility in `libm` (our only edition 2021 crate)
* Fix mixed hex cases
* Remove `allow`s for lints that have no issues
* Add comments about `allow`s
* Group the attributes