### PR TITLE
renovate: Add a custom manager to bump the benchmark toolchain

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ indent_size = 4
 
 [*.{yaml,yml}]
 indent_size = 2
+
+[*.json*]
+indent_size = 2

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,7 +24,18 @@
       // Every month
       schedule: "* 0 1 * *",
       groupName: "Github Actions",
-    }
+    },
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [".github/workflows/main.yaml"],
+      "matchStrings": ["BENCHMARK_RUSTC:\\s*(?<currentValue>\\S+)"],
+      "autoReplaceStringTemplate": "BENCHMARK_RUSTC: {{{newValue}}}",
+      "depNameTemplate": "nightly",
+      "datasourceTemplate": "rust-version",
+      "versioningTemplate": "rust-release-channel",
+    },
   ],
   // Receive any update that fixes security vulnerabilities.
   // We need this because we disabled "patch" updates for Rust.


### PR DESCRIPTION
It would be good to bump this on a monthly schedule to avoid catching up later and finding regressions.