### PR TITLE
test: Add an integer bitpattern generator

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -17,6 +17,7 @@ fi
 uname -a
 lscpu || true
 rustc -Vv
+cc -v || true
 
 if [ "${USING_CONTAINER_RUSTC:-}" = 1 ]; then
     # Install nonstandard components if we have control of the environment

--- a/libm-test/src/generate/bitpattern.rs
+++ b/libm-test/src/generate/bitpattern.rs
@@ -46,8 +46,34 @@ fn most_wanted_bitmask<F: Float>(count: u32) -> F::Int {
     mask |= low_mask_bits(n, F::EXP_MASK);
     mask |= high_mask_bits(n, F::EXP_MASK);
     mask |= high_mask_bits(n, F::SIG_MASK);
-    // spend the remaining budget on the least significant bits
+    // spend most of the remaining budget on the least significant bits, then use up remainders
     mask |= low_mask_bits(count - mask.count_ones(), F::SIG_MASK);
+    mask |= high_mask_bits(n + count - mask.count_ones(), F::SIG_MASK);
+    mask |= high_mask_bits(n + count - mask.count_ones(), F::EXP_MASK);
+    mask |= low_mask_bits(n + count - mask.count_ones(), F::EXP_MASK);
+    mask
+}
+
+/// Similar to `most_wanted_bitmask` but adds bits around the middle of the int rather than at
+/// a sign/exponent/significand boundary.
+fn most_wanted_int_bitmask<I: Int<Unsigned = I>>(count: u32) -> I {
+    if count == 0 {
+        return I::ZERO;
+    }
+    let mut mask = I::ZERO;
+    let n = count / 4;
+
+    let low_mask = I::MAX >> (I::BITS / 2);
+    let high_mask = low_mask << (I::BITS / 2);
+
+    mask |= low_mask_bits(n, high_mask);
+    mask |= high_mask_bits(n, high_mask);
+    mask |= high_mask_bits(n, low_mask);
+    // spend most of the remaining budget on the least significant bits, then use up remainders
+    mask |= low_mask_bits(count - mask.count_ones(), low_mask);
+    mask |= high_mask_bits(n + count - mask.count_ones(), low_mask);
+    mask |= high_mask_bits(n + count - mask.count_ones(), high_mask);
+    mask |= low_mask_bits(n + count - mask.count_ones(), high_mask);
     mask
 }
 
@@ -85,9 +111,24 @@ where
         .map(F::from_bits)
 }
 
+/// See [`float_gen`] docs for details.
+#[cfg_attr(not(test), expect(dead_code))]
+fn int_gen<I>(bits_to_vary: u32, fillers: impl IntoIterator<Item = I>) -> impl Iterator<Item = I>
+where
+    I: Int<Unsigned = I>,
+{
+    let varying = most_wanted_int_bitmask::<I>(bits_to_vary);
+    let patterns = bitwise_subsets(varying);
+
+    fillers
+        .into_iter()
+        .flat_map(move |preset| patterns.clone().map(move |x| x ^ preset))
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::f8;
 
     #[test]
     fn equivalence() {
@@ -100,7 +141,20 @@ mod test {
 
     #[test]
     fn most_wanted() {
-        let expected = [
+        let expected8 = [
+            0b0_0000_000,
+            //
+            0b1_0000_000,
+            0b1_0000_001,
+            0b1_0000_011,
+            0b1_0000_111,
+            //
+            0b1_1001_101,
+            0b1_1001_111,
+            0b1_1101_111,
+            0b1_1111_111,
+        ];
+        let expected32 = [
             0b0_00000000_00000000000000000000000,
             //
             0b1_00000000_00000000000000000000000,
@@ -143,8 +197,47 @@ mod test {
             0b1_11111111_11111110111111111111111,
             0b1_11111111_11111111111111111111111,
         ];
+        for k in 0..=8 {
+            let mask = most_wanted_bitmask::<f8>(k);
+            assert_eq!(mask, expected8[k as usize], "{k}");
+            assert_eq!(mask.count_ones(), k);
+        }
         for k in 0..=32 {
             let mask = most_wanted_bitmask::<f32>(k);
+            assert_eq!(mask, expected32[k as usize], "{k}");
+            assert_eq!(mask.count_ones(), k);
+        }
+    }
+
+    #[test]
+    fn most_wanted_int() {
+        let expected = [
+            0b0000_0000_0000_0000,
+            0b0000_0000_0000_0001,
+            0b0000_0000_0000_0011,
+            0b0000_0000_0000_0111,
+            //
+            0b1000_0001_1000_0001,
+            0b1000_0001_1000_0011,
+            0b1000_0001_1000_0111,
+            0b1000_0001_1000_1111,
+            //
+            0b1100_0011_1100_0011,
+            0b1100_0011_1100_0111,
+            0b1100_0011_1100_1111,
+            0b1100_0011_1101_1111,
+            //
+            0b1110_0111_1110_0111,
+            0b1110_0111_1110_1111,
+            0b1110_0111_1111_1111,
+            0b1111_0111_1111_1111,
+            //
+            0b1111_1111_1111_1111,
+        ];
+        let mut x = vec![];
+        for k in 0..=16 {
+            let mask = most_wanted_int_bitmask::<u16>(k);
+            x.push(mask);
             assert_eq!(mask, expected[k as usize], "{k}");
             assert_eq!(mask.count_ones(), k);
         }
@@ -185,6 +278,41 @@ mod test {
         let v = float_gen::<f16>(3, [0, u16::MAX, 0b1_00110_1000101011])
             .map(|x| x.to_bits())
             .collect::<Vec<_>>();
+        assert_eq!(expected.as_slice(), v);
+    }
+
+    #[test]
+    fn gen_int_with_fillers() {
+        let expected = [
+            // Filler: zeros
+            0b0000_0000_0000_0000,
+            0b0000_0000_0000_0001,
+            0b0000_0000_0000_0010,
+            0b0000_0000_0000_0011,
+            0b0000_0000_0000_0100,
+            0b0000_0000_0000_0101,
+            0b0000_0000_0000_0110,
+            0b0000_0000_0000_0111,
+            // Filler: ones
+            0b1111_1111_1111_1111,
+            0b1111_1111_1111_1110,
+            0b1111_1111_1111_1101,
+            0b1111_1111_1111_1100,
+            0b1111_1111_1111_1011,
+            0b1111_1111_1111_1010,
+            0b1111_1111_1111_1001,
+            0b1111_1111_1111_1000,
+            // Filler: pattern
+            0b1001_1010_0010_1011,
+            0b1001_1010_0010_1010,
+            0b1001_1010_0010_1001,
+            0b1001_1010_0010_1000,
+            0b1001_1010_0010_1111,
+            0b1001_1010_0010_1110,
+            0b1001_1010_0010_1101,
+            0b1001_1010_0010_1100,
+        ];
+        let v = int_gen::<u16>(3, [0, u16::MAX, 0b1001_1010_0010_1011]).collect::<Vec<_>>();
         assert_eq!(expected.as_slice(), v);
     }
 

--- a/libm-test/src/generate/bitpattern.rs
+++ b/libm-test/src/generate/bitpattern.rs
@@ -32,33 +32,39 @@ where
     })
 }
 
-fn low_exp_bits<F: Float>(count: u32) -> F::Int {
-    F::EXP_MASK & (F::EXP_MASK >> (F::EXP_BITS.saturating_sub(count)))
-}
-fn high_exp_bits<F: Float>(count: u32) -> F::Int {
-    F::EXP_MASK & (F::EXP_MASK << (F::EXP_BITS.saturating_sub(count)))
-}
-fn low_sig_bits<F: Float>(count: u32) -> F::Int {
-    F::SIG_MASK & (F::SIG_MASK >> (F::SIG_BITS.saturating_sub(count)))
-}
-fn high_sig_bits<F: Float>(count: u32) -> F::Int {
-    F::SIG_MASK & (F::SIG_MASK << (F::SIG_BITS.saturating_sub(count)))
-}
+/// Create a bitmask with `count` ones. The ones are filled in this order:
+///
+/// 1. Sign bit
+/// 2. Significand low bits
+/// 3. Significand high bits, exponent low bits, exponent high bits (increment together)
 fn most_wanted_bitmask<F: Float>(count: u32) -> F::Int {
     if count == 0 {
         return F::Int::ZERO;
     }
     let mut mask = F::SIGN_MASK;
     let n = (count - 1) / 4;
-    mask |= low_exp_bits::<F>(n);
-    mask |= high_exp_bits::<F>(n);
-    mask |= high_sig_bits::<F>(n);
+    mask |= low_mask_bits(n, F::EXP_MASK);
+    mask |= high_mask_bits(n, F::EXP_MASK);
+    mask |= high_mask_bits(n, F::SIG_MASK);
     // spend the remaining budget on the least significant bits
-    mask |= low_sig_bits::<F>(count - mask.count_ones());
+    mask |= low_mask_bits(count - mask.count_ones(), F::SIG_MASK);
     mask
 }
 
+/// Set `count` bits in the LSB of `mask`.
+fn low_mask_bits<I: Int>(count: u32, mask: I) -> I {
+    mask & (mask >> (mask.count_ones().saturating_sub(count)))
+}
+
+/// Set `count` bits in the MSB of `mask`.
+fn high_mask_bits<I: Int>(count: u32, mask: I) -> I {
+    mask & (mask << (mask.count_ones().saturating_sub(count)))
+}
+
 /// Biased generator for floats.
+///
+/// Starts with the first value of `fillers`, then toggles `bits_to_vary` bits exhaustively. Once
+/// that has completed, move on to the next filler.
 ///
 /// The returned iterator will produce `fillers.len() << bits_to_vary` items.
 #[cfg_attr(not(test), expect(dead_code))]
@@ -81,7 +87,8 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::{bitwise_subsets, float_gen};
+    use super::*;
+
     #[test]
     fn equivalence() {
         // with a small integer type, we can easily verify that behaviour matches for all arguments
@@ -137,9 +144,50 @@ mod test {
             0b1_11111111_11111111111111111111111,
         ];
         for k in 0..=32 {
-            assert_eq!(super::most_wanted_bitmask::<f32>(k), expected[k as usize]);
+            let mask = most_wanted_bitmask::<f32>(k);
+            assert_eq!(mask, expected[k as usize], "{k}");
+            assert_eq!(mask.count_ones(), k);
         }
     }
+
+    #[test]
+    #[cfg(f16_enabled)]
+    fn gen_with_fillers() {
+        let expected = [
+            // Filler: zeros
+            0b0_00000_0000000000,
+            0b0_00000_0000000001,
+            0b0_00000_0000000010,
+            0b0_00000_0000000011,
+            0b1_00000_0000000000,
+            0b1_00000_0000000001,
+            0b1_00000_0000000010,
+            0b1_00000_0000000011,
+            // Filler: ones
+            0b1_11111_1111111111,
+            0b1_11111_1111111110,
+            0b1_11111_1111111101,
+            0b1_11111_1111111100,
+            0b0_11111_1111111111,
+            0b0_11111_1111111110,
+            0b0_11111_1111111101,
+            0b0_11111_1111111100,
+            // Filler: pattern
+            0b1_00110_1000101011,
+            0b1_00110_1000101010,
+            0b1_00110_1000101001,
+            0b1_00110_1000101000,
+            0b0_00110_1000101011,
+            0b0_00110_1000101010,
+            0b0_00110_1000101001,
+            0b0_00110_1000101000,
+        ];
+        let v = float_gen::<f16>(3, [0, u16::MAX, 0b1_00110_1000101011])
+            .map(|x| x.to_bits())
+            .collect::<Vec<_>>();
+        assert_eq!(expected.as_slice(), v);
+    }
+
     #[test]
     fn gen_includes_specials() {
         let v: Vec<_> = float_gen(5, vec![0, 0x7fffff, !0x7fffff, !0])
@@ -157,6 +205,7 @@ mod test {
             assert!(v.contains(&(-x).to_bits()), "-{x} not found");
         }
     }
+
     #[test]
     fn count() {
         for k in 0..10 {
@@ -165,6 +214,7 @@ mod test {
             assert!(float_gen::<f32>(k, vec![0, 1, 2]).count() == 3 << k);
         }
     }
+
     #[test]
     fn specific() {
         let iter = float_gen::<f32>(1, vec![0]).map(f32::to_bits);


### PR DESCRIPTION
Adapt the float version to work for integers.

Additionally, ensure available bits are all used if they aren't
allocated in the lower mask (significand). This showed up when the
lower and upper mask regions had a similar number of bits, such as for
f8 or for evenly-split integers.