### PR TITLE
ci: Delete `RUST_TEST_THREADS=1`

### DIFF
--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -16,5 +16,4 @@ ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER=qemu-aarch64 \
     AR_aarch64_unknown_linux_gnu="$TOOLCHAIN_PREFIX"ar \
     CC_aarch64_unknown_linux_gnu="$TOOLCHAIN_PREFIX"gcc \
-    QEMU_LD_PREFIX=/usr/aarch64-linux-gnu \
-    RUST_TEST_THREADS=1
+    QEMU_LD_PREFIX=/usr/aarch64-linux-gnu

--- a/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
@@ -14,5 +14,4 @@ ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_RUNNER=qemu-arm \
     AR_arm_unknown_linux_gnueabi="$TOOLCHAIN_PREFIX"ar \
     CC_arm_unknown_linux_gnueabi="$TOOLCHAIN_PREFIX"gcc \
-    QEMU_LD_PREFIX=/usr/arm-linux-gnueabi \
-    RUST_TEST_THREADS=1
+    QEMU_LD_PREFIX=/usr/arm-linux-gnueabi

--- a/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -14,5 +14,4 @@ ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUNNER=qemu-arm \
     AR_arm_unknown_linux_gnueabihf="$TOOLCHAIN_PREFIX"ar \
     CC_arm_unknown_linux_gnueabihf="$TOOLCHAIN_PREFIX"gcc \
-    QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
-    RUST_TEST_THREADS=1
+    QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf

--- a/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -14,5 +14,4 @@ ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUNNER=qemu-arm \
     AR_armv7_unknown_linux_gnueabihf="$TOOLCHAIN_PREFIX"ar \
     CC_armv7_unknown_linux_gnueabihf="$TOOLCHAIN_PREFIX"gcc \
-    QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
-    RUST_TEST_THREADS=1
+    QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf

--- a/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
@@ -13,5 +13,4 @@ ENV CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER=loongarch64-linux-gnu-gcc-
     CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_RUNNER=qemu-loongarch64 \
     AR_loongarch64_unknown_linux_gnu=loongarch64-linux-gnu-ar \
     CC_loongarch64_unknown_linux_gnu=loongarch64-linux-gnu-gcc-14 \
-    QEMU_LD_PREFIX=/usr/loongarch64-linux-gnu \
-    RUST_TEST_THREADS=1
+    QEMU_LD_PREFIX=/usr/loongarch64-linux-gnu

--- a/ci/docker/mips-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/mips-unknown-linux-gnu/Dockerfile
@@ -16,5 +16,4 @@ ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER=qemu-mips \
     AR_mips_unknown_linux_gnu="$TOOLCHAIN_PREFIX"ar \
     CC_mips_unknown_linux_gnu="$TOOLCHAIN_PREFIX"gcc \
-    QEMU_LD_PREFIX=/usr/mips-linux-gnu \
-    RUST_TEST_THREADS=1
+    QEMU_LD_PREFIX=/usr/mips-linux-gnu

--- a/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
+++ b/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
@@ -15,5 +15,4 @@ ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_RUNNER=qemu-mips64 \
     AR_mips64_unknown_linux_gnuabi64="$TOOLCHAIN_PREFIX"ar \
     CC_mips64_unknown_linux_gnuabi64="$TOOLCHAIN_PREFIX"gcc \
-    QEMU_LD_PREFIX=/usr/mips64-linux-gnuabi64 \
-    RUST_TEST_THREADS=1
+    QEMU_LD_PREFIX=/usr/mips64-linux-gnuabi64

--- a/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
+++ b/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
@@ -14,5 +14,4 @@ ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_RUNNER=qemu-mips64el \
     AR_mips64el_unknown_linux_gnuabi64="$TOOLCHAIN_PREFIX"ar \
     CC_mips64el_unknown_linux_gnuabi64="$TOOLCHAIN_PREFIX"gcc \
-    QEMU_LD_PREFIX=/usr/mips64el-linux-gnuabi64 \
-    RUST_TEST_THREADS=1
+    QEMU_LD_PREFIX=/usr/mips64el-linux-gnuabi64

--- a/ci/docker/mipsel-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-gnu/Dockerfile
@@ -15,5 +15,4 @@ ENV CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_RUNNER=qemu-mipsel \
     AR_mipsel_unknown_linux_gnu="$TOOLCHAIN_PREFIX"ar \
     CC_mipsel_unknown_linux_gnu="$TOOLCHAIN_PREFIX"gcc \
-    QEMU_LD_PREFIX=/usr/mipsel-linux-gnu \
-    RUST_TEST_THREADS=1
+    QEMU_LD_PREFIX=/usr/mipsel-linux-gnu

--- a/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -15,5 +15,4 @@ ENV CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc \
     AR_powerpc_unknown_linux_gnu="$TOOLCHAIN_PREFIX"ar \
     CC_powerpc_unknown_linux_gnu="$TOOLCHAIN_PREFIX"gcc \
-    QEMU_LD_PREFIX=/usr/powerpc-linux-gnu \
-    RUST_TEST_THREADS=1
+    QEMU_LD_PREFIX=/usr/powerpc-linux-gnu

--- a/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -16,5 +16,4 @@ ENV CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc64 \
     AR_powerpc64_unknown_linux_gnu="$TOOLCHAIN_PREFIX"ar \
     CC_powerpc64_unknown_linux_gnu="$TOOLCHAIN_PREFIX"gcc \
-    QEMU_LD_PREFIX=/usr/powerpc64-linux-gnu \
-    RUST_TEST_THREADS=1
+    QEMU_LD_PREFIX=/usr/powerpc64-linux-gnu

--- a/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -15,5 +15,4 @@ ENV CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc64le \
     AR_powerpc64le_unknown_linux_gnu="$TOOLCHAIN_PREFIX"ar \
     CC_powerpc64le_unknown_linux_gnu="$TOOLCHAIN_PREFIX"gcc \
-    QEMU_LD_PREFIX=/usr/powerpc64le-linux-gnu \
-    RUST_TEST_THREADS=1
+    QEMU_LD_PREFIX=/usr/powerpc64le-linux-gnu

--- a/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
@@ -15,5 +15,4 @@ ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUNNER=qemu-riscv64 \
     AR_riscv64gc_unknown_linux_gnu="$TOOLCHAIN_PREFIX"ar \
     CC_riscv64gc_unknown_linux_gnu="$TOOLCHAIN_PREFIX"gcc \
-    QEMU_LD_PREFIX=/usr/riscv64-linux-gnu \
-    RUST_TEST_THREADS=1
+    QEMU_LD_PREFIX=/usr/riscv64-linux-gnu


### PR DESCRIPTION
This was added as part of the original test infrastructure at 8e161a791a89 ("Expand and refactor teting infrastructure") but there doesn't seem to be any reason to keep this restriction; qemu should handle the threads fine.

ci: test-libm