### PR TITLE
libm: Add a quieted signaling NaN constant

### DIFF
--- a/etc/nan-check.c
+++ b/etc/nan-check.c
@@ -1,0 +1,228 @@
+/* Print the representation of qNaNs, sNaNs, and quieted sNaNa.
+
+The behavior of NaN can be surprising on targets that don't use the typical
+quiet bit, as defined IEEE 754-2008. Most targets print the following:
+
+    bf_nan()                           0x7fc0
+    bf_snan()                          0x7fa0
+    quietb16(bf_nan())                 0x7fc0
+    quietb16(bf_snan())                0x7fe0
+
+    __builtin_nanf16("")               0x7e00
+    __builtin_nansf16("")              0x7d00
+    quiet16(__builtin_nanf16(""))      0x7e00
+    quiet16(__builtin_nansf16(""))     0x7f00
+
+    __builtin_nanf32("")               0x7fc00000
+    __builtin_nansf32("")              0x7fa00000
+    quiet32(__builtin_nanf32(""))      0x7fc00000
+    quiet32(__builtin_nansf32(""))     0x7fe00000
+
+    __builtin_nanf64("")               0x7ff8000000000000
+    __builtin_nansf64("")              0x7ff4000000000000
+    quiet64(__builtin_nanf64(""))      0x7ff8000000000000
+    quiet64(__builtin_nansf64(""))     0x7ffc000000000000
+
+    __builtin_nanf128("")              0x7fff8000000000000000000000000000
+    __builtin_nansf128("")             0x7fff4000000000000000000000000000
+    quiet128(__builtin_nanf128(""))    0x7fff8000000000000000000000000000
+    quiet128(__builtin_nansf128(""))   0x7fffc000000000000000000000000000
+
+MIPS targets, however, print the following when built with GCC:
+
+    bf16 not supported
+
+    f16 not supported
+
+    __builtin_nanf32("")               0x7fbfffff
+    __builtin_nansf32("")              0x7fffffff
+    quiet32(__builtin_nanf32(""))      0x7fbfffff
+    quiet32(__builtin_nansf32(""))     0x7fbfffff
+
+    __builtin_nanf64("")               0x7ff7ffffffffffff
+    __builtin_nansf64("")              0x7fffffffffffffff
+    quiet64(__builtin_nanf64(""))      0x7ff7ffffffffffff
+    quiet64(__builtin_nansf64(""))     0x7ff7ffffffffffff
+
+    __builtin_nanf128("")              0x7fff7fffffffffffffffffffffffffff
+    __builtin_nansf128("")             0x7fffffffffffffffffffffffffffffff
+    quiet128(__builtin_nanf128(""))    0x7fff7fffffffffffffffffffffffffff
+    quiet128(__builtin_nansf128(""))   0x7fff7fffffffffffffffffffffffffff
+
+(Note that GCC 13 changed the value of sNaNs on MIPS. Older versions reported
+the same number as for qNaN.)
+
+Clang just uses standard NaNs on MIPS for its `__builtin_` macros, but the
+results after the quiet functions wind up the same as GCC due to hardware
+instructions.
+
+*/
+
+#define __STDC_WANT_IEC_60559_EXT__
+#include <stdio.h>
+#include <float.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+/* Fill C23 float names if not supported */
+
+#if !defined(__FLT32_MANT_DIG__)
+typedef float _Float32;
+#endif
+
+/* Clang defines _Float64 on mips but doesn't set __FLT64 macros for
+ * some reason */
+#if !defined(__FLT64_MANT_DIG__) && !(defined(__clang__) && defined(__mips__))
+typedef double _Float64;
+#endif
+
+#if !defined(__FLT128_MANT_DIG__) && defined(__FLOAT128__)
+#define __FLT128_MANT_DIG__
+typedef __float128 _Float128;
+#endif
+
+#ifndef __builtin_nanf32
+#define __builtin_nanf32 __builtin_nanf
+#define __builtin_nansf32 __builtin_nansf
+#endif
+#ifndef __builtin_nanf64
+#define __builtin_nanf64 __builtin_nan
+#define __builtin_nansf64 __builtin_nans
+#endif
+
+/* Print reprs */
+
+#ifdef __BFLT16_MANT_DIG__
+/* Note that Clang never defines this bf macro */
+typedef union { __bf16 f; uint16_t i; } cvtb16;
+#endif
+#ifdef __FLT16_MANT_DIG__
+typedef union { _Float16 f; uint16_t i; } cvt16;
+#endif
+typedef union { _Float32 f; uint32_t i; } cvt32;
+typedef union { _Float64 f; uint64_t i; } cvt64;
+#ifdef __FLT128_MANT_DIG__
+typedef union { _Float128 f; __int128 i; } cvt128;
+#endif
+
+#define pfb16(x) do { \
+        cvtb16 c = { .f = x }; \
+        printf("%-34s %#06"PRIx16"\n", #x, c.i); \
+    } while (0)
+#define pf16(x) do { \
+        cvt16 c = { .f = x }; \
+        printf("%-34s %#06"PRIx16"\n", #x, c.i); \
+    } while (0)
+#define pf32(x) do { \
+        cvt32 c = { .f = x }; \
+        printf("%-34s %#010"PRIx32"\n", #x, c.i); \
+    } while (0)
+#define pf64(x) do { \
+        cvt64 c = { .f = x }; \
+        printf("%-34s %#018"PRIx64"\n", #x, c.i); \
+    } while (0)
+#define pf128(x) do { \
+        cvt128 c = { .f = x }; \
+        uint64_t lo = c.i; \
+        uint64_t hi = c.i >> 64; \
+        printf("%-34s %#018"PRIx64"%016"PRIx64"\n", #x, hi, lo); \
+    } while (0)
+
+/* There are no macros for bf16 NaNs, so assume they're the
+ * same as truncated f32 NaNs. */
+
+#ifdef __BFLT16_MANT_DIG__
+__bf16 bf_nan() {
+    cvt32 c32 = { .f = __builtin_nanf32("") };
+    cvtb16 c16 = { .i = c32.i >> 16 };
+    return c16.f;
+}
+
+__bf16 bf_snan() {
+    cvt32 c32 = { .f = __builtin_nansf32("") };
+    cvtb16 c16 = { .i = c32.i >> 16 };
+    return c16.f;
+}
+#endif
+
+/* Use asm to hide operands and force runtime execution, since GCC replaces
+ * sNaN * 1.0 with a canonical qNaN. */
+
+#ifdef __BFLT16_MANT_DIG__
+__bf16 quietb16(__bf16 x) {
+    __bf16 y = 1.0;
+    asm volatile("" : "+m"(x), "+m" (y) : :);
+    return x * y;
+}
+#endif
+
+#ifdef __FLT16_MANT_DIG__
+_Float16 quiet16(_Float16 x) {
+    _Float16 y = 1.0;
+    asm volatile("" : "+m"(x), "+m" (y) : :);
+    return x * y;
+}
+#endif
+
+_Float32 quiet32(_Float32 x) {
+    _Float32 y = 1.0;
+    asm volatile("" : "+m"(x), "+m" (y) : :);
+    return x * y;
+}
+
+_Float64 quiet64(_Float64 x) {
+    _Float64 y = 1.0;
+    asm volatile("" : "+m"(x), "+m" (y) : :);
+    return x * y;
+}
+
+#ifdef __FLT128_MANT_DIG__
+_Float128 quiet128(_Float128 x) {
+    _Float128 y = 1.0;
+    asm volatile("" : "+m"(x), "+m" (y) : :);
+    return x * y;
+}
+#endif
+
+int main() {
+#ifdef __BFLT16_MANT_DIG__
+    pfb16(bf_nan());
+    pfb16(bf_snan());
+    pfb16(quietb16(bf_nan()));
+    pfb16(quietb16(bf_snan()));
+#else
+    printf("bf16 not supported\n");
+#endif
+    printf("\n");
+
+#ifdef __FLT16_MANT_DIG__
+    pf16(__builtin_nanf16(""));
+    pf16(__builtin_nansf16(""));
+    pf16(quiet16(__builtin_nanf16("")));
+    pf16(quiet16(__builtin_nansf16("")));
+#else
+    printf("f16 not supported\n");
+#endif
+    printf("\n");
+
+    pf32(__builtin_nanf32(""));
+    pf32(__builtin_nansf32(""));
+    pf32(quiet32(__builtin_nanf32("")));
+    pf32(quiet32(__builtin_nansf32("")));
+    printf("\n");
+
+    pf64(__builtin_nanf64(""));
+    pf64(__builtin_nansf64(""));
+    pf64(quiet64(__builtin_nanf64("")));
+    pf64(quiet64(__builtin_nansf64("")));
+    printf("\n");
+
+#ifdef __FLT128_MANT_DIG__
+    pf128(__builtin_nanf128(""));
+    pf128(__builtin_nansf128(""));
+    pf128(quiet128(__builtin_nanf128("")));
+    pf128(quiet128(__builtin_nansf128("")));
+#else
+    printf("f128 not supported\n");
+#endif
+}

--- a/libm-test/src/f8_impl.rs
+++ b/libm-test/src/f8_impl.rs
@@ -31,9 +31,11 @@ impl Float for f8 {
     const MIN: Self = Self(0b1_1110_111);
 
     const NAN: Self = Self(0b0_1111_100);
-    const SNAN: Self = Self(0b0_1111_001);
+    const SNAN: Self = Self(0b0_1111_010);
+    const QSNAN: Self = Self(0b0_1111_110);
     const NEG_NAN: Self = Self(0b1_1111_100);
-    const NEG_SNAN: Self = Self(0b1_1111_001);
+    const NEG_SNAN: Self = Self(0b1_1111_010);
+    const NEG_QSNAN: Self = Self(0b1_1111_110);
 
     const MIN_POSITIVE_NORMAL: Self = Self(1 << Self::SIG_BITS);
     const MIN_POSITIVE_SUBNORMAL: Self = Self(1);

--- a/libm/src/math/support/float_traits.rs
+++ b/libm/src/math/support/float_traits.rs
@@ -11,10 +11,12 @@ pub type HalfRep<F> = <<F as Float>::Int as DInt>::H;
 ///
 /// Note that MIPS is doing some general migration here, though this is only available on (rare)
 /// modern MIPS hardware per discussion at <https://github.com/WebAssembly/design/issues/976>.
-const MIPS_NAN: bool = cfg!(target_arch = "mips") || cfg!(target_arch = "mips64");
+const MIPS_NAN: bool = cfg!(target_arch = "mips")
+    || cfg!(target_arch = "mips64")
+    || cfg!(target_arch = "mips32r6")
+    || cfg!(target_arch = "mips64r6");
 
 /// Trait for some basic operations on floats
-// #[allow(dead_code)]
 #[allow(dead_code)] // Some constants are only used with tests
 pub trait Float:
     Copy
@@ -55,6 +57,9 @@ pub trait Float:
     const SNAN: Self;
     const NEG_NAN: Self;
     const NEG_SNAN: Self;
+    /// The result of quieting the default sNaN.
+    const QSNAN: Self;
+    const NEG_QSNAN: Self;
 
     const EPSILON: Self;
     const PI: Self;
@@ -280,10 +285,16 @@ macro_rules! float_impl {
             } else {
                 Self::EXP_MASK | (Self::SIG_TOP_BIT >> 1)
             });
+            const QSNAN: Self = if MIPS_NAN {
+                <Self as Float>::NAN
+            } else {
+                $from_bits($to_bits(Self::SNAN) | Self::SIG_TOP_BIT)
+            };
             // NAN isn't guaranteed to be positive but it usually is. We only use these for
             // tests.
             const NEG_NAN: Self = $from_bits($to_bits(Self::NAN) | Self::SIGN_MASK);
             const NEG_SNAN: Self = $from_bits($to_bits(Self::SNAN) | Self::SIGN_MASK);
+            const NEG_QSNAN: Self = $from_bits($to_bits(Self::QSNAN) | Self::SIGN_MASK);
 
             const EPSILON: Self = <$ty>::EPSILON;
 
@@ -537,13 +548,16 @@ mod tests {
         // Value of NAN and FLT16_SNAN in C. We don't strictly need to match up, but it is good to
         // be aware if there are platforms where we don't.
         if MIPS_NAN {
-            assert_biteq!(f16::NAN, f16::from_bits(0x7fbf));
+            assert_biteq!(<f16 as Float>::NAN, f16::from_bits(0x7dff));
             assert_biteq!(f16::SNAN, f16::from_bits(0x7fff));
+            assert_biteq!(f16::QSNAN, f16::from_bits(0x7dff));
         } else {
             assert_biteq!(f16::NAN, f16::from_bits(0x7e00));
             assert_biteq!(f16::SNAN, f16::from_bits(0x7d00));
+            assert_biteq!(f16::QSNAN, f16::from_bits(0x7f00));
         }
-        assert!(f16::NAN.is_qnan());
+        assert!(<f16 as Float>::NAN.is_qnan());
+        assert!(f16::SNAN.is_snan());
 
         // `exp_unbiased`
         assert_eq!(f16::FRAC_PI_2.exp_unbiased(), 0);
@@ -574,13 +588,15 @@ mod tests {
         // Value of NAN and FLT_SNAN in C. We don't strictly need to match up, but it is good to
         // be aware if there are platforms where we don't.
         if MIPS_NAN {
-            assert_biteq!(f32::NAN, f32::from_bits(0x7fbfffff));
+            assert_biteq!(<f32 as Float>::NAN, f32::from_bits(0x7fbfffff));
             assert_biteq!(f32::SNAN, f32::from_bits(0x7fffffff));
+            assert_biteq!(f32::QSNAN, f32::from_bits(0x7fbfffff));
         } else {
             assert_biteq!(f32::NAN, f32::from_bits(0x7fc00000));
             assert_biteq!(f32::SNAN, f32::from_bits(0x7fa00000));
+            assert_biteq!(f32::QSNAN, f32::from_bits(0x7fe00000));
         }
-        assert!(f32::NAN.is_qnan());
+        assert!(<f32 as Float>::NAN.is_qnan());
         // FIXME(rust-lang/rust#115567): x87 use in `is_snan` quiets the sNaN
         if !cfg!(x86_no_sse2) {
             assert!(f32::SNAN.is_snan());
@@ -619,13 +635,15 @@ mod tests {
         // Value of NAN and DBL_SNAN in C. We don't strictly need to match up, but it is good to
         // be aware if there are platforms where we don't.
         if MIPS_NAN {
-            assert_biteq!(f64::NAN, f64::from_bits(0x7ff7ffffffffffff));
+            assert_biteq!(<f64 as Float>::NAN, f64::from_bits(0x7ff7ffffffffffff));
             assert_biteq!(f64::SNAN, f64::from_bits(0x7fffffffffffffff));
+            assert_biteq!(f64::QSNAN, f64::from_bits(0x7ff7ffffffffffff));
         } else {
             assert_biteq!(f64::NAN, f64::from_bits(0x7ff8000000000000));
             assert_biteq!(f64::SNAN, f64::from_bits(0x7ff4000000000000));
+            assert_biteq!(f64::QSNAN, f64::from_bits(0x7ffc000000000000));
         }
-        assert!(f64::NAN.is_qnan());
+        assert!(<f64 as Float>::NAN.is_qnan());
         // FIXME(rust-lang/rust#115567): x87 use in `is_snan` quiets the sNaN
         if !cfg!(x86_no_sse2) {
             assert!(f64::SNAN.is_snan());
@@ -666,12 +684,16 @@ mod tests {
         // be aware if there are platforms where we don't.
         if MIPS_NAN {
             assert_biteq!(
-                f128::NAN,
+                <f128 as Float>::NAN,
                 f128::from_bits(0x7fff7fffffffffffffffffffffffffff)
             );
             assert_biteq!(
                 f128::SNAN,
                 f128::from_bits(0x7fffffffffffffffffffffffffffffff)
+            );
+            assert_biteq!(
+                f128::QSNAN,
+                f128::from_bits(0x7fff7fffffffffffffffffffffffffff)
             );
         } else {
             assert_biteq!(
@@ -682,8 +704,12 @@ mod tests {
                 f128::SNAN,
                 f128::from_bits(0x7fff4000000000000000000000000000)
             );
+            assert_biteq!(
+                f128::QSNAN,
+                f128::from_bits(0x7fffc000000000000000000000000000)
+            );
         }
-        assert!(f128::NAN.is_qnan());
+        assert!(<f128 as Float>::NAN.is_qnan());
         assert!(f128::SNAN.is_snan());
 
         // `exp_unbiased`

--- a/libm/src/math/support/macros.rs
+++ b/libm/src/math/support/macros.rs
@@ -121,7 +121,8 @@ macro_rules! hf128 {
 }
 
 /// Assert `F::biteq` with better messages.
-#[cfg(test)]
+#[allow(unused_macros)]
+#[cfg_attr(feature = "unstable-public-internals", macro_export)]
 macro_rules! assert_biteq {
     ($left:expr, $right:expr, $($tt:tt)*) => {{
         let l = $left;


### PR DESCRIPTION
Introduce a constant for the result of perfoming a quietening operation on our default sNaN. Additionally check in the C file used to retrieve these values.