### PR TITLE
Rename `#[ppc_alias]` to `#[ppc_name]`

### DIFF
--- a/builtins-test/src/bench.rs
+++ b/builtins-test/src/bench.rs
@@ -76,11 +76,11 @@ macro_rules! float_bench {
         sig: ($($arg:ident: $arg_ty:ty),*) -> $ret_ty:ty,
         // Path to the crate in compiler_builtins
         crate_fn: $crate_fn:path,
-        // Optional alias on ppc
+        // Optional name on ppc
         $( crate_fn_ppc: $crate_fn_ppc:path, )?
         // Name of the system symbol
         sys_fn: $sys_fn:ident,
-        // Optional alias on ppc
+        // Optional name on ppc
         $( sys_fn_ppc: $sys_fn_ppc:path, )?
         // Meta saying whether the system symbol is available
         sys_available: $sys_available:meta,
@@ -122,7 +122,7 @@ macro_rules! float_bench {
                 #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
                 let target_crate_fn = $crate_fn;
 
-                // On PPC, use an alias if specified
+                // On PPC, use the PPC name if specified
                 #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
                 let target_crate_fn = float_bench!(@coalesce $($crate_fn_ppc)?, $crate_fn);
 
@@ -135,7 +135,7 @@ macro_rules! float_bench {
                 #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
                 let target_sys_fn = $sys_fn;
 
-                // On PPC, use an alias if specified
+                // On PPC, use the PPC name if specified
                 #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
                 let target_sys_fn = float_bench!(@coalesce $($sys_fn_ppc)?, $sys_fn);
 

--- a/compiler-builtins/src/float/add.rs
+++ b/compiler-builtins/src/float/add.rs
@@ -207,7 +207,7 @@ intrinsics! {
         add(a, b)
     }
 
-    #[ppc_alias = __addkf3]
+    #[ppc_name = __addkf3]
     #[cfg(f128_enabled)]
     pub extern "C" fn __addtf3(a: f128, b: f128) -> f128 {
         add(a, b)

--- a/compiler-builtins/src/float/cmp.rs
+++ b/compiler-builtins/src/float/cmp.rs
@@ -227,37 +227,37 @@ intrinsics! {
 
 #[cfg(f128_enabled)]
 intrinsics! {
-    #[ppc_alias = __lekf2]
+    #[ppc_name = __lekf2]
     pub extern "C" fn __letf2(a: f128, b: f128) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_default_cmp_result()
     }
 
-    #[ppc_alias = __gekf2]
+    #[ppc_name = __gekf2]
     pub extern "C" fn __getf2(a: f128, b: f128) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_gt_ge_cmp_result()
     }
 
-    #[ppc_alias = __unordkf2]
+    #[ppc_name = __unordkf2]
     pub extern "C" fn __unordtf2(a: f128, b: f128) -> crate::float::cmp::CmpResult {
         unord(a, b) as crate::float::cmp::CmpResult
     }
 
-    #[ppc_alias = __eqkf2]
+    #[ppc_name = __eqkf2]
     pub extern "C" fn __eqtf2(a: f128, b: f128) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_default_cmp_result()
     }
 
-    #[ppc_alias = __ltkf2]
+    #[ppc_name = __ltkf2]
     pub extern "C" fn __lttf2(a: f128, b: f128) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_default_cmp_result()
     }
 
-    #[ppc_alias = __nekf2]
+    #[ppc_name = __nekf2]
     pub extern "C" fn __netf2(a: f128, b: f128) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_default_cmp_result()
     }
 
-    #[ppc_alias = __gtkf2]
+    #[ppc_name = __gtkf2]
     pub extern "C" fn __gttf2(a: f128, b: f128) -> crate::float::cmp::CmpResult {
         cmp(a, b).to_gt_ge_cmp_result()
     }

--- a/compiler-builtins/src/float/conv.rs
+++ b/compiler-builtins/src/float/conv.rs
@@ -248,19 +248,19 @@ intrinsics! {
         f64::from_bits(int_to_float::u128_to_f64_bits((u128::from(hi) << 64) | u128::from(lo)))
     }
 
-    #[ppc_alias = __floatunsikf]
+    #[ppc_name = __floatunsikf]
     #[cfg(f128_enabled)]
     pub extern "C" fn __floatunsitf(i: u32) -> f128 {
         f128::from_bits(int_to_float::u32_to_f128_bits(i))
     }
 
-    #[ppc_alias = __floatundikf]
+    #[ppc_name = __floatundikf]
     #[cfg(f128_enabled)]
     pub extern "C" fn __floatunditf(i: u64) -> f128 {
         f128::from_bits(int_to_float::u64_to_f128_bits(i))
     }
 
-    #[ppc_alias = __floatuntikf]
+    #[ppc_name = __floatuntikf]
     #[cfg(f128_enabled)]
     pub extern "C" fn __floatuntitf(i: u128) -> f128 {
         f128::from_bits(int_to_float::u128_to_f128_bits(i))
@@ -309,19 +309,19 @@ intrinsics! {
         int_to_float::signed((i128::from(hi) << 64) | i128::from(lo), int_to_float::u128_to_f64_bits)
     }
 
-    #[ppc_alias = __floatsikf]
+    #[ppc_name = __floatsikf]
     #[cfg(f128_enabled)]
     pub extern "C" fn __floatsitf(i: i32) -> f128 {
         int_to_float::signed(i, int_to_float::u32_to_f128_bits)
     }
 
-    #[ppc_alias = __floatdikf]
+    #[ppc_name = __floatdikf]
     #[cfg(f128_enabled)]
     pub extern "C" fn __floatditf(i: i64) -> f128 {
         int_to_float::signed(i, int_to_float::u64_to_f128_bits)
     }
 
-    #[ppc_alias = __floattikf]
+    #[ppc_name = __floattikf]
     #[cfg(f128_enabled)]
     pub extern "C" fn __floattitf(i: i128) -> f128 {
         int_to_float::signed(i, int_to_float::u128_to_f128_bits)
@@ -439,19 +439,19 @@ intrinsics! {
         float_to_unsigned_int(f)
     }
 
-    #[ppc_alias = __fixunskfsi]
+    #[ppc_name = __fixunskfsi]
     #[cfg(f128_enabled)]
     pub extern "C" fn __fixunstfsi(f: f128) -> u32 {
         float_to_unsigned_int(f)
     }
 
-    #[ppc_alias = __fixunskfdi]
+    #[ppc_name = __fixunskfdi]
     #[cfg(f128_enabled)]
     pub extern "C" fn __fixunstfdi(f: f128) -> u64 {
         float_to_unsigned_int(f)
     }
 
-    #[ppc_alias = __fixunskfti]
+    #[ppc_name = __fixunskfti]
     #[cfg(f128_enabled)]
     pub extern "C" fn __fixunstfti(f: f128) -> u128 {
         float_to_unsigned_int(f)
@@ -488,19 +488,19 @@ intrinsics! {
         float_to_signed_int(f)
     }
 
-    #[ppc_alias = __fixkfsi]
+    #[ppc_name = __fixkfsi]
     #[cfg(f128_enabled)]
     pub extern "C" fn __fixtfsi(f: f128) -> i32 {
         float_to_signed_int(f)
     }
 
-    #[ppc_alias = __fixkfdi]
+    #[ppc_name = __fixkfdi]
     #[cfg(f128_enabled)]
     pub extern "C" fn __fixtfdi(f: f128) -> i64 {
         float_to_signed_int(f)
     }
 
-    #[ppc_alias = __fixkfti]
+    #[ppc_name = __fixkfti]
     #[cfg(f128_enabled)]
     pub extern "C" fn __fixtfti(f: f128) -> i128 {
         float_to_signed_int(f)

--- a/compiler-builtins/src/float/div.rs
+++ b/compiler-builtins/src/float/div.rs
@@ -615,7 +615,7 @@ intrinsics! {
         div(a, b)
     }
 
-    #[ppc_alias = __divkf3]
+    #[ppc_name = __divkf3]
     #[cfg(f128_enabled)]
     pub extern "C" fn __divtf3(a: f128, b: f128) -> f128 {
         div(a, b)

--- a/compiler-builtins/src/float/extend.rs
+++ b/compiler-builtins/src/float/extend.rs
@@ -100,21 +100,21 @@ intrinsics! {
     }
 
     #[aapcs_on_arm]
-    #[ppc_alias = __extendhfkf2]
+    #[ppc_name = __extendhfkf2]
     #[cfg(all(f16_enabled, f128_enabled))]
     pub extern "C" fn __extendhftf2(a: f16) -> f128 {
         extend(a)
     }
 
     #[aapcs_on_arm]
-    #[ppc_alias = __extendsfkf2]
+    #[ppc_name = __extendsfkf2]
     #[cfg(f128_enabled)]
     pub extern "C" fn __extendsftf2(a: f32) -> f128 {
         extend(a)
     }
 
     #[aapcs_on_arm]
-    #[ppc_alias = __extenddfkf2]
+    #[ppc_name = __extenddfkf2]
     #[cfg(f128_enabled)]
     pub extern "C" fn __extenddftf2(a: f64) -> f128 {
         extend(a)

--- a/compiler-builtins/src/float/mul.rs
+++ b/compiler-builtins/src/float/mul.rs
@@ -196,7 +196,7 @@ intrinsics! {
         mul(a, b)
     }
 
-    #[ppc_alias = __mulkf3]
+    #[ppc_name = __mulkf3]
     #[cfg(f128_enabled)]
     pub extern "C" fn __multf3(a: f128, b: f128) -> f128 {
         mul(a, b)

--- a/compiler-builtins/src/float/pow.rs
+++ b/compiler-builtins/src/float/pow.rs
@@ -29,7 +29,7 @@ intrinsics! {
         pow(a, b)
     }
 
-    #[ppc_alias = __powikf2]
+    #[ppc_name = __powikf2]
     #[cfg(f128_enabled)]
     pub extern "C" fn __powitf2(a: f128, b: i32) -> f128 {
         pow(a, b)

--- a/compiler-builtins/src/float/sub.rs
+++ b/compiler-builtins/src/float/sub.rs
@@ -16,7 +16,7 @@ intrinsics! {
         crate::float::add::__adddf3(a, f64::from_bits(b.to_bits() ^ f64::SIGN_MASK))
     }
 
-    #[ppc_alias = __subkf3]
+    #[ppc_name = __subkf3]
     #[cfg(f128_enabled)]
     pub extern "C" fn __subtf3(a: f128, b: f128) -> f128 {
         #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]

--- a/compiler-builtins/src/float/trunc.rs
+++ b/compiler-builtins/src/float/trunc.rs
@@ -146,21 +146,21 @@ intrinsics! {
     }
 
     #[aapcs_on_arm]
-    #[ppc_alias = __trunckfhf2]
+    #[ppc_name = __trunckfhf2]
     #[cfg(all(f16_enabled, f128_enabled))]
     pub extern "C" fn __trunctfhf2(a: f128) -> f16 {
         trunc(a)
     }
 
     #[aapcs_on_arm]
-    #[ppc_alias = __trunckfsf2]
+    #[ppc_name = __trunckfsf2]
     #[cfg(f128_enabled)]
     pub extern "C" fn __trunctfsf2(a: f128) -> f32 {
         trunc(a)
     }
 
     #[aapcs_on_arm]
-    #[ppc_alias = __trunckfdf2]
+    #[ppc_name = __trunckfdf2]
     #[cfg(f128_enabled)]
     pub extern "C" fn __trunctfdf2(a: f128) -> f64 {
         trunc(a)

--- a/compiler-builtins/src/macros.rs
+++ b/compiler-builtins/src/macros.rs
@@ -46,7 +46,7 @@
 ///   `"unadjusted"` abi on Win64 and the specified abi elsewhere.
 /// * `arm_aeabi_alias` - handles the "aliasing" of various intrinsics on ARM
 ///   their otherwise typical names to other prefixed ones.
-/// * `ppc_alias` - changes the name of the symbol on PowerPC platforms without
+/// * `ppc_name` - changes the name of the symbol on PowerPC platforms without
 ///   changing any other behavior. This is mostly for `f128`, which is `tf` on
 ///   most platforms but `kf` on PowerPC.
 macro_rules! intrinsics {
@@ -352,9 +352,9 @@ macro_rules! intrinsics {
     );
 
     // PowerPC usually uses `kf` rather than `tf` for `f128`. This is just an easy
-    // way to add an alias on those targets.
+    // way to change the name on those targets.
     (
-        #[ppc_alias = $alias:ident]
+        #[ppc_name = $ppc_name:ident]
         $(#[$($attr:tt)*])*
         pub extern $abi:tt fn $name:ident( $($argname:ident:  $ty:ty),* ) $(-> $ret:ty)? {
             $($body:tt)*
@@ -373,7 +373,7 @@ macro_rules! intrinsics {
         #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
         intrinsics! {
             $(#[$($attr)*])*
-            pub extern $abi fn $alias( $($argname: $ty),* ) $(-> $ret)? {
+            pub extern $abi fn $ppc_name( $($argname: $ty),* ) $(-> $ret)? {
                 $($body)*
             }
         }


### PR DESCRIPTION
`#[ppc_alias]` suggests this is just adding an additional export name (which would be incorrect), whereas it is actually renaming the function on PPC (which is correct).