### PR TITLE
bench: Update pinned nightly to 2026-05-24

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: full
-  BENCHMARK_RUSTC: nightly-2026-05-23 # Pin the toolchain for reproducable results
+  BENCHMARK_RUSTC: nightly-2026-05-24 # Pin the toolchain for reproducable results
 
 defaults:
   run:


### PR DESCRIPTION
2026-05-23 to 2026-05-24 includes a regression on aarch64, but this
seems to be in the setup code rather than the math code.

Link: https://github.com/rust-lang/rust/issues/160702

ci: allow-regressions