### PR TITLE
use `extern "C"` and  C names for complex div and mul of `f32` and `f64`

### DIFF
--- a/builtins-test/tests/complex.rs
+++ b/builtins-test/tests/complex.rs
@@ -382,45 +382,33 @@ mod complex {
         };
     }
 
-    #[cfg(all(f16_enabled, not(x86_no_sse2)))]
+    #[cfg(f16_enabled)]
     complex_mul! {
         f16, __rust_mulhc3, 1.0e-3;
     }
 
-    #[cfg(all(f16_enabled, not(x86_no_sse2)))]
+    #[cfg(f16_enabled)]
     complex_div! {
         f16, __rust_divhc3, 1.0e-3;
     }
 
     complex_mul! {
-        f32, __rust_mulsc3, 1.0e-6;
-        f64, __rust_muldc3, 1.0e-9;
+        f32, __mulsc3, 1.0e-6;
+        f64, __muldc3, 1.0e-9;
     }
 
     complex_div! {
-        f32, __rust_divsc3, 1.0e-6;
-        f64, __rust_divdc3, 1.0e-9;
+        f32, __divsc3, 1.0e-6;
+        f64, __divdc3, 1.0e-9;
     }
 
     #[cfg(f128_enabled)]
-    cfg_select! {
-        any(target_arch = "powerpc", target_arch = "powerpc64") => {
-            complex_mul! {
-                f128, __rust_mulkc3, 1.0e-12;
-            }
+    complex_mul! {
+        f128, __rust_multc3, 1.0e-12;
+    }
 
-            complex_div! {
-                f128, __rust_divkc3, 1.0e-12;
-            }
-        }
-        _ => {
-            complex_mul! {
-                f128, __rust_multc3, 1.0e-12;
-            }
-
-            complex_div! {
-                f128, __rust_divtc3, 1.0e-12;
-            }
-        }
+    #[cfg(f128_enabled)]
+    complex_div! {
+        f128, __rust_divtc3, 1.0e-12;
     }
 }

--- a/compiler-builtins/src/float/complex/div.rs
+++ b/compiler-builtins/src/float/complex/div.rs
@@ -54,21 +54,21 @@ where
 }
 
 intrinsics! {
-    #[cfg(all(f16_enabled, not(x86_no_sse2)))]
-    pub extern "C" fn __rust_divhc3(a: f16, b: f16, c: f16, d: f16) -> core::num::Complex<f16> {
+    #[cfg(f16_enabled)]
+    pub extern "Rust" fn __rust_divhc3(a: f16, b: f16, c: f16, d: f16) -> core::num::Complex<f16> {
         complex_div(a, b, c, d)
     }
 
-    pub extern "C" fn __rust_divsc3(a: f32, b: f32, c: f32, d: f32) -> core::num::Complex<f32> {
+    pub extern "C" fn __divsc3(a: f32, b: f32, c: f32, d: f32) -> core::num::Complex<f32> {
         complex_div(a, b, c, d)
     }
 
-    pub extern "C" fn __rust_divdc3(a: f64, b: f64, c: f64, d: f64) -> core::num::Complex<f64> {
+    pub extern "C" fn __divdc3(a: f64, b: f64, c: f64, d: f64) -> core::num::Complex<f64> {
         complex_div(a, b, c, d)
     }
 
     #[cfg(f128_enabled)]
-    pub extern "C" fn __rust_divtc3(a: f128, b: f128, c: f128, d: f128) -> core::num::Complex<f128> {
+    pub extern "Rust" fn __rust_divtc3(a: f128, b: f128, c: f128, d: f128) -> core::num::Complex<f128> {
         complex_div(a, b, c, d)
     }
 }

--- a/compiler-builtins/src/float/complex/mul.rs
+++ b/compiler-builtins/src/float/complex/mul.rs
@@ -60,21 +60,21 @@ fn complex_mul<F: Float>(mut a: F, mut b: F, mut c: F, mut d: F) -> Complex<F> {
 }
 
 intrinsics! {
-    #[cfg(all(f16_enabled, not(x86_no_sse2)))]
-    pub extern "C" fn __rust_mulhc3(a: f16, b: f16, c: f16, d: f16) -> core::num::Complex<f16> {
+    #[cfg(f16_enabled)]
+    pub extern "Rust" fn __rust_mulhc3(a: f16, b: f16, c: f16, d: f16) -> core::num::Complex<f16> {
         complex_mul(a, b, c, d)
     }
 
-    pub extern "C" fn __rust_mulsc3(a: f32, b: f32, c: f32, d: f32) -> core::num::Complex<f32> {
+    pub extern "C" fn __mulsc3(a: f32, b: f32, c: f32, d: f32) -> core::num::Complex<f32> {
         complex_mul(a, b, c, d)
     }
 
-    pub extern "C" fn __rust_muldc3(a: f64, b: f64, c: f64, d: f64) -> core::num::Complex<f64> {
+    pub extern "C" fn __muldc3(a: f64, b: f64, c: f64, d: f64) -> core::num::Complex<f64> {
         complex_mul(a, b, c, d)
     }
 
     #[cfg(f128_enabled)]
-    pub extern "C" fn __rust_multc3(a: f128, b: f128, c: f128, d: f128) -> core::num::Complex<f128> {
+    pub extern "Rust" fn __rust_multc3(a: f128, b: f128, c: f128, d: f128) -> core::num::Complex<f128> {
         complex_mul(a, b, c, d)
     }
 }


### PR DESCRIPTION
The `f16` and `f128` versions have abi issues, so continue to use `extern "Rust"` with a `__rust` prefix.