### PR TITLE
Add integer to `f16` conversions

### DIFF
--- a/builtins-test-intrinsics/src/main.rs
+++ b/builtins-test-intrinsics/src/main.rs
@@ -294,6 +294,11 @@ mod intrinsics {
         x as f128
     }
 
+    #[cfg(f16_enabled)]
+    pub fn floatsihf(x: i32) -> f16 {
+        x as f16
+    }
+
     pub fn aeabi_idiv(a: i32, b: i32) -> i32 {
         a.wrapping_div(b)
     }
@@ -317,6 +322,11 @@ mod intrinsics {
     #[cfg(f128_enabled)]
     pub fn floatditf(x: i64) -> f128 {
         x as f128
+    }
+
+    #[cfg(f16_enabled)]
+    pub fn floatdihf(x: i64) -> f16 {
+        x as f16
     }
 
     pub fn mulodi4(a: i64, b: i64) -> i64 {
@@ -352,6 +362,11 @@ mod intrinsics {
         x as f128
     }
 
+    #[cfg(f16_enabled)]
+    pub fn floattihf(x: i128) -> f16 {
+        x as f16
+    }
+
     pub fn lshrti3(a: i128, b: usize) -> i128 {
         a >> b
     }
@@ -381,6 +396,11 @@ mod intrinsics {
         x as f128
     }
 
+    #[cfg(f16_enabled)]
+    pub fn floatunsihf(x: u32) -> f16 {
+        x as f16
+    }
+
     pub fn aeabi_uidiv(a: u32, b: u32) -> u32 {
         a / b
     }
@@ -406,6 +426,11 @@ mod intrinsics {
         x as f128
     }
 
+    #[cfg(f16_enabled)]
+    pub fn floatundihf(x: u64) -> f16 {
+        x as f16
+    }
+
     // udivdi3
     pub fn aeabi_uldivmod(a: u64, b: u64) -> u64 {
         a * b
@@ -428,6 +453,11 @@ mod intrinsics {
     #[cfg(f128_enabled)]
     pub fn floatuntitf(x: u128) -> f128 {
         x as f128
+    }
+
+    #[cfg(f16_enabled)]
+    pub fn floatuntihf(x: u128) -> f16 {
+        x as f16
     }
 
     pub fn muloti4(a: u128, b: u128) -> Option<u128> {
@@ -550,6 +580,18 @@ fn run() {
     bb(floatuntisf(bb(2)));
     #[cfg(f128_enabled)]
     bb(floatuntitf(bb(2)));
+    #[cfg(f16_enabled)]
+    bb(floatsihf(bb(2)));
+    #[cfg(f16_enabled)]
+    bb(floatdihf(bb(2)));
+    #[cfg(f16_enabled)]
+    bb(floattihf(bb(2)));
+    #[cfg(f16_enabled)]
+    bb(floatunsihf(bb(2)));
+    #[cfg(f16_enabled)]
+    bb(floatundihf(bb(2)));
+    #[cfg(f16_enabled)]
+    bb(floatuntihf(bb(2)));
     #[cfg(f128_enabled)]
     bb(gttf(bb(2.), bb(2.)));
     bb(lshrti3(bb(2), bb(2)));

--- a/builtins-test/build.rs
+++ b/builtins-test/build.rs
@@ -13,6 +13,7 @@ enum SetCfg {
     NoSysF16,
     NoSysF16F64Convert,
     NoSysF16F128Convert,
+    NoSysF16IntConvert,
 }
 
 impl SetCfg {
@@ -22,15 +23,22 @@ impl SetCfg {
         Self::NoSysF16,
         Self::NoSysF16F64Convert,
         Self::NoSysF16F128Convert,
+        Self::NoSysF16IntConvert,
     ];
 
     fn implies(self) -> &'static [Self] {
         match self {
             Self::NoSysF128 => [Self::NoSysF128IntConvert, Self::NoSysF16F128Convert].as_slice(),
             Self::NoSysF128IntConvert => [].as_slice(),
-            Self::NoSysF16 => [Self::NoSysF16F64Convert, Self::NoSysF16F128Convert].as_slice(),
+            Self::NoSysF16 => [
+                Self::NoSysF16F64Convert,
+                Self::NoSysF16F128Convert,
+                Self::NoSysF16IntConvert,
+            ]
+            .as_slice(),
             Self::NoSysF16F64Convert => [].as_slice(),
             Self::NoSysF16F128Convert => [].as_slice(),
+            Self::NoSysF16IntConvert => [].as_slice(),
         }
     }
 
@@ -41,6 +49,7 @@ impl SetCfg {
             Self::NoSysF16F64Convert => "no_sys_f16_f64_convert",
             Self::NoSysF16F128Convert => "no_sys_f16_f128_convert",
             Self::NoSysF16 => "no_sys_f16",
+            Self::NoSysF16IntConvert => "no_sys_f16_int_convert",
         }
     }
 }
@@ -74,6 +83,8 @@ fn main() {
         to_set.insert(SetCfg::NoSysF128IntConvert);
         // FIXME: 32-bit x86 has a bug in `f128 -> f16` system libraries
         to_set.insert(SetCfg::NoSysF16F128Convert);
+        // 32-bit x86 libgcc does not provide the 128-bit integer to `f16` routines
+        to_set.insert(SetCfg::NoSysF16IntConvert);
     }
 
     // These platforms do not have f16 symbols available in their system libraries, so
@@ -95,9 +106,11 @@ fn main() {
         to_set.insert(SetCfg::NoSysF16);
     }
 
-    // These platforms are missing either `__extendhfdf2` or `__truncdfhf2`.
+    // These platforms are missing either `__extendhfdf2` or `__truncdfhf2`, and also
+    // lack the integer-to-`f16` conversion routines in their system libraries.
     if cfg.target_vendor == "apple" || cfg.target_os == "windows" {
         to_set.insert(SetCfg::NoSysF16F64Convert);
+        to_set.insert(SetCfg::NoSysF16IntConvert);
     }
 
     // Add implied features. Collection is required for borrows.

--- a/builtins-test/tests/conv.rs
+++ b/builtins-test/tests/conv.rs
@@ -18,7 +18,7 @@ mod i_to_f {
                 #[test]
                 fn $fn() {
                     use compiler_builtins::float::conv::$fn;
-                    use compiler_builtins::support::Int;
+                    use compiler_builtins::support::{Int, MinInt};
 
                     fuzz(N, |x: $i_ty| {
                         let f0 = apfloat_fallback!(
@@ -27,51 +27,83 @@ mod i_to_f {
                             // When the builtin is not available, we need to use a different conversion
                             // method (since apfloat doesn't support `as` casting).
                             |x: $i_ty| {
-                                use compiler_builtins::support::MinInt;
-
                                 let apf = if <$i_ty>::SIGNED {
                                     FloatTy::from_i128(x.try_into().unwrap()).value
                                 } else {
                                     FloatTy::from_u128(x.try_into().unwrap()).value
                                 };
 
-                                <$f_ty>::from_bits(apf.to_bits())
+                                <$f_ty>::from_bits(apf.to_bits().try_into().unwrap())
                             },
                             x
                         );
                         let f1: $f_ty = $fn(x);
 
+                        // This makes sure that the conversion produced the best rounding possible,
+                        // and does this independent of `x as $into` rounding correctly. It also
+                        // exercises the `f -> i` cast, which catches ABI and platform bugs that a
+                        // comparison against arbitrary-precision math would not.
+                        //
                         #[cfg($sys_available)] {
-                            // This makes sure that the conversion produced the best rounding possible, and does
-                            // this independent of `x as $into` rounding correctly.
-                            // This assumes that float to integer conversion is correct.
-                            let y_minus_ulp = <$f_ty>::from_bits(f1.to_bits().wrapping_sub(1)) as $i_ty;
-                            let y = f1 as $i_ty;
-                            let y_plus_ulp = <$f_ty>::from_bits(f1.to_bits().wrapping_add(1)) as $i_ty;
-                            let error_minus = <$i_ty as Int>::abs_diff(y_minus_ulp, x);
-                            let error = <$i_ty as Int>::abs_diff(y, x);
-                            let error_plus = <$i_ty as Int>::abs_diff(y_plus_ulp, x);
+                            if f1.is_infinite() {
+                                // Integer-to-float overflow is rounded as though the exponent were
+                                // unbounded. Recover the overflow threshold from the two largest
+                                // finite values, avoiding the meaningless `inf`/NaN-to-int casts.
+                                let y_toward_zero =
+                                    <$f_ty>::from_bits(f1.to_bits().wrapping_sub(1)) as $i_ty;
+                                let y_next_toward_zero =
+                                    <$f_ty>::from_bits(f1.to_bits().wrapping_sub(2)) as $i_ty;
+                                let half_ulp = <$i_ty as Int>::abs_diff(
+                                    y_toward_zero,
+                                    y_next_toward_zero,
+                                ) >> 1;
+                                let error = <$i_ty as Int>::abs_diff(y_toward_zero, x);
 
-                            // The first two conditions check that none of the two closest float values are
-                            // strictly closer in representation to `x`. The second makes sure that rounding is
-                            // towards even significand if two float values are equally close to the integer.
-                            if error_minus < error
-                                || error_plus < error
-                                || ((error_minus == error || error_plus == error)
-                                    && ((f0.to_bits() & 1) != 0))
-                            {
-                                panic!(
-                                    "incorrect rounding by {}({}): {}, ({}, {}, {}), errors ({}, {}, {})",
-                                    stringify!($fn),
-                                    x,
-                                    f1.to_bits(),
-                                    y_minus_ulp,
-                                    y,
-                                    y_plus_ulp,
-                                    error_minus,
-                                    error,
-                                    error_plus,
-                                );
+                                // Equality is the tie case: the unbounded power of two has an even
+                                // significand, so it rounds outward and then saturates to infinity.
+                                let x_is_negative = <$i_ty>::SIGNED && x.signed() < 0;
+                                if f1.is_sign_negative() != x_is_negative || error < half_ulp
+                                {
+                                    panic!(
+                                        "incorrect overflow by {}({}): {}, threshold error {} (half ULP {})",
+                                        stringify!($fn),
+                                        x,
+                                        f1.to_bits(),
+                                        error,
+                                        half_ulp,
+                                    );
+                                }
+                            } else {
+                                let y_minus_ulp =
+                                    <$f_ty>::from_bits(f1.to_bits().wrapping_sub(1)) as $i_ty;
+                                let y = f1 as $i_ty;
+                                let y_plus_ulp =
+                                    <$f_ty>::from_bits(f1.to_bits().wrapping_add(1)) as $i_ty;
+                                let error_minus = <$i_ty as Int>::abs_diff(y_minus_ulp, x);
+                                let error = <$i_ty as Int>::abs_diff(y, x);
+                                let error_plus = <$i_ty as Int>::abs_diff(y_plus_ulp, x);
+
+                                // The first two conditions check that none of the two closest float values are
+                                // strictly closer in representation to `x`. The second makes sure that rounding is
+                                // towards even significand if two float values are equally close to the integer.
+                                if error_minus < error
+                                    || error_plus < error
+                                    || ((error_minus == error || error_plus == error)
+                                        && ((f0.to_bits() & 1) != 0))
+                                {
+                                    panic!(
+                                        "incorrect rounding by {}({}): {}, ({}, {}, {}), errors ({}, {}, {})",
+                                        stringify!($fn),
+                                        x,
+                                        f1.to_bits(),
+                                        y_minus_ulp,
+                                        y,
+                                        y_plus_ulp,
+                                        error_minus,
+                                        error,
+                                        error_plus,
+                                    );
+                                }
                             }
                         }
 
@@ -95,6 +127,16 @@ mod i_to_f {
                 }
             )*
         };
+    }
+
+    #[cfg(f16_enabled)]
+    i_to_f! { f16, Half, not(no_sys_f16_int_convert),
+        u32, __floatunsihf;
+        i32, __floatsihf;
+        u64, __floatundihf;
+        i64, __floatdihf;
+        u128, __floatuntihf;
+        i128, __floattihf;
     }
 
     i_to_f! { f32, Single, all(),

--- a/compiler-builtins/README.md
+++ b/compiler-builtins/README.md
@@ -159,11 +159,17 @@ of being added to Rust.
 - [x] fixunstfdi.c
 - [x] fixunstfsi.c
 - [x] fixunstfti.c
+- [x] floatdihf.c (not yet in `compiler-rt` but emitted by LLVM)
 - [x] floatditf.c
+- [x] floatsihf.c (not yet in `compiler-rt` but emitted by LLVM)
 - [x] floatsitf.c
+- [x] floattihf.c (not yet in `compiler-rt` but emitted by LLVM)
 - [x] floattitf.c
+- [x] floatundihf.c (not yet in `compiler-rt` but emitted by LLVM)
 - [x] floatunditf.c
+- [x] floatunsihf.c (not yet in `compiler-rt` but emitted by LLVM)
 - [x] floatunsitf.c
+- [x] floatuntihf.c (not yet in `compiler-rt` but emitted by LLVM)
 - [x] floatuntitf.c
 - [x] multf3.c
 - [x] powitf2.c

--- a/compiler-builtins/src/float/conv.rs
+++ b/compiler-builtins/src/float/conv.rs
@@ -77,6 +77,26 @@ mod int_to_float {
         F::from_bits(conv(i.unsigned_abs()) | sign_bit)
     }
 
+    #[cfg(f16_enabled)]
+    pub fn u32_to_f16_bits(i: u32) -> u16 {
+        let n = i.leading_zeros();
+        let i_m = i.wrapping_shl(n);
+        // Mantissa with implicit bit set
+        let m_base: u16 = (i_m >> shift_f_lt_i::<u32, f16>()) as u16;
+        // The entire lower half of `i` will be truncated (masked portion), plus the
+        // next `EXP_BITS` bits.
+        let adj = (i_m >> f16::EXP_BITS | i_m & 0xFF) as u16;
+        let m = m_adj::<f16>(m_base, adj);
+        let e = if i == 0 { 0 } else { exp::<u32, f16>(n) - 1 };
+        // Any int can have an exponent out of range for `f16`, unlike other float types.
+        // Clamp this.
+        if e >= f16::EXP_SAT as u16 - 1 {
+            f16::INFINITY.to_bits()
+        } else {
+            repr::<f16>(e, m)
+        }
+    }
+
     pub fn u32_to_f32_bits(i: u32) -> u32 {
         if i == 0 {
             return 0;
@@ -120,6 +140,33 @@ mod int_to_float {
         (h as u128) << 64
     }
 
+    #[cfg(f16_enabled)]
+    pub fn u64_to_f16_bits(i: u64) -> u16 {
+        let n = i.leading_zeros();
+        let i_m = i.wrapping_shl(n); // Mantissa, shifted so the first bit is nonzero
+        let m_base: u16 = (i_m >> shift_f_lt_i::<u64, f16>()) as u16;
+
+        // Within the upper `F::BITS`, everything except for the signifcand
+        // gets truncated
+        let d1: u16 = (i_m >> (u64::BITS - f16::BITS - f16::SIG_BITS - 1)).cast_lossy();
+
+        // The entire rest of `i_m` gets truncated. Zero the upper `F::BITS` then just
+        // check if it is nonzero.
+        let d2: u16 = (i_m << f16::BITS >> f16::BITS != 0).into();
+        let adj = d1 | d2;
+
+        // Mantissa with implicit bit set
+        let m = m_adj::<f16>(m_base, adj);
+        let e = if i == 0 { 0 } else { exp::<u64, f16>(n) - 1 };
+
+        // Clamp to infinity if the exponent is out of range
+        if e >= f16::EXP_SAT as u16 - 1 {
+            f16::INFINITY.to_bits()
+        } else {
+            repr::<f16>(e, m)
+        }
+    }
+
     pub fn u64_to_f32_bits(i: u64) -> u32 {
         let n = i.leading_zeros();
         let i_m = i.wrapping_shl(n);
@@ -156,6 +203,33 @@ mod int_to_float {
         let m = (i as u128) << shift_f_gt_i::<u64, f128>(n);
         let e = exp::<u64, f128>(n) - 1;
         repr::<f128>(e, m)
+    }
+
+    #[cfg(f16_enabled)]
+    pub fn u128_to_f16_bits(i: u128) -> u16 {
+        let n = i.leading_zeros();
+        let i_m = i.wrapping_shl(n); // Mantissa, shifted so the first bit is nonzero
+        let m_base: u16 = (i_m >> shift_f_lt_i::<u128, f16>()) as u16;
+
+        // Within the upper `F::BITS`, everything except for the signifcand
+        // gets truncated
+        let d1: u16 = (i_m >> (u128::BITS - f16::BITS - f16::SIG_BITS - 1)).cast_lossy();
+
+        // The entire rest of `i_m` gets truncated. Zero the upper `F::BITS` then just
+        // check if it is nonzero.
+        let d2: u16 = (i_m << f16::BITS >> f16::BITS != 0).into();
+        let adj = d1 | d2;
+
+        // Mantissa with implicit bit set
+        let m = m_adj::<f16>(m_base, adj);
+        let e = if i == 0 { 0 } else { exp::<u128, f16>(n) - 1 };
+
+        // Clamp to infinity if the exponent is out of range
+        if e >= f16::EXP_SAT as u16 - 1 {
+            f16::INFINITY.to_bits()
+        } else {
+            repr::<f16>(e, m)
+        }
     }
 
     pub fn u128_to_f32_bits(i: u128) -> u32 {
@@ -208,6 +282,11 @@ mod int_to_float {
 
 // Conversions from unsigned integers to floats.
 intrinsics! {
+    #[cfg(f16_enabled)]
+    pub extern "C" fn __floatunsihf(i: u32) -> f16 {
+        f16::from_bits(int_to_float::u32_to_f16_bits(i))
+    }
+
     #[arm_aeabi_alias = __aeabi_ui2f]
     pub extern "C" fn __floatunsisf(i: u32) -> f32 {
         f32::from_bits(int_to_float::u32_to_f32_bits(i))
@@ -218,6 +297,11 @@ intrinsics! {
         f64::from_bits(int_to_float::u32_to_f64_bits(i))
     }
 
+    #[cfg(f16_enabled)]
+    pub extern "C" fn __floatundihf(i: u64) -> f16 {
+        f16::from_bits(int_to_float::u64_to_f16_bits(i))
+    }
+
     #[arm_aeabi_alias = __aeabi_ul2f]
     pub extern "C" fn __floatundisf(i: u64) -> f32 {
         f32::from_bits(int_to_float::u64_to_f32_bits(i))
@@ -226,6 +310,18 @@ intrinsics! {
     #[arm_aeabi_alias = __aeabi_ul2d]
     pub extern "C" fn __floatundidf(i: u64) -> f64 {
         f64::from_bits(int_to_float::u64_to_f64_bits(i))
+    }
+
+    #[cfg(f16_enabled)]
+    #[cfg(not(all(target_os = "uefi", target_arch = "x86_64")))]
+    pub extern "C" fn __floatuntihf(i: u128) -> f16 {
+        f16::from_bits(int_to_float::u128_to_f16_bits(i))
+    }
+
+    #[cfg(f16_enabled)]
+    #[cfg(all(target_os = "uefi", target_arch = "x86_64"))]
+    pub extern "C" fn __floatuntihf(lo: u64, hi: u64) -> f16 {
+        f16::from_bits(int_to_float::u128_to_f16_bits((u128::from(hi) << 64) | u128::from(lo)))
     }
 
     #[cfg(not(all(target_os = "uefi", target_arch = "x86_64")))]
@@ -269,6 +365,11 @@ intrinsics! {
 
 // Conversions from signed integers to floats.
 intrinsics! {
+    #[cfg(f16_enabled)]
+    pub extern "C" fn __floatsihf(i: i32) -> f16 {
+        int_to_float::signed(i, int_to_float::u32_to_f16_bits)
+    }
+
     #[arm_aeabi_alias = __aeabi_i2f]
     pub extern "C" fn __floatsisf(i: i32) -> f32 {
         int_to_float::signed(i, int_to_float::u32_to_f32_bits)
@@ -279,6 +380,11 @@ intrinsics! {
         int_to_float::signed(i, int_to_float::u32_to_f64_bits)
     }
 
+    #[cfg(f16_enabled)]
+    pub extern "C" fn __floatdihf(i: i64) -> f16 {
+        int_to_float::signed(i, int_to_float::u64_to_f16_bits)
+    }
+
     #[arm_aeabi_alias = __aeabi_l2f]
     pub extern "C" fn __floatdisf(i: i64) -> f32 {
         int_to_float::signed(i, int_to_float::u64_to_f32_bits)
@@ -287,6 +393,18 @@ intrinsics! {
     #[arm_aeabi_alias = __aeabi_l2d]
     pub extern "C" fn __floatdidf(i: i64) -> f64 {
         int_to_float::signed(i, int_to_float::u64_to_f64_bits)
+    }
+
+    #[cfg(f16_enabled)]
+    #[cfg(not(all(target_os = "uefi", target_arch = "x86_64")))]
+    pub extern "C" fn __floattihf(i: i128) -> f16 {
+        int_to_float::signed(i, int_to_float::u128_to_f16_bits)
+    }
+
+    #[cfg(f16_enabled)]
+    #[cfg(all(target_os = "uefi", target_arch = "x86_64"))]
+    pub extern "C" fn __floattihf(lo: u64, hi: u64) -> f16 {
+        int_to_float::signed((i128::from(hi) << 64) | i128::from(lo), int_to_float::u128_to_f16_bits)
     }
 
     #[cfg(not(all(target_os = "uefi", target_arch = "x86_64")))]


### PR DESCRIPTION
## Summary

LLVM emits `__float{,un}sihf`, `__float{,un}dihf`, and
`__float{,un}tihf` when converting 32-, 64-, and 128-bit integers to
`f16`, but compiler-builtins does not currently provide these symbols.
Consequently, `int as f16` can fail to link on targets without another
provider, including musl and Apple targets. glibc targets generally work
only because libgcc supplies the symbols.

This implements the compiler-builtins side of rust-lang/rust#132614,
which is part of the `f16` tracking issue rust-lang/rust#116909.

## Provenance and credit

The conversion algorithms were originally written by Trevor Gross in
rust-lang/compiler-builtins#729.

Trevor's implementation commit, `df3c10a`, was based on the November
2024 tree and also contained test and ordering changes that conflict with
current `main`, so it could not be applied verbatim. This PR preserves
the conversion bodies and ordinary entry points unchanged while adapting
their placement and target configuration to the current tree. The
implementation commit retains Trevor as its primary Git author, with me
listed as co-author.

The test commit incorporates Trevor's original `f16` conversion cases
and system-library gating work, so he is also listed as co-author there.
The overflow-threshold validation follows Juho Kahala's explanation in
rust-lang/compiler-builtins#729, and credits him with a `Suggested-by` trailer.

## Changes

The PR is divided into three commits:

1. **Exercise the integer-to-`f16` link paths**

   Add all six signed and unsigned `i32`/`i64`/`i128` conversions to
   `builtins-test-intrinsics`.

   On targets without a fallback provider, this commit reproduces the
   missing-symbol failure before the implementation is added. The
   intrinsic test crate is excluded from the workspace, so the default
   workspace still builds at this commit.

2. **Implement the six conversion routines**

   Add:

   - `__floatunsihf` and `__floatsihf`
   - `__floatundihf` and `__floatdihf`
   - `__floatuntihf` and `__floattihf`

   The routines reuse the existing left-alignment and round-to-even
   machinery. Because the `f16` range is narrower than every supported
   source integer type, all six paths handle exponent saturation by
   returning the appropriately signed infinity.

3. **Exercise and validate the conversions**

   Register all six routines with the existing `i_to_f` tests and add
   the necessary system-library availability configuration.

## Rounding validation

The existing `i_to_f` check casts the result and its neighboring float
values back to integers. This independently checks rounding and also
exercises the platform `f -> i` casts, which have previously caught ABI
and platform-specific problems.

That check cannot directly cast infinity and its NaN neighbor back to an
integer: those casts saturate or produce zero, yielding a meaningless
error bracket.

For an infinite result, the revised test instead:

1. casts the two adjacent finite values toward zero back to integers;
2. derives the half-ULP overflow threshold from them;
3. verifies that the source integer reached that threshold; and
4. verifies that the infinity has the correct sign.

Equality is accepted as the round-to-even case: the hypothetical
unbounded power of two has an even significand and rounds outward before
the exponent saturates to infinity.

Finite results continue to use the original three-value neighbor
bracket. The native `as`-cast comparison is also retained.

## Platform handling

System-library comparisons are disabled through
`no_sys_f16_int_convert` where the complete routine set is unavailable:

- Apple targets
- Windows targets
- 32-bit x86

On x86_64 UEFI, the `i128`/`u128` entry points use the same split-`u64`
argument ABI now used by the existing `f32` and `f64` conversions.
