### PR TITLE
Fix `__hexagon_fmadf5` overflow under directed rounding

### DIFF
--- a/compiler-builtins/src/hexagon/dffma.s
+++ b/compiler-builtins/src/hexagon/dffma.s
@@ -338,10 +338,8 @@ __hexagon_fmadf5:
  {
   p0 = !cmp.eq(r2,#1)
   p0 = !cmp.eq(r3,#2)
- }
- {
-  p0 = dfcmp.eq(r9:8,r9:8)
   if (p0.new) r11:10 = r9:8
+  p0 = dfcmp.eq(r9:8,r9:8)
  }
  {
   r1:0 = insert(r11:10,#63,#0)


### PR DESCRIPTION
The overflow path in __hexagon_fmadf5 computed the round-mode predicate (inf vs. largest-finite) into p0, but then overwrote p0 with `dfcmp.eq(ATMP,ATMP)` before consuming it. Since ATMP is +inf, `dfcmp.eq(ATMP,ATMP)` is always true, so CTMP was unconditionally set to infinity and the rounding-mode decision was discarded.

As a result, a finite-magnitude overflow returned +/-inf in every rounding mode.