### PR TITLE
bench: Update pinned nightly to 2026-05-23

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: full
-  BENCHMARK_RUSTC: nightly-2026-02-10 # Pin the toolchain for reproducable results
+  BENCHMARK_RUSTC: nightly-2026-05-23 # Pin the toolchain for reproducable results
 
 defaults:
   run:


### PR DESCRIPTION
Advance to after the first regression in `hypot` but before the second regression. See [1] for context on the regression.

[1]: https://github.com/rust-lang/compiler-builtins/issues/1249

ci: allow-regressions