### PR TITLE
bench: Update pinned nightly to 2026-08-05

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: full
-  BENCHMARK_RUSTC: nightly-2026-05-24 # Pin the toolchain for reproducable results
+  BENCHMARK_RUSTC: nightly-2026-08-05 # Pin the toolchain for reproducable results
 
 defaults:
   run:


### PR DESCRIPTION
One version before the LLVM update.

ci: allow-regressions