### PR TITLE
Remove `#[aapcs_on_arm]`

### DIFF
--- a/compiler-builtins/src/float/add.rs
+++ b/compiler-builtins/src/float/add.rs
@@ -195,13 +195,11 @@ intrinsics! {
         add(a, b)
     }
 
-    #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_fadd]
     pub extern "C" fn __addsf3(a: f32, b: f32) -> f32 {
         add(a, b)
     }
 
-    #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_dadd]
     pub extern "C" fn __adddf3(a: f64, b: f64) -> f64 {
         add(a, b)

--- a/compiler-builtins/src/float/extend.rs
+++ b/compiler-builtins/src/float/extend.rs
@@ -69,7 +69,6 @@ where
 }
 
 intrinsics! {
-    #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_f2d]
     pub extern "C" fn  __extendsfdf2(a: f32) -> f64 {
         extend(a)
@@ -77,7 +76,6 @@ intrinsics! {
 }
 
 intrinsics! {
-    #[aapcs_on_arm]
     #[apple_f16_arg_abi]
     #[arm_aeabi_alias = __aeabi_h2f]
     #[cfg(f16_enabled)]
@@ -85,35 +83,30 @@ intrinsics! {
         extend(a)
     }
 
-    #[aapcs_on_arm]
     #[apple_f16_arg_abi]
     #[cfg(f16_enabled)]
     pub extern "C" fn __gnu_h2f_ieee(a: f16) -> f32 {
         extend(a)
     }
 
-    #[aapcs_on_arm]
     #[apple_f16_arg_abi]
     #[cfg(f16_enabled)]
     pub extern "C" fn __extendhfdf2(a: f16) -> f64 {
         extend(a)
     }
 
-    #[aapcs_on_arm]
     #[ppc_name = __extendhfkf2]
     #[cfg(all(f16_enabled, f128_enabled))]
     pub extern "C" fn __extendhftf2(a: f16) -> f128 {
         extend(a)
     }
 
-    #[aapcs_on_arm]
     #[ppc_name = __extendsfkf2]
     #[cfg(f128_enabled)]
     pub extern "C" fn __extendsftf2(a: f32) -> f128 {
         extend(a)
     }
 
-    #[aapcs_on_arm]
     #[ppc_name = __extenddfkf2]
     #[cfg(f128_enabled)]
     pub extern "C" fn __extenddftf2(a: f64) -> f128 {

--- a/compiler-builtins/src/float/mul.rs
+++ b/compiler-builtins/src/float/mul.rs
@@ -184,13 +184,11 @@ intrinsics! {
         mul(a, b)
     }
 
-    #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_fmul]
     pub extern "C" fn __mulsf3(a: f32, b: f32) -> f32 {
         mul(a, b)
     }
 
-    #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_dmul]
     pub extern "C" fn __muldf3(a: f64, b: f64) -> f64 {
         mul(a, b)

--- a/compiler-builtins/src/float/trunc.rs
+++ b/compiler-builtins/src/float/trunc.rs
@@ -114,7 +114,6 @@ where
 }
 
 intrinsics! {
-    #[aapcs_on_arm]
     #[arm_aeabi_alias = __aeabi_d2f]
     pub extern "C" fn __truncdfsf2(a: f64) -> f32 {
         trunc(a)
@@ -122,7 +121,6 @@ intrinsics! {
 }
 
 intrinsics! {
-    #[aapcs_on_arm]
     #[apple_f16_ret_abi]
     #[arm_aeabi_alias = __aeabi_f2h]
     #[cfg(f16_enabled)]
@@ -130,14 +128,12 @@ intrinsics! {
         trunc(a)
     }
 
-    #[aapcs_on_arm]
     #[apple_f16_ret_abi]
     #[cfg(f16_enabled)]
     pub extern "C" fn __gnu_f2h_ieee(a: f32) -> f16 {
         trunc(a)
     }
 
-    #[aapcs_on_arm]
     #[apple_f16_ret_abi]
     #[arm_aeabi_alias = __aeabi_d2h]
     #[cfg(f16_enabled)]
@@ -145,21 +141,18 @@ intrinsics! {
         trunc(a)
     }
 
-    #[aapcs_on_arm]
     #[ppc_name = __trunckfhf2]
     #[cfg(all(f16_enabled, f128_enabled))]
     pub extern "C" fn __trunctfhf2(a: f128) -> f16 {
         trunc(a)
     }
 
-    #[aapcs_on_arm]
     #[ppc_name = __trunckfsf2]
     #[cfg(f128_enabled)]
     pub extern "C" fn __trunctfsf2(a: f128) -> f32 {
         trunc(a)
     }
 
-    #[aapcs_on_arm]
     #[ppc_name = __trunckfdf2]
     #[cfg(f128_enabled)]
     pub extern "C" fn __trunctfdf2(a: f128) -> f64 {

--- a/compiler-builtins/src/macros.rs
+++ b/compiler-builtins/src/macros.rs
@@ -38,12 +38,9 @@
 ///
 /// A quick overview of attributes supported right now are:
 ///
+// FIXME: Add missing attributes.
 /// * `maybe_use_optimized_c_shim` - indicates that the Rust implementation is
 ///   ignored if an optimized C version was compiled.
-/// * `aapcs_on_arm` - forces the ABI of the function to be `"aapcs"` on ARM and
-///   the specified ABI everywhere else.
-/// * `unadjusted_on_win64` - like `aapcs_on_arm` this switches to the
-///   `"unadjusted"` abi on Win64 and the specified abi elsewhere.
 /// * `arm_aeabi_alias` - handles the "aliasing" of various intrinsics on ARM
 ///   their otherwise typical names to other prefixed ones.
 /// * `ppc_name` - changes the name of the symbol on PowerPC platforms without
@@ -170,38 +167,7 @@ macro_rules! intrinsics {
         intrinsics!($($rest)*);
     );
 
-    // We recognize the `#[aapcs_on_arm]` attribute here and generate the
-    // same intrinsic but force it to have the `"aapcs"` calling convention on
-    // ARM and `"C"` elsewhere.
-    (
-        #[aapcs_on_arm]
-        $(#[$($attr:tt)*])*
-        pub extern $abi:tt fn $name:ident( $($argname:ident:  $ty:ty),* ) $(-> $ret:ty)? {
-            $($body:tt)*
-        }
-
-        $($rest:tt)*
-    ) => (
-        #[cfg(target_arch = "arm")]
-        intrinsics! {
-            $(#[$($attr)*])*
-            pub extern "aapcs" fn $name( $($argname: $ty),* ) $(-> $ret)? {
-                $($body)*
-            }
-        }
-
-        #[cfg(not(target_arch = "arm"))]
-        intrinsics! {
-            $(#[$($attr)*])*
-            pub extern $abi fn $name( $($argname: $ty),* ) $(-> $ret)? {
-                $($body)*
-            }
-        }
-
-        intrinsics!($($rest)*);
-    );
-
-    // `arm_aeabi_alias` would conflict with `f16_apple_{arg,ret}_abi` not handled here. Avoid macro ambiguity by combining in a
+    // `arm_aeabi_alias` would conflict with `apple_f16_{arg,ret}_abi` not handled here. Avoid macro ambiguity by combining in a
     // single `#[]`.
     (
         #[apple_f16_arg_abi]


### PR DESCRIPTION
Fixes rust-lang/compiler-builtins#1271 by removing `#[aapcs_on_arm]`: `compiler-rt` only does the equivalent on ARM soft-float targets where the `"C"` ABI is already AAPCS.