### PR TITLE
bench: Update pinned nightly to 2026-08-06

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: full
-  BENCHMARK_RUSTC: nightly-2026-08-05 # Pin the toolchain for reproducable results
+  BENCHMARK_RUSTC: nightly-2026-08-06 # Pin the toolchain for reproducable results
 
 defaults:
   run:


### PR DESCRIPTION
This is the first version with LLVM23.

ci: allow-regressions