### PR TITLE
c-b: Use integers in `__gnu_f2h_ieee` and `__gnu_h2f_ieee` signatures

### DIFF
--- a/builtins-test/tests/conv.rs
+++ b/builtins-test/tests/conv.rs
@@ -314,6 +314,13 @@ mod extend {
         pub use compiler_builtins::float::extend::__extendsfdf2;
         #[cfg(f16_enabled)]
         pub use compiler_builtins::float::extend::{__extendhfdf2, __extendhfsf2, __gnu_h2f_ieee};
+
+        #[cfg(f16_enabled)]
+        pub fn check_gnu_h2f_ieee(x: f16) -> f32 {
+            f32::from_bits(compiler_builtins::float::extend::__gnu_h2f_ieee(
+                x.to_bits(),
+            ))
+        }
     }
 
     use super::*;
@@ -322,7 +329,7 @@ mod extend {
     f_to_f! {
         extend,
         f16 => f32, Half => Single, __extendhfsf2, not(no_sys_f16);
-        f16 => f32, Half => Single, __gnu_h2f_ieee, not(no_sys_f16);
+        f16 => f32, Half => Single, check_gnu_h2f_ieee, not(no_sys_f16);
         f16 => f64, Half => Double, __extendhfdf2, not(no_sys_f16_f64_convert);
     }
 
@@ -366,6 +373,11 @@ mod trunc {
         pub use compiler_builtins::float::trunc::__truncdfsf2;
         #[cfg(f16_enabled)]
         pub use compiler_builtins::float::trunc::{__gnu_f2h_ieee, __truncdfhf2, __truncsfhf2};
+
+        #[cfg(f16_enabled)]
+        pub fn check_gnu_f2h_ieee(x: f32) -> f16 {
+            f16::from_bits(compiler_builtins::float::trunc::__gnu_f2h_ieee(x.to_bits()))
+        }
     }
 
     use super::*;
@@ -374,7 +386,7 @@ mod trunc {
     f_to_f! {
         trunc,
         f32 => f16, Single => Half, __truncsfhf2, not(no_sys_f16);
-        f32 => f16, Single => Half, __gnu_f2h_ieee, not(no_sys_f16);
+        f32 => f16, Single => Half, check_gnu_f2h_ieee, not(no_sys_f16);
         f64 => f16, Double => Half, __truncdfhf2, not(no_sys_f16_f64_convert);
     }
 

--- a/compiler-builtins/src/float/extend.rs
+++ b/compiler-builtins/src/float/extend.rs
@@ -83,10 +83,9 @@ intrinsics! {
         extend(a)
     }
 
-    #[apple_f16_arg_abi]
     #[cfg(f16_enabled)]
-    pub extern "C" fn __gnu_h2f_ieee(a: f16) -> f32 {
-        extend(a)
+    pub extern "C" fn __gnu_h2f_ieee(a: u16) -> u32 {
+        extend::<f16, f32>(f16::from_bits(a)).to_bits()
     }
 
     #[apple_f16_arg_abi]

--- a/compiler-builtins/src/float/trunc.rs
+++ b/compiler-builtins/src/float/trunc.rs
@@ -128,10 +128,9 @@ intrinsics! {
         trunc(a)
     }
 
-    #[apple_f16_ret_abi]
     #[cfg(f16_enabled)]
-    pub extern "C" fn __gnu_f2h_ieee(a: f32) -> f16 {
-        trunc(a)
+    pub extern "C" fn __gnu_f2h_ieee(a: u32) -> u16 {
+        trunc::<f32, f16>(f32::from_bits(a)).to_bits()
     }
 
     #[apple_f16_ret_abi]


### PR DESCRIPTION
GCC's definition of these functions uses integers in the signature rather than `_Float16` and `float`, while compiler-rt uses AAPCS (via `AEABI_RTABI`). These happen to match up because floats and integers are passed the same with non-vector AAPCS.

When we had `aapcs_on_arm` our definitions matched up as well, but this was removed recently. Change our signatures to match the GCC definition.

Fixes: 11eda6a4d5a0 ("c-b: Remove `#[aapcs_on_arm]`")

[1]: https://github.com/llvm/llvm-project/blob/cd08ff07cee9e29bca1c5db229b1cf43d3f2c572/compiler-rt/lib/builtins/extendhfsf2.c#L19-L29