### PR TITLE
ci: Disable install-action fallback for nextest

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -140,8 +140,13 @@ jobs:
       run: ./ci/install-test-deps.sh "$JOB_TARGET" "$JOB_CHANNEL" "$RUN_IN_DOCKER"
 
     - uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
+      continue-on-error: true
       with:
         tool: nextest@0.9.131
+        # On platforms without prebuilts, nextest can be installed system-wide
+        # or omitted. Building it probably takes longer than running tests
+        # without it
+        fallback: none
 
     - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -150,8 +150,13 @@ jobs:
         rustup target add "$JOB_TARGET"
 
     - uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+      continue-on-error: true
       with:
         tool: nextest@0.9.131
+        # On platforms without prebuilts, nextest can be installed system-wide
+        # or omitted. Building it probably takes longer than running tests
+        # without it
+        fallback: none
 
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:

--- a/builtins-test/Cargo.toml
+++ b/builtins-test/Cargo.toml
@@ -37,6 +37,10 @@ icount = ["dep:gungraun"]
 benchmarking-reports = ["walltime", "criterion/plotters", "criterion/html_reports"]
 walltime = ["dep:criterion"]
 
+[lints.clippy]
+# This sometimes reads better
+needless-range-loop = "allow"
+
 [[bench]]
 name = "float_add"
 harness = false


### PR DESCRIPTION
This should make it fall back to a system-wide cargo-nextest install or running the tests without nextest, which is probably still faster than building nextest from source.