### PR TITLE
test: Allow Clippy's `needless-range-loop`

### DIFF
--- a/builtins-test/Cargo.toml
+++ b/builtins-test/Cargo.toml
@@ -37,6 +37,10 @@ icount = ["dep:gungraun"]
 benchmarking-reports = ["walltime", "criterion/plotters", "criterion/html_reports"]
 walltime = ["dep:criterion"]
 
+[lints.clippy]
+# This sometimes reads better
+needless-range-loop = "allow"
+
 [[bench]]
 name = "float_add"
 harness = false


### PR DESCRIPTION
This error started appearing in the latest nightly:

    error: the loop variable `i` is used to index `ret.0`
       --> builtins-test/tests/mem.rs:149:14
        |
    149 |     for i in 0..N {
        |              ^^^^
        |
    note: for this index operation
       --> builtins-test/tests/mem.rs:150:9
        |
    150 |         ret.0[i] = i as u8;
        |         ^^^^^^^^
        = help: for further information visit https://rust-lang.github.io/rust-clippy/main/index.html#needless_range_loop
        = note: `-D clippy::needless-range-loop` implied by `-D warnings`
        = help: to override `-D warnings` add `#[allow(clippy::needless_range_loop)]`
    help: consider using an iterator and `.enumerate()`
        |
    149 -     for i in 0..N {
    149 +     for (i, <item>) in ret.0.iter_mut().enumerate().take(N) {
        |