### PR TITLE
Add wcslen builtin

### DIFF
--- a/builtins-test/tests/mem.rs
+++ b/builtins-test/tests/mem.rs
@@ -1,4 +1,4 @@
-use compiler_builtins::mem::{memcmp, memcpy, memmove, memset, strlen};
+use compiler_builtins::mem::{memcmp, memcpy, memmove, memset, strlen, wchar_t};
 
 const WORD_SIZE: usize = core::mem::size_of::<usize>();
 
@@ -284,6 +284,21 @@ fn memset_backward_aligned() {
     }
 }
 
+/// Wrapper that prevents inlining the wcslen implementation into the test.
+///
+/// Inlining causes LLVM to pick up the wcslen pattern and generate a call to
+/// wcslen. That causes a linker error for tests on platforms without wcslen
+/// (such as wasm).
+///
+/// `no_mangle` is needed because LLVM knows not to apply the wcslen
+/// optimization to a function with this name:
+/// https://github.com/llvm/llvm-project/pull/132572
+#[inline(never)]
+#[unsafe(no_mangle)]
+unsafe fn wcslen(p: *const wchar_t) -> usize {
+    unsafe { compiler_builtins::mem::wcslen(p) }
+}
+
 #[test]
 fn test_strlen() {
     unsafe {
@@ -292,4 +307,13 @@ fn test_strlen() {
         let s = c"hello, world!";
         assert_eq!(strlen(s.as_ptr()), 13);
     }
+}
+
+#[test]
+fn wide_string_length() {
+    let s = [0];
+    assert_eq!(unsafe { wcslen(s.as_ptr()) }, 0);
+
+    let s = [97, 98, 99, 0];
+    assert_eq!(unsafe { wcslen(s.as_ptr()) }, 3);
 }

--- a/compiler-builtins/src/mem/mod.rs
+++ b/compiler-builtins/src/mem/mod.rs
@@ -9,6 +9,13 @@
 #[cfg_attr(all(feature = "arch", target_arch = "x86_64"), path = "x86_64.rs")]
 mod impls;
 
+#[cfg(any(windows, target_os = "uefi"))]
+#[expect(non_camel_case_types)]
+pub type wchar_t = u16;
+#[cfg(not(any(windows, target_os = "uefi")))]
+#[expect(non_camel_case_types)]
+pub type wchar_t = i32;
+
 intrinsics! {
     #[mem_builtin]
     #[allow(suspicious_runtime_symbol_definitions)]
@@ -53,5 +60,16 @@ intrinsics! {
     #[mem_builtin]
     pub unsafe extern "C" fn strlen(s: *const core::ffi::c_char) -> usize {
         impls::c_string_length(s)
+    }
+
+    #[mem_builtin]
+    pub unsafe extern "C" fn wcslen(s: *const crate::mem::wchar_t) -> usize {
+        let mut s = s;
+        let mut n = 0;
+        while *s != 0 {
+            n += 1;
+            s = s.add(1);
+        }
+        n
     }
 }


### PR DESCRIPTION
In LLVM 23, calls to `wcslen` are sometimes generated by a loop optimization pass: https://github.com/llvm/llvm-project/pull/132572. This causes some Rust targets (including but not limited to the UEFI targets) to fail with a linker error if a loop is transformed into a `wcslen` call. Provide a simple implementation of `wcslen` in compiler-builtins to fix this.

Fixes https://github.com/rust-lang/rust/issues/160827